### PR TITLE
fix: add required os field to empty matrix configuration

### DIFF
--- a/ci_utils/build-order-to-matrix.py
+++ b/ci_utils/build-order-to-matrix.py
@@ -34,7 +34,13 @@ def main():
                         matrix["config"].append(deepcopy(platform_final))
 
             if len(matrix["config"]) == 0:
-                matrix["config"].append({"reference": "null"})
+                # Create a dummy entry with minimal required fields when no dependencies to build
+                # This prevents workflow errors when os field is accessed
+                matrix["config"].append({
+                    "reference": "null",
+                    "os": "ubuntu-latest",
+                    "context": "host"
+                })
 
     print(matrix)
     with open("matrix.json", "w") as write_file:


### PR DESCRIPTION
## Problem
GitHub Actions workflow failed with error:
```
Error when evaluating 'runs-on' for job 'reusable-build-deps-without-container'.
Unexpected value ''
```

## Root Cause
When `build_order.json` is empty (no dependencies to build), the `build-order-to-matrix.py` script was creating a matrix entry with only:
```json
{"reference": "null"}
```

But the workflow expects an `os` field for the `runs-on` parameter, causing the error.

## Solution
Updated the script to include all required fields when creating the dummy entry:
```json
{
  "reference": "null",
  "os": "ubuntu-latest",
  "context": "host"
}
```

## Changes
- `ci_utils/build-order-to-matrix.py`: Add `os` and `context` fields to empty matrix entry

## Testing
This will fix the workflow error that occurred during the 0.71.0 release attempt.