### PR TITLE
fix: eliminate circular dependency in executor.hpp

### DIFF
--- a/src/node/include/kth/node.hpp
+++ b/src/node/include/kth/node.hpp
@@ -22,6 +22,7 @@
 #include <kth/node/parser.hpp>
 #include <kth/node/settings.hpp>
 #include <kth/node/version.hpp>
+#include <kth/node/executor/executor.hpp>
 
 #if ! defined(__EMSCRIPTEN__)
 #include <kth/node/protocols/protocol_block_in.hpp>

--- a/src/node/include/kth/node/executor/executor.hpp
+++ b/src/node/include/kth/node/executor/executor.hpp
@@ -12,13 +12,13 @@
 #include <kth/database/databases/property_code.hpp>
 
 #include <kth/infrastructure/handlers.hpp>
-#include <kth/node.hpp>
+#include <kth/node/configuration.hpp>
+#include <kth/node/full_node.hpp>
 #include <kth/node/executor/executor_info.hpp>
 
 namespace kth::node {
 
-class executor {
-public:
+struct executor {
     executor(kth::node::configuration const& config, bool stdout_enabled = true);
 
     executor(executor const&) = delete;
@@ -70,9 +70,8 @@ private:
     void handle_running(kth::code const& ec);
     void handle_stopped(kth::code const& ec);
 
-    // Termination state.
-    static
-    std::promise<kth::code> stopping_;
+    // Termination state
+    static std::promise<kth::code> stopping_;
 
     bool stdout_enabled_;
     kth::node::configuration config_;


### PR DESCRIPTION
## Summary
Eliminates circular dependency between node.hpp and executor.hpp.

## Changes
- Changed executor.hpp to include specific headers instead of `<kth/node.hpp>`
- Prevents circular dependency between node.hpp and executor.hpp
- Changed executor from class to struct (public by default, simpler)
- Added executor.hpp include to node.hpp after full_node.hpp

## Benefits
- Fixes compilation issues when including executor.hpp in the wrong order
- Improves compilation times by reducing include chains
- Makes dependencies explicit and easier to maintain