### PR TITLE
refactor: apply Rule of Zero to config classes

### DIFF
--- a/src/infrastructure/include/kth/infrastructure/config/authority.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/authority.hpp
@@ -30,13 +30,7 @@ namespace kth::infrastructure::config {
 struct KI_API authority {
     using list = std::vector<authority>;
 
-
     authority() = default;
-    authority(authority const& x) = default;
-    authority(authority&& x) = default;
-    authority& operator=(authority const& x) = default;
-    authority& operator=(authority&& x) = default;
-
 
     explicit
     authority(std::string_view authority);

--- a/src/infrastructure/include/kth/infrastructure/config/base16.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/base16.hpp
@@ -21,12 +21,7 @@ namespace kth::infrastructure::config {
  */
 //TODO(fernando): make a generic class for baseX
 struct KI_API base16 {
-
     base16() = default;
-    base16(base16 const& x) = default;
-    base16(base16&& x) = default;
-    base16& operator=(base16 const&) = default;
-    base16& operator=(base16&&) = default;
 
     explicit
     base16(std::string_view hexcode);
@@ -51,14 +46,14 @@ struct KI_API base16 {
      * @return  This object's value cast to internal type reference.
      */
     // implicit
-    operator data_chunk const&() const;
+    [[nodiscard]] operator data_chunk const&() const noexcept;
 
     /**
      * Overload cast to generic data reference.
      * @return  This object's value cast to a generic data.
      */
-    explicit
-    operator data_slice() const;
+    [[nodiscard]] explicit
+    operator data_slice() const noexcept;
 
     /**
      * Overload stream in. If input is invalid sets no bytes in argument.

--- a/src/infrastructure/include/kth/infrastructure/config/base2.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/base2.hpp
@@ -19,12 +19,7 @@ namespace kth::infrastructure::config {
  * Serialization helper for base2 encoded data.
  */
 struct KI_API base2 {
-
     base2() = default;
-    base2(base2 const& x) = default;
-    base2(base2&& x) = default;
-    base2& operator=(base2 const&) = default;
-    base2& operator=(base2&&) = default;
 
     /**
      * Initialization constructor.
@@ -39,18 +34,17 @@ struct KI_API base2 {
     explicit
     base2(binary const& value);
 
-
     /**
      * Get number of bits in value.
      */
-    size_t size() const;
+    [[nodiscard]] size_t size() const noexcept;
 
     /**
      * Overload cast to internal type.
      * @return  This object's value cast to internal type reference.
      */
-    explicit
-    operator binary const&() const;
+    [[nodiscard]] explicit
+    operator binary const&() const noexcept;
 
     /**
      * Overload stream in. If input is invalid sets no bytes in argument.

--- a/src/infrastructure/include/kth/infrastructure/config/base58.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/base58.hpp
@@ -18,13 +18,7 @@ namespace kth::infrastructure::config {
  * Serialization helper for base58 encoded text.
  */
 struct KI_API base58 {
-
     base58() = default;
-    base58(base58 const& x) = default;
-    base58(base58&& x) = default;
-    base58& operator=(base58 const&) = default;
-    base58& operator=(base58&&) = default;
-
 
     explicit
     base58(std::string_view base58);
@@ -39,15 +33,15 @@ struct KI_API base58 {
      * Overload cast to internal type.
      * @return  This object's value cast to internal type reference.
      */
-    explicit
-    operator data_chunk const&() const;
+    [[nodiscard]] explicit
+    operator data_chunk const&() const noexcept;
 
     /**
      * Overload cast to generic data reference.
      * @return  This object's value cast to a generic data.
      */
-    explicit
-    operator data_slice() const;
+    [[nodiscard]] explicit
+    operator data_slice() const noexcept;
 
     /**
      * Overload stream in. Throws if input is invalid.

--- a/src/infrastructure/include/kth/infrastructure/config/base64.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/base64.hpp
@@ -18,12 +18,7 @@ namespace kth::infrastructure::config {
  * Serialization helper for base64 encoded data.
  */
 struct KI_API base64 {
-
     base64() = default;
-    base64(base64 const& x) = default;
-    base64(base64&& x) = default;
-    base64& operator=(base64 const&) = default;
-    base64& operator=(base64&&) = default;
 
     explicit
     base64(std::string_view base64);
@@ -34,20 +29,19 @@ struct KI_API base64 {
     explicit
     base64(data_chunk&& value);
 
-
     /**
      * Overload cast to internal type.
      * @return  This object's value cast to internal type reference.
      */
-    explicit
-    operator data_chunk const&() const;
+    [[nodiscard]] explicit
+    operator data_chunk const&() const noexcept;
 
     /**
      * Overload cast to generic data reference.
      * @return  This object's value cast to a generic data.
      */
-    explicit
-    operator data_slice() const;
+    [[nodiscard]] explicit
+    operator data_slice() const noexcept;
 
     /**
      * Overload stream in. Throws if input is invalid.

--- a/src/infrastructure/include/kth/infrastructure/config/checkpoint.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/checkpoint.hpp
@@ -49,7 +49,6 @@ struct KI_API checkpoint {
     bool validate(hash_digest const& hash, size_t height, list const& checks);
 
     checkpoint() = default;
-    checkpoint(checkpoint const& x) noexcept = default;
 
     /**
      * Initialization constructor.

--- a/src/infrastructure/include/kth/infrastructure/config/hash160.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/hash160.hpp
@@ -18,9 +18,7 @@ namespace kth::infrastructure::config {
  * Serialization helper for a bitcoin 160 bit hash.
  */
 struct KI_API hash160 {
-
     hash160() = default;
-    hash160(hash160 const& x) = default;
 
     explicit
     hash160(std::string_view hexcode);
@@ -35,8 +33,8 @@ struct KI_API hash160 {
      * Overload cast to internal type.
      * @return  This object's value cast to internal type.
      */
-    explicit
-    operator short_hash const&() const;
+    [[nodiscard]] explicit
+    operator short_hash const&() const noexcept;
 
     /**
      * Overload stream in. Throws if input is invalid.

--- a/src/infrastructure/include/kth/infrastructure/config/hash256.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/hash256.hpp
@@ -24,8 +24,6 @@ public:
 
     hash256() = default;
 
-    hash256(hash256 const& x) = default;
-
     /**
      * Initialization constructor.
      * @param[in]  hexcode  The hash value in string hexidecimal form.
@@ -44,20 +42,20 @@ public:
      * Get the hash as a string.
      * @return The hash in the string hexidecimal form.
      */
-    std::string to_string() const;
+    [[nodiscard]] std::string to_string() const;
 
     /**
      * Override the equality operator.
      * @param[in]  other  The other object with which to compare.
      */
-    bool operator==(const hash256& x) const;
+    [[nodiscard]] bool operator==(const hash256& x) const noexcept;
 
     /**
      * Cast to internal type.
      * @return  This object's value cast to internal type.
      */
     // implicit
-    operator hash_digest const&() const;    //NOLINT
+    [[nodiscard]] operator hash_digest const&() const noexcept;    //NOLINT
 
     /**
      * Define stream in. Throws if input is invalid.

--- a/src/infrastructure/src/config/base16.cpp
+++ b/src/infrastructure/src/config/base16.cpp
@@ -31,11 +31,11 @@ base16::base16(data_chunk&& value)
     : value_(std::move(value))
 {}
 
-base16::operator data_chunk const&() const {
+base16::operator data_chunk const&() const noexcept {
     return value_;
 }
 
-base16::operator data_slice() const {
+base16::operator data_slice() const noexcept {
     return value_;
 }
 

--- a/src/infrastructure/src/config/base2.cpp
+++ b/src/infrastructure/src/config/base2.cpp
@@ -25,11 +25,11 @@ base2::base2(binary const& value)
     : value_(value)
 {}
 
-size_t base2::size() const {
+size_t base2::size() const noexcept {
     return value_.size();
 }
 
-base2::operator binary const&() const {
+base2::operator binary const&() const noexcept {
     return value_;
 }
 

--- a/src/infrastructure/src/config/base58.cpp
+++ b/src/infrastructure/src/config/base58.cpp
@@ -34,11 +34,11 @@ base58::base58(data_chunk&& value)
     : value_(std::move(value))
 {}
 
-base58::operator data_chunk const&() const {
+base58::operator data_chunk const&() const noexcept {
     return value_;
 }
 
-base58::operator data_slice() const {
+base58::operator data_slice() const noexcept {
     return value_;
 }
 

--- a/src/infrastructure/src/config/base64.cpp
+++ b/src/infrastructure/src/config/base64.cpp
@@ -31,11 +31,11 @@ base64::base64(data_chunk&& value)
 {}
 
 
-base64::operator data_chunk const&() const {
+base64::operator data_chunk const&() const noexcept {
     return value_;
 }
 
-base64::operator data_slice() const {
+base64::operator data_slice() const noexcept {
     return value_;
 }
 

--- a/src/infrastructure/src/config/hash160.cpp
+++ b/src/infrastructure/src/config/hash160.cpp
@@ -35,7 +35,7 @@ hash160::hash160(short_hash const& value)
 //     std::copy_n(value.begin(), value_.size(), value_.begin());
 // }
 
-hash160::operator short_hash const&() const {
+hash160::operator short_hash const&() const noexcept {
     return value_;
 }
 

--- a/src/infrastructure/src/config/hash256.cpp
+++ b/src/infrastructure/src/config/hash256.cpp
@@ -18,9 +18,7 @@
 
 namespace kth::infrastructure::config {
 
-hash256::hash256(std::string_view hexcode)
-    : hash256()
-{
+hash256::hash256(std::string_view hexcode) {
     std::stringstream(std::string(hexcode)) >> *this;
 }
 
@@ -34,7 +32,7 @@ std::string hash256::to_string() const {
     return value.str();
 }
 
-hash256::operator hash_digest const&() const {
+hash256::operator hash_digest const&() const noexcept {
     return value_;
 }
 


### PR DESCRIPTION
## Summary
Apply the Rule of Zero principle to config classes by removing unnecessary special member function declarations. When all special members would be trivial, let the compiler generate them automatically.

## Changes
- Remove trivial copy/move constructors and assignment operators from config classes
- Add explicit default constructors for consistency across all config classes
- Add `[[nodiscard]]` attributes to conversion operators and getters for better API safety
- Add `noexcept` specifications to const conversion operators for performance

## Classes Updated
- `base2`, `base16`, `base58`, `base64`
- `hash256`, `hash160`
- `checkpoint`, `authority`

## Impact
- **Code reduction**: -36 lines (14 files changed: +30, -66)
- **Improved maintainability**: Less boilerplate code
- **Better API safety**: `[[nodiscard]]` warns on ignored return values
- **Performance**: `noexcept` enables compiler optimizations

## Dependencies
This PR depends on #85 and should be merged after it.

## Testing
✅ Build passes
✅ All tests pass