### PR TITLE
fix: restore script_basis constructor behavior to use valid state ins…

### DIFF
--- a/src/domain/src/chain/script_basis.cpp
+++ b/src/domain/src/chain/script_basis.cpp
@@ -57,7 +57,8 @@ script_basis::script_basis(data_chunk&& encoded, bool prefix) {
         byte_reader reader(encoded);
         auto obj = from_data(reader, prefix);
         if (! obj) {
-            throw std::runtime_error(obj.error().message());
+            valid_ = false;
+            return;
         }
         valid_ = true;
         *this = std::move(obj.value());
@@ -73,7 +74,8 @@ script_basis::script_basis(data_chunk const& encoded, bool prefix) {
     byte_reader reader(encoded);
     auto obj = from_data(reader, prefix);
     if (! obj) {
-        throw std::runtime_error(obj.error().message());
+        valid_ = false;
+        return;
     }
     valid_ = true;
     *this = std::move(obj.value());


### PR DESCRIPTION
…tead of exceptions

  - Remove exception throwing from script_basis constructors
  - Set valid_ = false when deserialization fails instead of throwing
  - Maintain backward compatibility with existing code that checks is_valid()
  - Preserve move constructor optimization for non-prefixed data