### PR TITLE
fix: Update conancenter URL to center2.conan.io

### DIFF
--- a/ci_utils/.conan/remotes.json
+++ b/ci_utils/.conan/remotes.json
@@ -2,7 +2,7 @@
  "remotes": [
   {
    "name": "conancenter",
-   "url": "https://center.conan.io",
+   "url": "https://center2.conan.io",
    "verify_ssl": true
   },
   {


### PR DESCRIPTION
- Update conancenter remote URL from center.conan.io to center2.conan.io
- This aligns with Conan's current infrastructure and ensures reliable package downloads

The old center.conan.io URL has been deprecated in favor of center2.conan.io