### PR TITLE
fix: Update Conan profiles to C++23 standard

### DIFF
--- a/ci_utils/.conan/profiles/general-ci-cd
+++ b/ci_utils/.conan/profiles/general-ci-cd
@@ -1,4 +1,4 @@
 include(default)
 
 [settings]
-compiler.cppstd=20
+compiler.cppstd=23

--- a/ci_utils/.conan/profiles/linux-ci-cd
+++ b/ci_utils/.conan/profiles/linux-ci-cd
@@ -4,7 +4,7 @@ include(default)
 os=Linux
 arch=x86_64
 compiler=gcc
-compiler.cppstd=20
+compiler.cppstd=23
 # compiler.version=12
 # compiler.libcxx=libstdc++11
 # compiler.musl=1.2


### PR DESCRIPTION
- Update linux-ci-cd profile: compiler.cppstd=20 -> compiler.cppstd=23
- Update general-ci-cd profile: compiler.cppstd=20 -> compiler.cppstd=23

This fixes the build error in GitHub Actions where the code requires C++23 but Conan profiles were configured for C++20.

Error resolved: 'Current cppstd (20) is lower than the required C++ standard (23)'