### PR TITLE
fix: enable Conan package upload for release/hotfix PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -208,7 +208,7 @@ jobs:
     uses: ./.github/workflows/build-with-container.yml
     with:
       if: ${{ matrix.config.compiler == 'GCC' }}
-      upload: ${{ github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/hotfix') || startsWith(github.ref, 'refs/heads/dev-publish')) }}
+      upload: ${{ (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/hotfix') || startsWith(github.ref, 'refs/heads/dev-publish'))) || (github.event_name == 'pull_request' && (startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'hotfix/') || startsWith(github.head_ref, 'dev-publish/'))) }}
       os: ${{ matrix.config.os }}
       image: "kthnode/gcc${{ matrix.config.version }}${{ matrix.config.docker_suffix }}"
       conan-remote: "kth"
@@ -230,7 +230,7 @@ jobs:
     uses: ./.github/workflows/build-without-container.yml
     with:
       if: ${{ matrix.config.compiler != 'GCC' }}
-      upload: ${{ github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/hotfix') || startsWith(github.ref, 'refs/heads/dev-publish')) }}
+      upload: ${{ (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/hotfix') || startsWith(github.ref, 'refs/heads/dev-publish'))) || (github.event_name == 'pull_request' && (startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'hotfix/') || startsWith(github.head_ref, 'dev-publish/'))) }}
       os: ${{ matrix.config.os }}
       conan-remote: "kth"
       recipe-name: "kth"


### PR DESCRIPTION
## Problem
Currently, Conan packages are only uploaded when pushing directly to release/hotfix branches. This causes issues when using Pull Requests for release branches, as the CI runs are triggered by `pull_request` events instead of `push` events.

## Solution
Modified the upload condition in GitHub Actions to also support Pull Requests from release/hotfix/dev-publish branches.

## Changes
- **Before**: Only uploaded on `push` to release branches
- **After**: Uploads on both `push` to release branches AND `pull_request` from release branches

### Modified Files
- `.github/workflows/main.yml`: Updated upload conditions for both `build-with-container` and `build-without-container` jobs

## Testing
This change will allow the current `release/0.68.0` PR to properly upload Conan packages when the CI runs.

## Impact
- ✅ Fixes CI package upload issues for release PRs
- ✅ Maintains backward compatibility with direct pushes
- ✅ No breaking changes to existing workflows