### PR TITLE
fix: update network macros to use std::bind_front

### DIFF
--- a/src/network/include/kth/network/protocols/protocol.hpp
+++ b/src/network/include/kth/network/protocols/protocol.hpp
@@ -20,14 +20,14 @@ namespace kth::network {
     shared_from_base<Protocol>(), \
     std::forward<Args>(args)...
 #define BOUND_PROTOCOL(handler, args) \
-    std::bind(PROTOCOL_ARGS(handler, args))
+    std::bind_front(PROTOCOL_ARGS(handler, args))
 
 #define PROTOCOL_ARGS_TYPE(handler, args) \
     std::forward<Handler>(handler), \
     std::shared_ptr<Protocol>(), \
     std::forward<Args>(args)...
 #define BOUND_PROTOCOL_TYPE(handler, args) \
-    std::bind(PROTOCOL_ARGS_TYPE(handler, args))
+    std::bind_front(PROTOCOL_ARGS_TYPE(handler, args))
 
 class p2p;
 

--- a/src/network/include/kth/network/sessions/session.hpp
+++ b/src/network/include/kth/network/sessions/session.hpp
@@ -25,14 +25,14 @@ namespace kth::network {
     shared_from_base<Session>(), \
     std::forward<Args>(args)...
 #define BOUND_SESSION(handler, args) \
-    std::bind(SESSION_ARGS(handler, args))
+    std::bind_front(SESSION_ARGS(handler, args))
 
 #define SESSION_ARGS_TYPE(handler, args) \
     std::forward<Handler>(handler), \
     std::shared_ptr<Session>(), \
     std::forward<Args>(args)...
 #define BOUND_SESSION_TYPE(handler, args) \
-    std::bind(SESSION_ARGS_TYPE(handler, args))
+    std::bind_front(SESSION_ARGS_TYPE(handler, args))
 
 class p2p;
 


### PR DESCRIPTION
## Summary
- Update BOUND_SESSION and BOUND_PROTOCOL macros to use `std::bind_front` instead of `std::bind`
- Matches the changes in infrastructure delegates from PR #115

## Context
After merging PR #115 (refactor: migrate to Boost 1.89.0), the build failed because the network macros still used `std::bind` while `dispatcher.hpp` now uses `std::bind_front`. This caused type mismatches in the return types.

## Files Changed
- `src/network/include/kth/network/sessions/session.hpp`
- `src/network/include/kth/network/protocols/protocol.hpp`