### PR TITLE
cleanup: remove deprecated use_libmdbx options from all modules

### DIFF
--- a/src/blockchain/conanfile.py
+++ b/src/blockchain/conanfile.py
@@ -52,7 +52,6 @@ class KnuthBlockchainConan(KnuthConanFileV2):
         "db_readonly": False,
         "cmake_export_compile_commands": False,
         "log": "spdlog",
-        "use_libmdbx": False,
     }
 
     exports_sources = "src/*", "CMakeLists.txt", "ci_utils/cmake/*", "cmake/*", "knuthbuildinfo.cmake", "include/*", "test/*", "tools/*"
@@ -93,9 +92,6 @@ class KnuthBlockchainConan(KnuthConanFileV2):
         self.options["*"].log = self.options.log
         self.output.info("Compiling with log: %s" % (self.options.log,))
 
-        self.options["*"].use_libmdbx = self.options.use_libmdbx
-        self.output.info("Compiling with use_libmdbx: %s" % (self.options.use_libmdbx,))
-
 
     def package_id(self):
         KnuthConanFileV2.package_id(self)
@@ -112,7 +108,6 @@ class KnuthBlockchainConan(KnuthConanFileV2):
         tc.variables["WITH_MEMPOOL"] = option_on_off(self.options.mempool)
         tc.variables["DB_READONLY_MODE"] = option_on_off(self.options.db_readonly)
         tc.variables["LOG_LIBRARY"] = self.options.log
-        tc.variables["USE_LIBMDBX"] = option_on_off(self.options.use_libmdbx)
         tc.variables["CONAN_DISABLE_CHECK_COMPILER"] = option_on_off(True)
 
         tc.generate()

--- a/src/c-api/conanfile.py
+++ b/src/c-api/conanfile.py
@@ -36,7 +36,6 @@ class KnuthCAPIConan(KnuthConanFileV2):
         "cflags": ["ANY"],
         "cmake_export_compile_commands": [True, False],
         "log": ["boost", "spdlog", "binlog"],
-        "use_libmdbx": [True, False],
     }
 
     default_options = {
@@ -53,7 +52,6 @@ class KnuthCAPIConan(KnuthConanFileV2):
         "db_readonly": False,
         "cmake_export_compile_commands": False,
         "log": "spdlog",
-        "use_libmdbx": False,
     }
 
     exports_sources = "src/*", "CMakeLists.txt", "ci_utils/cmake/*", "cmake/*", "knuthbuildinfo.cmake","include/*", "test/*", "console/*"
@@ -106,9 +104,6 @@ class KnuthCAPIConan(KnuthConanFileV2):
         self.options["*"].log = self.options.log
         self.output.info("Compiling with log: %s" % (self.options.log,))
 
-        self.options["*"].use_libmdbx = self.options.use_libmdbx
-        self.output.info("Compiling with use_libmdbx: %s" % (self.options.use_libmdbx,))
-
 
     def package_id(self):
         KnuthConanFileV2.package_id(self)
@@ -133,7 +128,6 @@ class KnuthCAPIConan(KnuthConanFileV2):
         tc.variables["WITH_MEMPOOL"] = option_on_off(self.options.mempool)
         tc.variables["DB_READONLY_MODE"] = option_on_off(self.options.db_readonly)
         tc.variables["LOG_LIBRARY"] = self.options.log
-        tc.variables["USE_LIBMDBX"] = option_on_off(self.options.use_libmdbx)
         tc.variables["CONAN_DISABLE_CHECK_COMPILER"] = option_on_off(True)
 
         tc.generate()

--- a/src/database/conanfile.py
+++ b/src/database/conanfile.py
@@ -35,7 +35,6 @@ class KnuthDatabaseConan(KnuthConanFileV2):
                "cflags": ["ANY"],
                "cmake_export_compile_commands": [True, False],
                "log": ["boost", "spdlog", "binlog"],
-               "use_libmdbx": [True, False],
     }
 
     default_options = {
@@ -52,7 +51,6 @@ class KnuthDatabaseConan(KnuthConanFileV2):
         "cached_rpc_data": False,
         "cmake_export_compile_commands": False,
         "log": "spdlog",
-        "use_libmdbx": False,
     }
 
     exports_sources = "src/*", "CMakeLists.txt", "ci_utils/cmake/*", "cmake/*", "knuthbuildinfo.cmake", "include/*", "test/*", "tools/*"
@@ -63,13 +61,8 @@ class KnuthDatabaseConan(KnuthConanFileV2):
 
     def requirements(self):
         self.requires("domain/0.45.0", transitive_headers=True, transitive_libs=True)
-
-        if self.options.use_libmdbx:
-            self.requires("libmdbx/0.7.0@kth/stable", transitive_headers=True, transitive_libs=True)
-            self.output.info("Using libmdbx for DB management")
-        else:
-            self.requires("lmdb/0.9.32", transitive_headers=True, transitive_libs=True)
-            self.output.info("Using lmdb for DB management")
+        self.requires("lmdb/0.9.32", transitive_headers=True, transitive_libs=True)
+        self.output.info("Using lmdb for DB management")
 
     def validate(self):
         KnuthConanFileV2.validate(self)
@@ -108,7 +101,6 @@ class KnuthDatabaseConan(KnuthConanFileV2):
         tc.variables["WITH_MEASUREMENTS"] = option_on_off(self.options.measurements)
         tc.variables["DB_READONLY_MODE"] = option_on_off(self.options.db_readonly)
         tc.variables["LOG_LIBRARY"] = self.options.log
-        tc.variables["USE_LIBMDBX"] = option_on_off(self.options.use_libmdbx)
         tc.variables["CONAN_DISABLE_CHECK_COMPILER"] = option_on_off(True)
 
         if self.options.cmake_export_compile_commands:

--- a/src/node-exe/conanfile.py
+++ b/src/node-exe/conanfile.py
@@ -32,7 +32,6 @@ class KnuthNodeExeConan(KnuthConanFileV2):
         "cflags": ["ANY"],
         "cmake_export_compile_commands": [True, False],
         "log": ["boost", "spdlog", "binlog"],
-        "use_libmdbx": [True, False],
         "statistics": [True, False],
     }
 
@@ -46,7 +45,6 @@ class KnuthNodeExeConan(KnuthConanFileV2):
         "db_readonly": False,
         "cmake_export_compile_commands": False,
         "log": "spdlog",
-        "use_libmdbx": False,
         "statistics": False,
     }
 
@@ -88,9 +86,6 @@ class KnuthNodeExeConan(KnuthConanFileV2):
         self.options["*"].log = self.options.log
         self.output.info("Compiling with log: %s" % (self.options.log,))
 
-        self.options["*"].use_libmdbx = self.options.use_libmdbx
-        self.output.info("Compiling with use_libmdbx: %s" % (self.options.use_libmdbx,))
-
         self.options["*"].statistics = self.options.statistics
         self.output.info("Compiling with statistics: %s" % (self.options.statistics,))
 
@@ -124,7 +119,6 @@ class KnuthNodeExeConan(KnuthConanFileV2):
         tc.variables["WITH_MEMPOOL"] = option_on_off(self.options.mempool)
         tc.variables["DB_READONLY_MODE"] = option_on_off(self.options.db_readonly)
         tc.variables["LOG_LIBRARY"] = self.options.log
-        tc.variables["USE_LIBMDBX"] = option_on_off(self.options.use_libmdbx)
         tc.variables["STATISTICS"] = option_on_off(self.options.statistics)
         tc.variables["CONAN_DISABLE_CHECK_COMPILER"] = option_on_off(True)
         tc.generate()

--- a/src/node/conanfile.py
+++ b/src/node/conanfile.py
@@ -34,7 +34,6 @@ class KnuthNodeConan(KnuthConanFileV2):
         "cflags": ["ANY"],
         "cmake_export_compile_commands": [True, False],
         "log": ["boost", "spdlog", "binlog"],
-        "use_libmdbx": [True, False],
         "statistics": [True, False],
     }
 
@@ -50,7 +49,6 @@ class KnuthNodeConan(KnuthConanFileV2):
         "db_readonly": False,
         "cmake_export_compile_commands": False,
         "log": "spdlog",
-        "use_libmdbx": False,
         "statistics": False,
     }
 
@@ -96,9 +94,6 @@ class KnuthNodeConan(KnuthConanFileV2):
         self.options["*"].log = self.options.log
         self.output.info("Compiling with log: %s" % (self.options.log,))
 
-        self.options["*"].use_libmdbx = self.options.use_libmdbx
-        self.output.info("Compiling with use_libmdbx: %s" % (self.options.use_libmdbx,))
-
     def package_id(self):
         KnuthConanFileV2.package_id(self)
 
@@ -112,7 +107,6 @@ class KnuthNodeConan(KnuthConanFileV2):
         tc.variables["WITH_MEMPOOL"] = option_on_off(self.options.mempool)
         tc.variables["DB_READONLY_MODE"] = option_on_off(self.options.db_readonly)
         tc.variables["LOG_LIBRARY"] = self.options.log
-        tc.variables["USE_LIBMDBX"] = option_on_off(self.options.use_libmdbx)
         tc.variables["STATISTICS"] = option_on_off(self.options.statistics)
         tc.variables["CONAN_DISABLE_CHECK_COMPILER"] = option_on_off(True)
         tc.generate()


### PR DESCRIPTION
Remove the deprecated use_libmdbx option from all conanfile.py modules:
- blockchain: remove use_libmdbx option and related configuration
- c-api: remove use_libmdbx option and related configuration
- database: remove use_libmdbx option, simplify to use only lmdb
- node-exe: remove use_libmdbx option and related configuration
- node: remove use_libmdbx option and related configuration

The project has standardized on LMDB as the database backend, making the libmdbx option obsolete. This cleanup removes the deprecated configuration options and simplifies the build system.

Changes per module:
- Removed 'use_libmdbx' from options dictionary
- Removed 'use_libmdbx: False' from default_options
- Removed use_libmdbx configuration in configure() method
- Removed USE_LIBMDBX CMake variable in generate() method
- In database module: simplified requirements() to only use lmdb

This is a breaking change for users who were using use_libmdbx=True, but the option was already non-functional in recent versions.