### PR TITLE
fix: detect and handle tool_requires vs requires in dependency builds

### DIFF
--- a/.github/workflows/build-deps-with-container.yml
+++ b/.github/workflows/build-deps-with-container.yml
@@ -14,6 +14,10 @@ on:
       reference:
         required: true
         type: string
+      context:
+        required: false
+        type: string
+        default: 'host'
       conan-remote:
         required: true
         type: string
@@ -64,7 +68,14 @@ jobs:
           name: conan-lockfile-container
       - name: 🏗️ Build dependencies
         if: ${{ inputs.reference != 'null' }}
-        run: conan install --requires=${{ inputs.reference }} -l conan.lock -b missing -pr:b linux-ci-cd -pr:h linux-ci-cd
+        run: |
+          if [ "${{ inputs.context }}" = "build" ]; then
+            echo "Building tool requirement: ${{ inputs.reference }}"
+            conan install --tool-requires=${{ inputs.reference }} -l conan.lock -b missing -pr:b linux-ci-cd -pr:h linux-ci-cd
+          else
+            echo "Building host requirement: ${{ inputs.reference }}"
+            conan install --requires=${{ inputs.reference }} -l conan.lock -b missing -pr:b linux-ci-cd -pr:h linux-ci-cd
+          fi
       - name: 📦 Upload package
         if: ${{ inputs.reference != 'null' }}
         run: conan upload ${{ inputs.reference }} -r ${{ inputs.conan-remote }} # --all

--- a/.github/workflows/build-deps-without-container.yml
+++ b/.github/workflows/build-deps-without-container.yml
@@ -11,6 +11,10 @@ on:
       reference:
         required: true
         type: string
+      context:
+        required: false
+        type: string
+        default: 'host'
       conan-remote:
         required: true
         type: string
@@ -74,7 +78,14 @@ jobs:
           name: conan-lockfile-no-container
       - name: 🏗️ Build dependencies
         if: ${{ inputs.reference != 'null' }}
-        run: conan install --requires=${{ inputs.reference }} -l conan.lock -b missing -pr:b general-ci-cd -pr:h general-ci-cd
+        run: |
+          if [ "${{ inputs.context }}" = "build" ]; then
+            echo "Building tool requirement: ${{ inputs.reference }}"
+            conan install --tool-requires=${{ inputs.reference }} -l conan.lock -b missing -pr:b general-ci-cd -pr:h general-ci-cd
+          else
+            echo "Building host requirement: ${{ inputs.reference }}"
+            conan install --requires=${{ inputs.reference }} -l conan.lock -b missing -pr:b general-ci-cd -pr:h general-ci-cd
+          fi
       - name: 📦 Upload package
         if: ${{ inputs.reference != 'null' }}
         run: conan upload ${{ inputs.reference }} -r ${{ inputs.conan-remote }} # --all

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -247,6 +247,7 @@ jobs:
       os: ${{ matrix.config.os }}
       image: "kthnode/gcc${{ matrix.config.version }}${{ matrix.config.docker_suffix }}"
       reference: ${{ matrix.config.reference }}
+      context: ${{ matrix.config.context }}
       conan-remote: "kth"
     secrets:
       conan-user: ${{ secrets.CONAN_LOGIN_USERNAME }}
@@ -262,6 +263,7 @@ jobs:
       if: ${{ matrix.config.compiler != 'GCC' }}
       os: ${{ matrix.config.os }}
       reference: ${{ matrix.config.reference }}
+      context: ${{ matrix.config.context }}
       conan-remote: "kth"
     secrets:
       conan-user: ${{ secrets.CONAN_LOGIN_USERNAME }}

--- a/ci_utils/build-order-to-matrix.py
+++ b/ci_utils/build-order-to-matrix.py
@@ -15,10 +15,21 @@ def main():
                 for reference in level:
                     # print(f"reference: {reference}")
                     # print(f"reference: {reference['ref']}")
+
+                    # Detect if this is a build requirement (tool_requires)
+                    is_build = False
+                    if 'packages' in reference and reference['packages']:
+                        for pkg_list in reference['packages']:
+                            for pkg in pkg_list:
+                                if isinstance(pkg, dict) and pkg.get('context') == 'build':
+                                    is_build = True
+                                    break
+
                     for platform in platform_data['config']:
                         platform_final = deepcopy(platform)
                         platform_final["name"] = f'{platform_final["name"]} - {reference["ref"]}'
                         platform_final["reference"] = reference["ref"]
+                        platform_final["context"] = "build" if is_build else "host"
                         # print(f"reference: {platform['reference']}")
                         matrix["config"].append(deepcopy(platform_final))
 


### PR DESCRIPTION
## Summary
Fixes the error where `secp256k1-precompute` and other tool_requires were being installed with `--requires` instead of `--tool-requires`, causing the error:
```
ERROR: Requirement 'secp256k1-precompute/1.0.0#...' not in lockfile 'requires'
```

## Changes
- Update `build-order-to-matrix.py` to detect build context from Conan graph output
- Add `context` parameter to build-deps workflows (default: 'host')
- Use `--tool-requires` for build dependencies and `--requires` for host dependencies
- Pass context through matrix in main workflow

## How it works
The script now examines the `packages[].context` field in `build_order.json` to determine if a dependency is a build requirement (`tool_requires`) or a host requirement (`requires`), similar to the approach used in the WASM build workflow.

## Testing
CI will verify the fix by successfully building tool_requires with the correct Conan command.