### PR TITLE
fix: use fmt library directly instead of spdlog bundled version

### DIFF
--- a/src/infrastructure/include/kth/infrastructure/config/endpoint.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/endpoint.hpp
@@ -10,16 +10,16 @@
 #include <string>
 #include <vector>
 
-// #include <fmt/ostream.h>
+#include <fmt/ostream.h>
 
 #include <kth/infrastructure/config/authority.hpp>
 #include <kth/infrastructure/define.hpp>
 #include <kth/infrastructure/formats/base_16.hpp>
 #include <kth/infrastructure/utility/asio_helper.hpp>
 
-#if defined(KTH_LOG_LIBRARY_SPDLOG)
-#include <spdlog/fmt/ostr.h>
-#endif
+// #if defined(KTH_LOG_LIBRARY_SPDLOG)
+// #include <spdlog/fmt/ostr.h>
+// #endif
 
 namespace kth::infrastructure::config {
 

--- a/src/infrastructure/src/log/sink.cpp
+++ b/src/infrastructure/src/log/sink.cpp
@@ -25,8 +25,7 @@
 #include <kth/infrastructure/unicode/ofstream.hpp>
 
 #elif defined(KTH_LOG_LIBRARY_SPDLOG)
-#include <iostream>
-
+#include <fmt/core.h>
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/stdout_color_sinks.h> // or "../stdout_sinks.h" if no colors needed
 #include <spdlog/sinks/basic_file_sink.h>
@@ -232,7 +231,7 @@ void initialize(std::string const& debug_file, std::string const& error_file, bo
         spdlog::flush_every(std::chrono::seconds(2));
     }
     catch (spdlog::spdlog_ex const& ex) {
-        std::cout << "Log initialization failed: " << ex.what() << std::endl;
+        fmt::print("Log initialization failed: {}\n", ex.what());
     }
 }
 


### PR DESCRIPTION
## Summary
Uses fmt library directly instead of relying on spdlog's bundled version.

## Changes
- `endpoint.hpp` now includes `<fmt/ostream.h>` directly
- Commented out spdlog's `<spdlog/fmt/ostr.h>` include (kept for potential rollback)
- `sink.cpp` uses `fmt::print` instead of `std::cout` in error handler

## Benefits
- Eliminates dependency on spdlog's bundled fmt library
- Uses the fmt library directly, avoiding potential symbol conflicts
- Fixes potential initialization order issues during static construction
- More explicit about which library provides formatting capabilities

## Related
This change likely fixes the bus error that was occurring during program shutdown, as it eliminates a layer of dependency that could cause static initialization/destruction order problems.