### PR TITLE
feat: add Emscripten (WebAssembly) support

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -135,11 +135,17 @@ class KthRecipe(KnuthConanFileV2):
 
     def config_options(self):
         KnuthConanFileV2.config_options(self)
+        # Disable ecmult static precomputation for Emscripten to avoid native build issues
+        if self.settings.os == "Emscripten":
+            self.output.info("Setting enable_ecmult_static_precomputation to False for Emscripten")
+            self.options.enable_ecmult_static_precomputation = False
 
     def configure(self):
         KnuthConanFileV2.configure(self)
 
         self.options["fmt/*"].header_only = True
+        # log os
+        self.output.info("Compiling for OS: %s" % (self.settings.os,))
         if self.settings.os == "Emscripten":
             self.options["boost/*"].header_only = True
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,12 +8,18 @@ add_subdirectory(secp256k1)
 add_subdirectory(infrastructure)
 add_subdirectory(domain)
 add_subdirectory(consensus)
-add_subdirectory(network)
+
+# Network module is not compatible with Emscripten
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+    add_subdirectory(network)
+endif()
+
 add_subdirectory(database)
 add_subdirectory(blockchain)
 add_subdirectory(node)
 
-if (BUILD_NODE_EXE)
+# Node executable is not compatible with Emscripten
+if (BUILD_NODE_EXE AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     add_subdirectory(node-exe)
 endif()
 

--- a/src/secp256k1/CMakeLists.txt
+++ b/src/secp256k1/CMakeLists.txt
@@ -24,6 +24,9 @@ option(ENABLE_MODULE_RECOVERY "Enable ECDSA pubkey recovery module." ON)
 option(ENABLE_MODULE_MULTISET "Enable multiset operations (experimental)." ON)
 
 
+message(STATUS "******************* ENABLE_ECMULT_STATIC_PRECOMPUTATION: ${ENABLE_ECMULT_STATIC_PRECOMPUTATION}")
+
+
 # Make the emult window size customizable.
 set(SECP256K1_ECMULT_WINDOW_SIZE 15 CACHE STRING "Window size for ecmult precomputation for verification, specified as integer in range [2..24].")
 if(${SECP256K1_ECMULT_WINDOW_SIZE} LESS 2 OR ${SECP256K1_ECMULT_WINDOW_SIZE} GREATER 24)
@@ -76,7 +79,7 @@ if (ENABLE_ECMULT_STATIC_PRECOMPUTATION)
 	# # include(NativeExecutable)
 	add_native_executable(gen_context src/gen_context.c)
 
-  target_include_directories(gen_context PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+  native_target_include_directories(gen_context PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
   # target_include_directories(gen_context PUBLIC
   # $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>


### PR DESCRIPTION
- Add Emscripten-specific configuration in conanfile.py
- Disable ecmult static precomputation for Emscripten builds
- Add OS detection logging in conanfile.py
- Exclude network module for Emscripten builds in src/CMakeLists.txt
- Exclude node-exe for Emscripten builds
- Fix native_target_include_directories usage in secp256k1