### PR TITLE
refactor: modernize binary class with C++20/23 features

### DIFF
--- a/src/infrastructure/include/kth/infrastructure/utility/binary.hpp
+++ b/src/infrastructure/include/kth/infrastructure/utility/binary.hpp
@@ -5,8 +5,10 @@
 #ifndef KTH_INFRASTRUCTURE_BINARY_HPP
 #define KTH_INFRASTRUCTURE_BINARY_HPP
 
+#include <bit>
 #include <cstdint>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include <kth/infrastructure/constants.hpp>
@@ -21,42 +23,41 @@ struct KI_API binary {
     static
     constexpr size_type bits_per_block = byte_bits;
 
-    static
-    size_type blocks_size(size_type bit_size);
+    [[nodiscard]] static constexpr
+    size_type blocks_size(size_type bit_size) noexcept;
 
-    static
-    bool is_base2(std::string const& text);
+    [[nodiscard]] static
+    bool is_base2(std::string_view text) noexcept;
 
     binary() = default;
-    binary(binary const& x) = default;
 
     explicit
-    binary(std::string const& bit_string);
+    binary(std::string_view bit_string);
 
     binary(size_type size, uint32_t number);
     binary(size_type size, data_slice blocks);
 
     void resize(size_type size);
-    bool operator[](size_type index) const;
-    data_chunk const& blocks() const;
-    std::string encoded() const;
+    [[nodiscard]] bool operator[](size_type index) const;
+    [[nodiscard]] data_chunk const& blocks() const noexcept;
+    [[nodiscard]] std::string encoded() const;
 
     /// size in bits
-    size_type size() const;
+    [[nodiscard]] size_type size() const noexcept;
     void append(binary const& post);
     void prepend(binary const& prior);
     void shift_left(size_type distance);
     void shift_right(size_type distance);
-    binary substring(size_type start, size_type length=max_size_t) const;
+    [[nodiscard]] binary substring(size_type start, size_type length=max_size_t) const;
 
-    bool is_prefix_of(data_slice field) const;
-    bool is_prefix_of(uint32_t field) const;
-    bool is_prefix_of(binary const& field) const;
+    [[nodiscard]] bool is_prefix_of(data_slice field) const;
+    [[nodiscard]] bool is_prefix_of(uint32_t field) const;
+    [[nodiscard]] bool is_prefix_of(binary const& field) const;
 
     binary& operator=(binary const& x);
-    bool operator==(binary const& x) const;
-    bool operator!=(binary const& x) const;
-    bool operator<(binary const& x) const;
+    [[nodiscard]] bool operator==(binary const& x) const;
+    [[nodiscard]] bool operator!=(binary const& x) const;
+    [[nodiscard]] bool operator<(binary const& x) const;
 
     friend
     std::istream& operator>>(std::istream& in, binary& to);

--- a/src/infrastructure/src/utility/binary.cpp
+++ b/src/infrastructure/src/utility/binary.cpp
@@ -16,12 +16,12 @@
 
 namespace kth {
 
-binary::size_type binary::blocks_size(size_type bit_size) {
+constexpr binary::size_type binary::blocks_size(size_type bit_size) noexcept {
     return bit_size == 0 ? 0 : (bit_size - 1) / bits_per_block + 1;
 }
 
-bool binary::is_base2(std::string const& text) {
-    for (auto const& character: text) {
+bool binary::is_base2(std::string_view text) noexcept {
+    for (auto const character: text) {
         if (character != '0' && character != '1') {
             return false;
         }
@@ -29,10 +29,10 @@ bool binary::is_base2(std::string const& text) {
     return true;
 }
 
-binary::binary(std::string const& bit_string)
+binary::binary(std::string_view bit_string)
     : binary()
 {
-    std::stringstream(bit_string) >> *this;
+    std::stringstream(std::string(bit_string)) >> *this;
 }
 
 binary::binary(size_type size, uint32_t number)
@@ -85,7 +85,7 @@ bool binary::operator[](size_type index) const {
     return (block & bitmask) > 0;
 }
 
-data_chunk const& binary::blocks() const {
+data_chunk const& binary::blocks() const noexcept {
     return blocks_;
 }
 
@@ -95,7 +95,7 @@ std::string binary::encoded() const {
     return bits.str();
 }
 
-binary::size_type binary::size() const {
+binary::size_type binary::size() const noexcept {
     size_type const base_bit_size = blocks_.size() * bits_per_block;
     auto const res = safe_subtract(base_bit_size, static_cast<size_type>(final_block_excess_));
     if ( ! res) {


### PR DESCRIPTION
## Summary
Modernize the `binary` utility class using C++20/23 features for better API safety, performance, and maintainability.

## Changes
- **Add `<bit>` header** for future use of C++20 bit manipulation utilities
- **Apply Rule of Zero** by removing unnecessary copy constructor
- **Replace `std::string const&` with `std::string_view`** in constructors and static methods
- **Add `[[nodiscard]]`** attributes to all getters, conversion functions, and predicates
- **Add `noexcept`** specifications to non-throwing functions (`blocks()`, `size()`, `is_base2()`, `blocks_size()`)
- **Add `constexpr`** to `blocks_size()` for compile-time evaluation
- **Improve const correctness** in `is_base2()` loop variable

## Impact
- ✅ **Better API safety**: `[[nodiscard]]` warns on ignored return values
- ✅ **Performance**: `noexcept` enables compiler optimizations
- ✅ **Compile-time optimization**: `constexpr` allows compile-time evaluation where possible
- ✅ **Less copying**: `string_view` avoids unnecessary string copies
- ✅ **Cleaner code**: Rule of Zero reduces boilerplate

## Code Changes
- **2 files changed**: +25 insertions, -24 deletions
- **Net improvement**: More features with similar code size

## Dependencies
This PR is based on #86 (Rule of Zero for config classes), which is based on #85 (string_view modernization).

**Recommended review/merge order:**
1. #85 (modernize/use-string-view) - string_view modernization
2. #86 (modernize/apply-rule-of-zero) - Rule of Zero for config classes  
3. **This PR** (modernize/binary-use-std-bit) - binary class modernization

This order makes review easier and allows for clean rebases between PRs.

## Testing
✅ Build passes
✅ All tests pass