### PR TITLE
ci: update compiler versions to GCC 15 and apple-clang 17

### DIFF
--- a/ci_utils/.github/matrix.json
+++ b/ci_utils/.github/matrix.json
@@ -1,1 +1,1 @@
-{"config": [{"name": "Linux x86_64 GCC 14","compiler": "GCC","version": "14","os": "ubuntu-24.04","docker_suffix": "-ubuntu20.04"},{"name": "macOS - arm64 - apple-clang 15","compiler": "apple-clang","version": "15","os": "macos-14"}]}
+{"config": [{"name": "Linux x86_64 GCC 15","compiler": "GCC","version": "15","os": "ubuntu-24.04","docker_suffix": "-ubuntu20.04"},{"name": "macOS - arm64 - apple-clang 17","compiler": "apple-clang","version": "17","os": "macos-15"}]}


### PR DESCRIPTION
## Summary
- Update GCC from version 14 to 15
- Update apple-clang from version 15 to 17
- Update macOS runner from macos-14 to macos-15

## Dependencies
Requires new Docker image `kthnode/gcc15-ubuntu20.04` to be built and published first (docker-images repository workflow is already updated with GCC 15.2.0).

## Testing
CI will verify the build with the new compiler versions.