### PR TITLE
refactor: modernize string parameters to use std::string_view

### DIFF
--- a/src/infrastructure/include/kth/infrastructure/config/authority.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/authority.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <iostream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 // #include <fmt/ostream.h>
@@ -39,7 +40,7 @@ public:
 
 
     explicit
-    authority(std::string const& authority);
+    authority(std::string_view authority);
 
     //Note(fernando): in kth-network it is used the implicit convertion
     // implicit
@@ -48,7 +49,7 @@ public:
     authority(message::ip_address const& ip, uint16_t port);
 
 
-    authority(std::string const& host, uint16_t port);
+    authority(std::string_view host, uint16_t port);
 
 #if ! defined(__EMSCRIPTEN__)
     authority(asio::address const& ip, uint16_t port);

--- a/src/infrastructure/include/kth/infrastructure/config/base16.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/base16.hpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <iostream>
 #include <string>
+#include <string_view>
 
 #include <kth/infrastructure/define.hpp>
 #include <kth/infrastructure/utility/data.hpp>
@@ -29,7 +30,7 @@ public:
     base16& operator=(base16&&) = default;
 
     explicit
-    base16(std::string const& hexcode);
+    base16(std::string_view hexcode);
 
     explicit
     base16(data_chunk const& value);

--- a/src/infrastructure/include/kth/infrastructure/config/base2.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/base2.hpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <iostream>
 #include <string>
+#include <string_view>
 
 #include <kth/infrastructure/define.hpp>
 #include <kth/infrastructure/utility/binary.hpp>
@@ -31,7 +32,7 @@ public:
      * @param[in]  bin  The value to initialize with.
      */
     explicit
-    base2(std::string const& binary);
+    base2(std::string_view binary);
 
     /**
      * @param[in]  value  The value to initialize with.

--- a/src/infrastructure/include/kth/infrastructure/config/base58.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/base58.hpp
@@ -7,6 +7,7 @@
 
 #include <iostream>
 #include <string>
+#include <string_view>
 
 #include <kth/infrastructure/define.hpp>
 #include <kth/infrastructure/utility/data.hpp>
@@ -27,7 +28,7 @@ public:
 
 
     explicit
-    base58(std::string const& base58);
+    base58(std::string_view base58);
 
     explicit
     base58(data_chunk const& value);

--- a/src/infrastructure/include/kth/infrastructure/config/base64.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/base64.hpp
@@ -7,6 +7,7 @@
 
 #include <iostream>
 #include <string>
+#include <string_view>
 
 #include <kth/infrastructure/define.hpp>
 #include <kth/infrastructure/utility/data.hpp>
@@ -26,7 +27,7 @@ public:
     base64& operator=(base64&&) = default;
 
     explicit
-    base64(std::string const& base64);
+    base64(std::string_view base64);
 
     explicit
     base64(data_chunk const& value);

--- a/src/infrastructure/include/kth/infrastructure/config/checkpoint.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/checkpoint.hpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <iostream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <kth/infrastructure/define.hpp>
@@ -57,14 +58,14 @@ public:
      * @param[in]  value  The value of the hash[:height] form.
      */
     explicit
-    checkpoint(std::string const& value);
+    checkpoint(std::string_view value);
 
     /**
      * Initialization constructor.
      * @param[in]  hash    The string block hash for the checkpoint.
      * @param[in]  height  The height of the hash.
      */
-    checkpoint(std::string const& hash, size_t height);
+    checkpoint(std::string_view hash, size_t height);
 
     /**
      * Initialization constructor.

--- a/src/infrastructure/include/kth/infrastructure/config/endpoint.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/endpoint.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <iostream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 // #include <fmt/ostream.h>
@@ -48,7 +49,7 @@ public:
      */
     // explicit
     // implicit
-    endpoint(std::string const& value);
+    endpoint(std::string_view value);
 
     /**
      * Initialization constructor.
@@ -62,7 +63,7 @@ public:
      * @param[in]  host  The host name or ip address to initialize with.
      * @param[in]  port  The port to initialize with.
      */
-    endpoint(std::string const& host, uint16_t port);
+    endpoint(std::string_view host, uint16_t port);
 
 #if ! defined(__EMSCRIPTEN__)
     /**

--- a/src/infrastructure/include/kth/infrastructure/config/hash160.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/hash160.hpp
@@ -7,6 +7,7 @@
 
 #include <iostream>
 #include <string>
+#include <string_view>
 
 #include <kth/infrastructure/define.hpp>
 #include <kth/infrastructure/math/hash.hpp>
@@ -23,7 +24,7 @@ public:
     hash160(hash160 const& x) = default;
 
     explicit
-    hash160(std::string const& hexcode);
+    hash160(std::string_view hexcode);
 
     explicit
     hash160(short_hash const& value);

--- a/src/infrastructure/include/kth/infrastructure/config/hash256.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/hash256.hpp
@@ -7,6 +7,7 @@
 
 #include <iostream>
 #include <string>
+#include <string_view>
 
 #include <kth/infrastructure/define.hpp>
 #include <kth/infrastructure/math/hash.hpp>
@@ -30,7 +31,7 @@ public:
      * @param[in]  hexcode  The hash value in string hexidecimal form.
      */
     explicit
-    hash256(std::string const& hexcode);
+    hash256(std::string_view hexcode);
 
     /**
      * Initialization constructor.

--- a/src/infrastructure/include/kth/infrastructure/config/sodium.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/sodium.hpp
@@ -7,6 +7,7 @@
 
 #include <iostream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <kth/infrastructure/define.hpp>
@@ -31,7 +32,7 @@ public:
      * @param[in]  base85  The value to initialize with.
      */
     explicit
-    sodium(std::string const& base85);
+    sodium(std::string_view base85);
 
     /**
      * Initialization constructor.

--- a/src/infrastructure/include/kth/infrastructure/formats/base_16.hpp
+++ b/src/infrastructure/include/kth/infrastructure/formats/base_16.hpp
@@ -6,6 +6,7 @@
 #define KTH_INFRASTUCTURE_BASE_16_HPP
 
 #include <string>
+#include <string_view>
 
 #include <kth/infrastructure/define.hpp>
 #include <kth/infrastructure/math/hash.hpp>
@@ -28,14 +29,14 @@ KI_API std::string encode_base16(data_slice data);
  * Convert a hex string into bytes.
  * @return false if the input is malformed.
  */
-KI_API bool decode_base16(data_chunk& out, std::string const &in);
+KI_API bool decode_base16(data_chunk& out, std::string_view in);
 
 /**
  * Converts a hex string to a number of bytes.
  * @return false if the input is malformed, or the wrong length.
  */
 template <size_t Size>
-bool decode_base16(byte_array<Size>& out, std::string const &in);
+bool decode_base16(byte_array<Size>& out, std::string_view in);
 
 /**
  * Converts a hex string literal to a data array.
@@ -56,7 +57,7 @@ KI_API std::string encode_hash(hash_digest hash);
  * The bitcoin_hash format is like base16, but with the bytes reversed.
  * @return false if the input is malformed.
  */
-KI_API bool decode_hash(hash_digest& out, std::string const& in);
+KI_API bool decode_hash(hash_digest& out, std::string_view in);
 
 /**
  * Convert a hex string literal into a bitcoin_hash.

--- a/src/infrastructure/include/kth/infrastructure/formats/base_58.hpp
+++ b/src/infrastructure/include/kth/infrastructure/formats/base_58.hpp
@@ -6,6 +6,7 @@
 #define KTH_INFRASTUCTURE_BASE_58_HPP
 
 #include <string>
+#include <string_view>
 
 #include <kth/infrastructure/define.hpp>
 #include <kth/infrastructure/utility/data.hpp>
@@ -13,14 +14,14 @@
 namespace kth {
 
 KI_API bool is_base58(char ch);
-KI_API bool is_base58(std::string const& text);
+KI_API bool is_base58(std::string_view text);
 
 /**
  * Converts a base58 string to a number of bytes.
  * @return false if the input is malformed, or the wrong length.
  */
 template <size_t Size>
-bool decode_base58(byte_array<Size>& out, std::string const &in);
+bool decode_base58(byte_array<Size>& out, std::string_view in);
 
 /**
  * Converts a base58 string literal to a data array.
@@ -41,7 +42,7 @@ KI_API std::string encode_base58(data_slice unencoded);
  * Attempt to decode base58 data.
  * @return false if the input contains non-base58 characters.
  */
-KI_API bool decode_base58(data_chunk& out, std::string const& in);
+KI_API bool decode_base58(data_chunk& out, std::string_view in);
 
 } // namespace kth
 

--- a/src/infrastructure/include/kth/infrastructure/formats/base_64.hpp
+++ b/src/infrastructure/include/kth/infrastructure/formats/base_64.hpp
@@ -6,6 +6,7 @@
 #define KTH_INFRASTUCTURE_BASE_64_HPP
 
 #include <string>
+#include <string_view>
 
 #include <kth/infrastructure/define.hpp>
 #include <kth/infrastructure/utility/data.hpp>
@@ -22,7 +23,7 @@ KI_API std::string encode_base64(data_slice unencoded);
  * Attempt to decode base64 data.
  * @return false if the input contains non-base64 characters.
  */
-KI_API bool decode_base64(data_chunk& out, std::string const& in);
+KI_API bool decode_base64(data_chunk& out, std::string_view in);
 
 } // namespace kth
 

--- a/src/infrastructure/include/kth/infrastructure/formats/base_85.hpp
+++ b/src/infrastructure/include/kth/infrastructure/formats/base_85.hpp
@@ -6,6 +6,7 @@
 #define KTH_INFRASTUCTURE_BASE_85_HPP
 
 #include <string>
+#include <string_view>
 
 #include <kth/infrastructure/define.hpp>
 #include <kth/infrastructure/utility/data.hpp>
@@ -22,7 +23,7 @@ KI_API bool encode_base85(std::string& out, data_slice in);
  * Attempt to decode base85 (Z85) data.
  * @return false if the input contains non-base85 characters or length (% 5).
  */
-KI_API bool decode_base85(data_chunk& out, std::string const& in);
+KI_API bool decode_base85(data_chunk& out, std::string_view in);
 
 } // namespace kth
 

--- a/src/infrastructure/include/kth/infrastructure/impl/formats/base_16.ipp
+++ b/src/infrastructure/include/kth/infrastructure/impl/formats/base_16.ipp
@@ -14,7 +14,7 @@ KI_API bool decode_base16_private(uint8_t* out, size_t out_size,
     char const* in);
 
 template <size_t Size>
-bool decode_base16(byte_array<Size>& out, std::string const &in)
+bool decode_base16(byte_array<Size>& out, std::string_view in)
 {
     if (in.size() != 2 * Size) {
         return false;

--- a/src/infrastructure/include/kth/infrastructure/impl/formats/base_58.ipp
+++ b/src/infrastructure/include/kth/infrastructure/impl/formats/base_58.ipp
@@ -15,7 +15,7 @@ KI_API bool decode_base58_private(uint8_t* out, size_t out_size,
     char const* in);
 
 template <size_t Size>
-bool decode_base58(byte_array<Size>& out, std::string const &in)
+bool decode_base58(byte_array<Size>& out, std::string_view in)
 {
     byte_array<Size> result;
     if ( ! decode_base58_private(result.data(), result.size(), in.data())) {

--- a/src/infrastructure/src/config/authority.cpp
+++ b/src/infrastructure/src/config/authority.cpp
@@ -115,8 +115,8 @@ std::string to_ipv6_hostname(asio::address const& ip_address) {
 // {}
 
 // authority: [2001:db8::2]:port or 1.2.240.1:port
-authority::authority(std::string const& authority) {
-    std::stringstream(authority) >> *this;
+authority::authority(std::string_view authority) {
+    std::stringstream(std::string(authority)) >> *this;
 }
 
 // This is the format returned from peers on the bitcoin network.
@@ -163,8 +163,8 @@ authority::authority(message::ip_address const& ip, uint16_t port)
 {}
 
 // host: [2001:db8::2] or 2001:db8::2 or 1.2.240.1
-authority::authority(std::string const& host, uint16_t port)
-    : authority(to_authority(host, port))
+authority::authority(std::string_view host, uint16_t port)
+    : authority(to_authority(std::string(host), port))
 {}
 
 #if ! defined(__EMSCRIPTEN__)

--- a/src/infrastructure/src/config/base16.cpp
+++ b/src/infrastructure/src/config/base16.cpp
@@ -19,8 +19,8 @@
 namespace kth::infrastructure::config {
 
 
-base16::base16(std::string const& hexcode) {
-    std::stringstream(hexcode) >> *this;
+base16::base16(std::string_view hexcode) {
+    std::stringstream(std::string(hexcode)) >> *this;
 }
 
 base16::base16(data_chunk const& value)

--- a/src/infrastructure/src/config/base2.cpp
+++ b/src/infrastructure/src/config/base2.cpp
@@ -17,8 +17,8 @@
 
 namespace kth::infrastructure::config {
 
-base2::base2(std::string const& binary) {
-    std::stringstream(binary) >> *this;
+base2::base2(std::string_view binary) {
+    std::stringstream(std::string(binary)) >> *this;
 }
 
 base2::base2(binary const& value)

--- a/src/infrastructure/src/config/base58.cpp
+++ b/src/infrastructure/src/config/base58.cpp
@@ -22,8 +22,8 @@ namespace kth::infrastructure::config {
 // {
 // }
 
-base58::base58(std::string const& base58) {
-    std::stringstream(base58) >> *this;
+base58::base58(std::string_view base58) {
+    std::stringstream(std::string(base58)) >> *this;
 }
 
 base58::base58(data_chunk const& value)

--- a/src/infrastructure/src/config/base64.cpp
+++ b/src/infrastructure/src/config/base64.cpp
@@ -18,8 +18,8 @@
 
 namespace kth::infrastructure::config {
 
-base64::base64(std::string const& base64) {
-    std::stringstream(base64) >> *this;
+base64::base64(std::string_view base64) {
+    std::stringstream(std::string(base64)) >> *this;
 }
 
 base64::base64(data_chunk const& value)

--- a/src/infrastructure/src/config/checkpoint.cpp
+++ b/src/infrastructure/src/config/checkpoint.cpp
@@ -31,10 +31,10 @@ using namespace boost::program_options;
 //     : hash_(kth::null_hash)
 // {}
 
-checkpoint::checkpoint(std::string const& value)
+checkpoint::checkpoint(std::string_view value)
     : checkpoint()
 {
-    std::stringstream(value) >> *this;
+    std::stringstream(std::string(value)) >> *this;
 }
 
 // checkpoint::checkpoint(checkpoint const& x)
@@ -42,15 +42,15 @@ checkpoint::checkpoint(std::string const& value)
 // {}
 
 // This is intended for static initialization (i.e. of the internal defaults).
-checkpoint::checkpoint(std::string const& hash, size_t height)
+checkpoint::checkpoint(std::string_view hash, size_t height)
     : height_(height)
 {
     if ( ! decode_hash(hash_, hash)) {
 #if ! defined(__EMSCRIPTEN__)
         using namespace boost::program_options;
-        BOOST_THROW_EXCEPTION(invalid_option_value(hash));
+        BOOST_THROW_EXCEPTION(invalid_option_value(std::string(hash)));
 #else
-        throw std::invalid_argument(hash);
+        throw std::invalid_argument(std::string(hash));
 #endif
     }
 }
@@ -118,7 +118,7 @@ std::istream& operator>>(std::istream& input, checkpoint& argument) {
     }
 
     auto const& match = *it;
-    if ( ! decode_hash(argument.hash_, match[1])) {
+    if ( ! decode_hash(argument.hash_, match[1].str())) {
 #if ! defined(__EMSCRIPTEN__)
         using namespace boost::program_options;
         BOOST_THROW_EXCEPTION(invalid_option_value(value));

--- a/src/infrastructure/src/config/endpoint.cpp
+++ b/src/infrastructure/src/config/endpoint.cpp
@@ -35,15 +35,15 @@ endpoint::endpoint(endpoint const& x)
     : scheme_(x.scheme()), host_(x.host()), port_(x.port())
 {}
 
-endpoint::endpoint(std::string const& value) {
-    std::stringstream(value) >> *this;
+endpoint::endpoint(std::string_view value) {
+    std::stringstream(std::string(value)) >> *this;
 }
 
 endpoint::endpoint(authority const& authority)
     : endpoint(authority.to_string())
 {}
 
-endpoint::endpoint(std::string const& host, uint16_t port)
+endpoint::endpoint(std::string_view host, uint16_t port)
     : host_(host), port_(port)
 {}
 

--- a/src/infrastructure/src/config/hash160.cpp
+++ b/src/infrastructure/src/config/hash160.cpp
@@ -18,8 +18,8 @@
 
 namespace kth::infrastructure::config {
 
-hash160::hash160(std::string const& hexcode) {
-    std::stringstream(hexcode) >> *this;
+hash160::hash160(std::string_view hexcode) {
+    std::stringstream(std::string(hexcode)) >> *this;
 }
 
 hash160::hash160(short_hash const& value)

--- a/src/infrastructure/src/config/hash256.cpp
+++ b/src/infrastructure/src/config/hash256.cpp
@@ -18,10 +18,10 @@
 
 namespace kth::infrastructure::config {
 
-hash256::hash256(std::string const& hexcode)
+hash256::hash256(std::string_view hexcode)
     : hash256()
 {
-    std::stringstream(hexcode) >> *this;
+    std::stringstream(std::string(hexcode)) >> *this;
 }
 
 hash256::hash256(hash_digest const& value)

--- a/src/infrastructure/src/config/sodium.cpp
+++ b/src/infrastructure/src/config/sodium.cpp
@@ -22,8 +22,8 @@ sodium::sodium()
     : value_(null_hash)
 {}
 
-sodium::sodium(std::string const& base85) {
-    std::stringstream(base85) >> *this;
+sodium::sodium(std::string_view base85) {
+    std::stringstream(std::string(base85)) >> *this;
 }
 
 sodium::sodium(hash_digest const& value)

--- a/src/infrastructure/src/formats/base_16.cpp
+++ b/src/infrastructure/src/formats/base_16.cpp
@@ -41,7 +41,7 @@ unsigned from_hex(char c) {
     return c - '0';
 }
 
-bool decode_base16(data_chunk& out, std::string const& in) {
+bool decode_base16(data_chunk& out, std::string_view in) {
     // This prevents a last odd character from being ignored:
     if (in.size() % 2 != 0) {
         return false;
@@ -62,7 +62,7 @@ std::string encode_hash(hash_digest hash) {
     return encode_base16(hash);
 }
 
-bool decode_hash(hash_digest& out, std::string const& in) {
+bool decode_hash(hash_digest& out, std::string_view in) {
     if (in.size() != 2 * hash_size) {
         return false;
     }

--- a/src/infrastructure/src/formats/base_58.cpp
+++ b/src/infrastructure/src/formats/base_58.cpp
@@ -17,7 +17,7 @@ bool is_base58(char ch) {
     return std::binary_search(base58_chars.begin(), base58_chars.end(), ch);
 }
 
-bool is_base58(std::string const& text) {
+bool is_base58(std::string_view text) {
     auto const test = [](char ch) {
         return is_base58(ch);
     };
@@ -93,7 +93,7 @@ std::string encode_base58(data_slice unencoded) {
     return encoded;
 }
 
-size_t count_leading_zeros(std::string const& encoded) {
+size_t count_leading_zeros(std::string_view encoded) {
     // Skip and count leading '1's.
     size_t leading_zeros = 0;
     for (uint8_t const digit: encoded) {
@@ -117,7 +117,7 @@ void unpack_char(data_chunk& data, size_t carry) {
     KTH_ASSERT(carry == 0);
 }
 
-bool decode_base58(data_chunk& out, std::string const& in) {
+bool decode_base58(data_chunk& out, std::string_view in) {
     // Trim spaces and newlines around the string.
     auto const leading_zeros = count_leading_zeros(in);
 

--- a/src/infrastructure/src/formats/base_64.cpp
+++ b/src/infrastructure/src/formats/base_64.cpp
@@ -63,7 +63,7 @@ std::string encode_base64(data_slice unencoded)
     return encoded;
 }
 
-bool decode_base64(data_chunk& out, std::string const& in)
+bool decode_base64(data_chunk& out, std::string_view in)
 {
     const static uint32_t mask = 0x000000FF;
 

--- a/src/infrastructure/src/formats/base_85.cpp
+++ b/src/infrastructure/src/formats/base_85.cpp
@@ -105,7 +105,7 @@ bool encode_base85(std::string& out, data_slice in)
 }
 
 // Accepts only strings bounded to 5 characters.
-bool decode_base85(data_chunk& out, std::string const& in)
+bool decode_base85(data_chunk& out, std::string_view in)
 {
     size_t const length = in.size();
     if (length % 5 != 0) {


### PR DESCRIPTION
## Summary

Modernize infrastructure code to use `std::string_view` for read-only string parameters, following C++17 best practices.

## Changes

### Base Encoding Functions
- Updated all base encoding/decoding functions to accept `std::string_view`:
  - `base_16.hpp/cpp`: `decode_base16()`, `decode_hash()`
  - `base_58.hpp/cpp`: `is_base58()`, `decode_base58()`
  - `base_64.hpp/cpp`: `decode_base64()`
  - `base_85.hpp/cpp`: `decode_base85()`

### Config Classes
- Modernized constructors to accept `std::string_view`:
  - `base16`, `base58`, `base64`, `base2`
  - `hash256`, `hash160`
  - `sodium`
  - `checkpoint`
  - `authority`
  - `endpoint`

## Benefits

- **Better Performance**: Avoids unnecessary string copies
- **More Flexible API**: Accepts string literals, `std::string`, and substrings without copies
- **Modern C++**: Follows C++17/20/23 best practices
- **Backward Compatible**: `std::string` implicitly converts to `std::string_view`

## Testing

- ✅ All tests passing
- ✅ Build successful
- ✅ No API breaking changes (implicit conversion maintains compatibility)

## Technical Notes

- Used `std::string(string_view)` conversions where functions require `std::string` (e.g., `std::stringstream`, Boost exceptions)
- Template implementations updated in `.ipp` files
- Implementation files (`.cpp`) updated to match header declarations