### PR TITLE
feat: upgrade C++ standard to C++23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 
 message(STATUS "Knuth: Cryptocurrency: ${CURRENCY}")
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(BUILD_NODE_EXE "Build the node executable." ON)
@@ -67,22 +67,6 @@ endif()
 find_package(gmp REQUIRED)
 
 add_subdirectory(src)
-# add_subdirectory(secp256k1)
-# add_subdirectory(infrastructure)
-# add_subdirectory(domain)
-# add_subdirectory(consensus)
-# add_subdirectory(network)
-# add_subdirectory(database)
-# add_subdirectory(blockchain)
-# add_subdirectory(node)
-
-# if (BUILD_NODE_EXE)
-#     add_subdirectory(node-exe)
-# endif()
-
-# if (BUILD_C_API)
-#     add_subdirectory(c-api)
-# endif()
 
 if (WITH_TESTS)
   enable_testing()

--- a/conanfile.py
+++ b/conanfile.py
@@ -14,7 +14,6 @@ required_conan_version = ">=2.0"
 
 class KthRecipe(KnuthConanFileV2):
     # version is set dynamically via --version parameter
-    # version="0.68.0"
     name = "kth"
     license = "https://opensource.org/licenses/MIT"
     url = "https://github.com/k-nuth/kth-mono"
@@ -106,7 +105,7 @@ class KthRecipe(KnuthConanFileV2):
     def validate(self):
         KnuthConanFileV2.validate(self)
         if self.info.settings.compiler.cppstd:
-            check_min_cppstd(self, "20")
+            check_min_cppstd(self, "23")
 
     def requirements(self):
         self.requires("boost/1.86.0", transitive_headers=True, transitive_libs=True)

--- a/src/domain/test/aserti3-2d/CMakeLists.txt
+++ b/src/domain/test/aserti3-2d/CMakeLists.txt
@@ -14,7 +14,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # Check for baseline language coverage in the compiler for the C++14 standard.
 #------------------------------------------------------------------------------
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # set(KTH_PROJECT_VERSION "-" CACHE STRING "Specify the Knuth Project Version.")


### PR DESCRIPTION
### Summary
This PR upgrades the C++ standard from C++20 to C++23 across the codebase.

### Changes
- Update CMAKE_CXX_STANDARD from 20 to 23 in main CMakeLists.txt
- Update CMAKE_CXX_STANDARD in domain test CMakeLists.txt  
- Update conanfile.py to validate C++23 minimum standard

### Benefits
- Enables the use of C++23 features across the codebase
- Keeps the project up-to-date with modern C++ standards
- Future-proofs the codebase for newer language features

### Testing
- [ ] Verify builds with C++23 compilers
- [ ] Confirm no breaking changes in existing code