### PR TITLE
fix: improve Emscripten support and spdlog configuration

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -140,7 +140,11 @@ class KthRecipe(KnuthConanFileV2):
         KnuthConanFileV2.configure(self)
 
         self.options["fmt/*"].header_only = True
-        self.options["spdlog/*"].header_only = True
+        if self.settings.os == "Emscripten":
+            self.options["boost/*"].header_only = True
+
+        if self.options.log == "spdlog":
+            self.options["spdlog/*"].header_only = True
 
         self.options["*"].db_readonly = self.options.db_readonly
         self.output.info("Compiling with read-only DB: %s" % (self.options.db_readonly,))
@@ -150,7 +154,6 @@ class KthRecipe(KnuthConanFileV2):
 
         self.options["*"].log = self.options.log
         self.output.info("Compiling with log: %s" % (self.options.log,))
-
 
     def package_id(self):
         KnuthConanFileV2.package_id(self)


### PR DESCRIPTION
- Set boost as header_only when building for Emscripten to avoid linking issues
- Only set spdlog as header_only when log option is 'spdlog'
- Improve conditional configuration logic for better cross-platform support

This change fixes compilation issues when targeting Emscripten by ensuring boost is configured correctly for that platform, and makes spdlog configuration more conditional based on the actual log library being used.