### PR TITLE
Refactor Conan package to expose multiple CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,3 +72,22 @@ add_subdirectory(src)
 if (WITH_TESTS)
   enable_testing()
 endif()
+
+# Install the main kth CMake configuration file
+# ------------------------------------------------------------------------------
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
+# Configure the main kth config file
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/kth-config.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/kth-config.cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/kth"
+    PATH_VARS CMAKE_INSTALL_INCLUDEDIR CMAKE_INSTALL_LIBDIR
+)
+
+# Install the config file
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/kth-config.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/kth"
+)

--- a/cmake/kth-config.cmake.in
+++ b/cmake/kth-config.cmake.in
@@ -1,0 +1,91 @@
+# Copyright (c) 2016-2025 Knuth Project developers.
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+# Find all dependencies that the kth components need
+find_dependency(Boost REQUIRED)
+find_dependency(gmp REQUIRED)
+
+# Include all component config files
+include("${CMAKE_CURRENT_LIST_DIR}/secp256k1-config.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/infrastructure-config.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/domain-config.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/consensus-config.cmake")
+
+# Include network only if it was built (not compatible with Emscripten)
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/network-config.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/network-config.cmake")
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/database-config.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/blockchain-config.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/node-config.cmake")
+
+# Include optional components
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/node-exe-config.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/node-exe-config.cmake")
+endif()
+
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/c-api-config.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/c-api-config.cmake")
+endif()
+
+# Create aliases with kth:: namespace for all components
+if(TARGET secp256k1::secp256k1 AND NOT TARGET kth::secp256k1)
+    add_library(kth::secp256k1 ALIAS secp256k1::secp256k1)
+endif()
+
+if(TARGET infrastructure::infrastructure AND NOT TARGET kth::infrastructure)
+    add_library(kth::infrastructure ALIAS infrastructure::infrastructure)
+endif()
+
+if(TARGET domain::domain AND NOT TARGET kth::domain)
+    add_library(kth::domain ALIAS domain::domain)
+endif()
+
+if(TARGET consensus::consensus AND NOT TARGET kth::consensus)
+    add_library(kth::consensus ALIAS consensus::consensus)
+endif()
+
+if(TARGET network::network AND NOT TARGET kth::network)
+    add_library(kth::network ALIAS network::network)
+endif()
+
+if(TARGET database::database AND NOT TARGET kth::database)
+    add_library(kth::database ALIAS database::database)
+endif()
+
+if(TARGET blockchain::blockchain AND NOT TARGET kth::blockchain)
+    add_library(kth::blockchain ALIAS blockchain::blockchain)
+endif()
+
+if(TARGET node::node AND NOT TARGET kth::node)
+    add_library(kth::node ALIAS node::node)
+endif()
+
+if(TARGET node-exe::node-exe AND NOT TARGET kth::node-exe)
+    add_library(kth::node-exe ALIAS node-exe::node-exe)
+endif()
+
+if(TARGET c-api::c-api AND NOT TARGET kth::c-api)
+    add_library(kth::c-api ALIAS c-api::c-api)
+endif()
+
+# Create a meta target that includes all the core components
+if(NOT TARGET kth::kth)
+    add_library(kth::kth INTERFACE IMPORTED)
+    set_target_properties(kth::kth PROPERTIES
+        INTERFACE_LINK_LIBRARIES "kth::infrastructure;kth::domain;kth::consensus;kth::database;kth::blockchain;kth::node;kth::secp256k1"
+    )
+    
+    # Add network if available
+    if(TARGET kth::network)
+        set_property(TARGET kth::kth APPEND PROPERTY INTERFACE_LINK_LIBRARIES "kth::network")
+    endif()
+endif()
+
+check_required_components(kth)

--- a/conanfile.py
+++ b/conanfile.py
@@ -231,4 +231,122 @@ class KthRecipe(KnuthConanFileV2):
         cmake.install()
 
     def package_info(self):
-        self.cpp_info.libs = collect_libs(self)
+        # Set the main CMake file name
+        self.cpp_info.set_property("cmake_file_name", "kth")
+        
+        # Define individual components as separate targets
+        # Each component will be available as kth::component_name
+        
+        # Secp256k1 cryptographic library
+        self.cpp_info.components["secp256k1"].libs = ["secp256k1"]
+        self.cpp_info.components["secp256k1"].names["cmake_find_package"] = "secp256k1"
+        self.cpp_info.components["secp256k1"].names["cmake_find_package_multi"] = "secp256k1"
+        # secp256k1 requires GMP for big number operations
+        self.cpp_info.components["secp256k1"].requires = ["gmp::gmp"]
+
+        # Core infrastructure component
+        self.cpp_info.components["infrastructure"].libs = ["infrastructure"]
+        self.cpp_info.components["infrastructure"].names["cmake_find_package"] = "infrastructure"
+        self.cpp_info.components["infrastructure"].names["cmake_find_package_multi"] = "infrastructure"
+        # Infrastructure core dependencies: secp256k1, boost, fmt, expected-lite, ctre, spdlog
+        self.cpp_info.components["infrastructure"].requires = [
+            "secp256k1", 
+            "boost::boost", 
+            "fmt::fmt", 
+            "expected-lite::expected-lite", 
+            "ctre::ctre", 
+            "spdlog::spdlog"
+        ]
+        
+        
+        # Domain models and business logic
+        self.cpp_info.components["domain"].libs = ["domain"]
+        self.cpp_info.components["domain"].names["cmake_find_package"] = "domain"
+        self.cpp_info.components["domain"].names["cmake_find_package_multi"] = "domain"
+        # Domain depends on infrastructure and tiny-aes-c for wallet encryption
+        self.cpp_info.components["domain"].requires = [
+            "infrastructure", 
+            "tiny-aes-c::tiny-aes-c"
+        ]
+        
+        # Consensus rules and validation
+        self.cpp_info.components["consensus"].libs = ["consensus"]
+        self.cpp_info.components["consensus"].names["cmake_find_package"] = "consensus"
+        self.cpp_info.components["consensus"].names["cmake_find_package_multi"] = "consensus"
+        # Consensus has its own direct dependencies: boost, openssl, secp256k1 (internal component)
+        self.cpp_info.components["consensus"].requires = [
+            "secp256k1",
+            "boost::boost", 
+            "openssl::openssl"
+        ]
+        
+        # Database layer
+        self.cpp_info.components["database"].libs = ["database"]
+        self.cpp_info.components["database"].names["cmake_find_package"] = "database"
+        self.cpp_info.components["database"].names["cmake_find_package_multi"] = "database"
+        # Database depends on domain and lmdb
+        self.cpp_info.components["database"].requires = ["domain", "lmdb::lmdb"]
+        
+        # Blockchain management
+        self.cpp_info.components["blockchain"].libs = ["blockchain"]
+        self.cpp_info.components["blockchain"].names["cmake_find_package"] = "blockchain"
+        self.cpp_info.components["blockchain"].names["cmake_find_package_multi"] = "blockchain"
+        # Blockchain depends on database and optionally consensus
+        self.cpp_info.components["blockchain"].requires = [
+            "database", 
+            "consensus"
+        ]
+        
+        # Network layer (not available in Emscripten builds)
+        if self.settings.os != "Emscripten":
+            self.cpp_info.components["network"].libs = ["network"]
+            self.cpp_info.components["network"].names["cmake_find_package"] = "network"
+            self.cpp_info.components["network"].names["cmake_find_package_multi"] = "network"
+            # Network depends on domain
+            self.cpp_info.components["network"].requires = ["domain"]
+        
+        # Node implementation
+        self.cpp_info.components["node"].libs = ["node"]
+        self.cpp_info.components["node"].names["cmake_find_package"] = "node"
+        self.cpp_info.components["node"].names["cmake_find_package_multi"] = "node"
+        # Node depends on blockchain and optionally network (if not Emscripten)
+        node_requires = ["blockchain"]
+        if self.settings.os != "Emscripten":
+            node_requires.append("network")
+        self.cpp_info.components["node"].requires = node_requires
+        
+        # Optional components
+        # Node executable (if built)
+        try:
+            node_exe_libs = [lib for lib in collect_libs(self) if "node-exe" in lib or "kth-node-exe" in lib]
+            if node_exe_libs:
+                self.cpp_info.components["node-exe"].libs = node_exe_libs
+                self.cpp_info.components["node-exe"].names["cmake_find_package"] = "node-exe"
+                self.cpp_info.components["node-exe"].names["cmake_find_package_multi"] = "node-exe"
+                self.cpp_info.components["node-exe"].requires = ["node"]
+        except:
+            # If collect_libs fails or node-exe is not built, skip it
+            pass
+        
+        # C API (if enabled)
+        # Note: BUILD_C_API option might not be accessible here, so we'll try to detect if the lib exists
+        try:
+            c_api_libs = [lib for lib in collect_libs(self) if "c-api" in lib or "kth-c-api" in lib]
+            if c_api_libs:
+                self.cpp_info.components["c-api"].libs = c_api_libs
+                self.cpp_info.components["c-api"].names["cmake_find_package"] = "c-api"
+                self.cpp_info.components["c-api"].names["cmake_find_package_multi"] = "c-api"
+                self.cpp_info.components["c-api"].requires = ["node"]
+        except:
+            # If collect_libs fails or c-api is not built, skip it
+            pass
+        
+        # Main target that includes all core components (equivalent to the old behavior)
+        # This provides a convenient way to link against all of kth at once
+        main_requires = ["infrastructure", "domain", "consensus", "database", "blockchain", "node", "secp256k1"]
+        if self.settings.os != "Emscripten":
+            main_requires.append("network")
+        
+        self.cpp_info.components["kth"].requires = main_requires
+        self.cpp_info.components["kth"].names["cmake_find_package"] = "kth"
+        self.cpp_info.components["kth"].names["cmake_find_package_multi"] = "kth"

--- a/doc/CMAKE_TARGETS.md
+++ b/doc/CMAKE_TARGETS.md
@@ -1,0 +1,118 @@
+# Kth Mono Repository - CMake Targets
+
+This Kth mono repository exposes multiple CMake targets that allow users to import only the components they need.
+
+## Available Targets
+
+After calling `find_package(kth REQUIRED)`, the following targets are available:
+
+### Individual Component Targets
+
+- `kth::infrastructure` - Basic utilities, logging, fundamental data structures
+- `kth::secp256k1` - Elliptic curve cryptographic library
+- `kth::domain` - Domain models and blockchain business logic
+- `kth::consensus` - Consensus rules and validation
+- `kth::database` - Data access layer and persistence
+- `kth::blockchain` - Blockchain management and operations
+- `kth::network` - Network layer (not available in Emscripten builds)
+- `kth::node` - Complete node implementation
+
+### Optional Targets
+
+- `kth::node-exe` - Node executable (console application) - only if built
+- `kth::c-api` - C API for interoperability - only if built with BUILD_C_API=True
+
+### Meta Target
+
+- `kth::kth` - Target that includes all core components (equivalent to previous behavior)
+
+## Usage Examples
+
+### Using Specific Components Only
+
+If you only need to work with domain models and validation:
+
+```cmake
+find_package(kth REQUIRED)
+
+target_link_libraries(my_application 
+    PRIVATE 
+    kth::domain 
+    kth::consensus
+)
+```
+
+### Using the Complete Network Stack
+
+For an application that needs full network functionality:
+
+```cmake
+find_package(kth REQUIRED)
+
+target_link_libraries(my_application 
+    PRIVATE 
+    kth::node
+    kth::network
+    kth::blockchain
+)
+```
+
+### Using All Kth (Traditional Behavior)
+
+To use the entire Kth ecosystem as before:
+
+```cmake
+find_package(kth REQUIRED)
+
+target_link_libraries(my_application 
+    PRIVATE 
+    kth::kth
+)
+```
+
+### Cryptography Only
+
+If you only need cryptographic functions:
+
+```cmake
+find_package(kth REQUIRED)
+
+target_link_libraries(my_application 
+    PRIVATE 
+    kth::secp256k1
+    kth::infrastructure  # For basic utilities
+)
+```
+
+## Conanfile.py
+
+In your `conanfile.py`:
+
+```python
+def requirements(self):
+    self.requires("kth/0.68.2", transitive_headers=True, transitive_libs=True)
+```
+
+## Benefits
+
+1. **Modularity**: You can import only what you need, reducing compilation time and binary size
+2. **Clarity**: It's explicit which components your application uses
+3. **Flexibility**: You can use different combinations of components according to your needs
+4. **Compatibility**: The `kth::kth` target maintains compatibility with previous usage
+
+## Dependencies Between Components
+
+```
+kth::secp256k1          (independent)
+kth::infrastructure    ← kth::secp256k1
+kth::domain            ← kth::infrastructure
+kth::consensus         ← kth::secp256k1
+kth::database          ← kth::domain
+kth::blockchain        ← kth::database
+kth::network           ← kth::domain
+kth::node              ← kth::blockchain, [kth::network]
+kth::node-exe          ← kth::node
+kth::c-api             ← kth::node
+```
+
+**Note**: `kth::network` is not available in Emscripten builds.

--- a/scripts/build-create-ems.sh
+++ b/scripts/build-create-ems.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -x
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <version>"
+    exit 1
+fi
+VERSION="$1"
+
+echo "Building version: ${VERSION}"
+
+rm -rf build
+rm -rf conan.lock
+
+conan lock create conanfile.py --version="${VERSION}" --update -pr ems2
+
+conan lock create conanfile.py --version "${VERSION}" --lockfile=conan.lock --lockfile-out=build/conan.lock -pr ems2
+conan create conanfile.py --version "${VERSION}" --lockfile=build/conan.lock --build=missing  -pr ems2
+
+

--- a/test_targets/CMakeLists.txt
+++ b/test_targets/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 3.20)
+project(test_kth_targets)
+
+find_package(kth REQUIRED)
+
+# Test individual targets
+add_executable(test_individual test_individual.cpp)
+target_link_libraries(test_individual 
+    PRIVATE 
+    kth::infrastructure
+    kth::domain
+    kth::secp256k1
+)
+
+# Test meta target
+add_executable(test_meta test_meta.cpp)
+target_link_libraries(test_meta 
+    PRIVATE 
+    kth::kth
+)
+
+# Print available targets for verification
+message(STATUS "Testing KTH targets:")
+if(TARGET kth::infrastructure)
+    message(STATUS "  ✓ kth::infrastructure - Available")
+endif()
+if(TARGET kth::domain)
+    message(STATUS "  ✓ kth::domain - Available")
+endif()
+if(TARGET kth::consensus)
+    message(STATUS "  ✓ kth::consensus - Available")
+endif()
+if(TARGET kth::secp256k1)
+    message(STATUS "  ✓ kth::secp256k1 - Available")
+endif()
+if(TARGET kth::database)
+    message(STATUS "  ✓ kth::database - Available")
+endif()
+if(TARGET kth::blockchain)
+    message(STATUS "  ✓ kth::blockchain - Available")
+endif()
+if(TARGET kth::node)
+    message(STATUS "  ✓ kth::node - Available")
+endif()
+if(TARGET kth::network)
+    message(STATUS "  ✓ kth::network - Available")
+endif()
+if(TARGET kth::c-api)
+    message(STATUS "  ✓ kth::c-api - Available")
+endif()
+if(TARGET kth::kth)
+    message(STATUS "  ✓ kth::kth - Available (meta target)")
+endif()

--- a/test_targets/conanfile.py
+++ b/test_targets/conanfile.py
@@ -1,0 +1,19 @@
+from conan import ConanFile
+from conan.tools.cmake import CMakeDeps, CMakeToolchain, cmake_layout
+
+class TestKthTargetsConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        # When using the actual package, you would do:
+        # self.requires("kth/0.68.2", transitive_headers=True, transitive_libs=True)
+        
+        # For local testing with the editable package:
+        self.requires("kth/0.68.2", transitive_headers=True, transitive_libs=True)
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.20]")

--- a/test_targets/test_individual.cpp
+++ b/test_targets/test_individual.cpp
@@ -1,0 +1,16 @@
+#include <iostream>
+
+// Test individual targets - include version headers from each module
+#include <kth/infrastructure/version.hpp>
+#include <kth/domain/version.hpp>
+#include <secp256k1/version.h>
+
+int main() {
+    std::cout << "Testing individual KTH targets..." << std::endl;
+    std::cout << "Infrastructure version: " << kth::infrastructure::version() << std::endl;
+    std::cout << "Domain version: " << kth::domain::version() << std::endl;
+    // Note: secp256k1 doesn't have a version function, just the macro
+    std::cout << "Successfully linked kth::infrastructure, kth::domain, and kth::secp256k1" << std::endl;
+    std::cout << "All individual targets are working correctly!" << std::endl;
+    return 0;
+}

--- a/test_targets/test_meta.cpp
+++ b/test_targets/test_meta.cpp
@@ -1,0 +1,20 @@
+#include <iostream>
+
+// Test meta target (includes everything) - show versions from multiple modules
+#include <kth/infrastructure/version.hpp>
+#include <kth/domain/version.hpp>
+#include <kth/consensus/version.hpp>
+#include <kth/blockchain/version.hpp>
+#include <kth/node/version.hpp>
+
+int main() {
+    std::cout << "Testing KTH meta target (kth::kth)..." << std::endl;
+    std::cout << "=== KTH Component Versions ===" << std::endl;
+    std::cout << "Infrastructure: " << kth::infrastructure::version() << std::endl;
+    std::cout << "Domain: " << kth::domain::version() << std::endl;
+    // Note: Not all modules may have version functions implemented
+    std::cout << "Blockchain: " << kth::blockchain::version() << std::endl;
+    std::cout << "Node: " << kth::node::version() << std::endl;
+    std::cout << "Meta target includes all core components!" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
- Define Conan components for each submodule (secp256k1, infrastructure, domain, consensus, database, blockchain, network, node) with accurate dependencies
- Add cmake/kth-config.cmake.in to expose all submodule targets with kth:: namespace aliases
- Create kth::kth meta-target that includes all core components for backward compatibility
- Fix dependency references (use expected-lite::expected-lite, fmt::fmt instead of header-only variants)
- Ensure consensus and infrastructure use correct secp256k1 references
- Handle Emscripten builds properly (exclude network component)
- Update CMakeLists.txt to install the new CMake config file

This allows users to import only the specific components they need:
- Individual targets: kth::infrastructure, kth::domain, kth::consensus, etc.
- Meta target: kth::kth (maintains backward compatibility)
- Optional targets: kth::c-api, kth::node-exe (if built)

Fixes dependency propagation issues and enables modular usage of the Kth library.