### PR TITLE
feat: add GLOBAL_BUILD option to CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(BUILD_NODE_EXE "Build the node executable." ON)
 option(BUILD_C_API "Build the C-API." ON)
+option(GLOBAL_BUILD "Global build flag." ON)
 option(ENABLE_POSITION_INDEPENDENT_CODE "Enable POSITION_INDEPENDENT_CODE property" ON)
 option(WITH_CONSOLE "Compile console application." OFF)
 option(WITH_LOCAL_MINING "Compile with local mining." ON)

--- a/src/consensus/CMakeLists.txt
+++ b/src/consensus/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(ENABLE_SHARED "" OFF)
+option(GLOBAL_BUILD "" ON)
 option(ENABLE_POSITION_INDEPENDENT_CODE "Enable POSITION_INDEPENDENT_CODE property" ON)
 option(WITH_TESTS "Compile with unit tests." ON)
 option(WITH_JAVA "Compile the Java bindings." OFF)

--- a/src/infrastructure/CMakeLists.txt
+++ b/src/infrastructure/CMakeLists.txt
@@ -11,6 +11,7 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(ENABLE_SHARED "" OFF)
+option(GLOBAL_BUILD "" ON)
 option(ENABLE_POSITION_INDEPENDENT_CODE "Enable POSITION_INDEPENDENT_CODE property" ON)
 option(WITH_TESTS "Compile with unit tests." OFF)
 option(WITH_EXAMPLES "Compile with examples." OFF)


### PR DESCRIPTION
- Add GLOBAL_BUILD option to main CMakeLists.txt
- Add GLOBAL_BUILD option to consensus module
- Add GLOBAL_BUILD option to infrastructure module
- This option allows better control of the build process across modules