### PR TITLE
fix: add missing conan profiles to unit test steps

### DIFF
--- a/.github/workflows/build-with-container.yml
+++ b/.github/workflows/build-with-container.yml
@@ -118,7 +118,7 @@ jobs:
           
           # Build with tests enabled
           conan lock create conanfile.py --version ${{ inputs.build-version }} --lockfile=conan.lock --lockfile-out=build/conan.lock -pr:b linux-ci-cd -pr:h linux-ci-cd -o march_id=ZLm9Pjh
-          conan install conanfile.py --lockfile=build/conan.lock -of build --build=missing -o tests=True
+          conan install conanfile.py --lockfile=build/conan.lock -of build --build=missing -pr:b linux-ci-cd -pr:h linux-ci-cd -o tests=True
           
           # Configure with tests enabled
           cmake --preset conan-release \

--- a/.github/workflows/build-without-container.yml
+++ b/.github/workflows/build-without-container.yml
@@ -110,7 +110,7 @@ jobs:
           
           # Build with tests enabled
           conan lock create conanfile.py --version ${{ inputs.build-version }} --lockfile=conan.lock --lockfile-out=build/conan.lock -pr:b general-ci-cd -pr:h general-ci-cd
-          conan install conanfile.py --lockfile=build/conan.lock -of build --build=missing -o tests=True
+          conan install conanfile.py --lockfile=build/conan.lock -of build --build=missing -pr:b general-ci-cd -pr:h general-ci-cd -o tests=True
           
           # Configure with tests enabled
           cmake --preset conan-release \


### PR DESCRIPTION
  - Add -pr:b linux-ci-cd -pr:h linux-ci-cd to build-with-container.yml
  - Add -pr:b general-ci-cd -pr:h general-ci-cd to build-without-container.yml
  - Ensures unit tests use correct compiler configurations and C++ version
  - Maintains consistency with main build profiles used in each workflow