### PR TITLE
refactor: simplify network binding macros

### DIFF
--- a/src/network/include/kth/network/protocols/protocol.hpp
+++ b/src/network/include/kth/network/protocols/protocol.hpp
@@ -15,19 +15,11 @@
 
 namespace kth::network {
 
-#define PROTOCOL_ARGS(handler, args) \
-    std::forward<Handler>(handler), \
-    shared_from_base<Protocol>(), \
-    std::forward<Args>(args)...
 #define BOUND_PROTOCOL(handler, args) \
-    std::bind_front(PROTOCOL_ARGS(handler, args))
+    std::bind_front(std::forward<Handler>(handler), shared_from_base<Protocol>(), std::forward<Args>(args)...)
 
-#define PROTOCOL_ARGS_TYPE(handler, args) \
-    std::forward<Handler>(handler), \
-    std::shared_ptr<Protocol>(), \
-    std::forward<Args>(args)...
 #define BOUND_PROTOCOL_TYPE(handler, args) \
-    std::bind_front(PROTOCOL_ARGS_TYPE(handler, args))
+    std::bind_front(std::forward<Handler>(handler), std::shared_ptr<Protocol>(), std::forward<Args>(args)...)
 
 class p2p;
 
@@ -108,9 +100,7 @@ private:
     const std::string name_;
 };
 
-#undef PROTOCOL_ARGS
 #undef BOUND_PROTOCOL
-#undef PROTOCOL_ARGS_TYPE
 #undef BOUND_PROTOCOL_TYPE
 
 #define SEND1(message, method, p1) \

--- a/src/network/include/kth/network/sessions/session.hpp
+++ b/src/network/include/kth/network/sessions/session.hpp
@@ -20,19 +20,11 @@
 
 namespace kth::network {
 
-#define SESSION_ARGS(handler, args) \
-    std::forward<Handler>(handler), \
-    shared_from_base<Session>(), \
-    std::forward<Args>(args)...
 #define BOUND_SESSION(handler, args) \
-    std::bind_front(SESSION_ARGS(handler, args))
+    std::bind_front(std::forward<Handler>(handler), shared_from_base<Session>(), std::forward<Args>(args)...)
 
-#define SESSION_ARGS_TYPE(handler, args) \
-    std::forward<Handler>(handler), \
-    std::shared_ptr<Session>(), \
-    std::forward<Args>(args)...
 #define BOUND_SESSION_TYPE(handler, args) \
-    std::bind_front(SESSION_ARGS_TYPE(handler, args))
+    std::bind_front(std::forward<Handler>(handler), std::shared_ptr<Session>(), std::forward<Args>(args)...)
 
 class p2p;
 
@@ -171,9 +163,7 @@ private:
     mutable dispatcher dispatch_;
 };
 
-#undef SESSION_ARGS
 #undef BOUND_SESSION
-#undef SESSION_ARGS_TYPE
 #undef BOUND_SESSION_TYPE
 
 #define BIND1(method, p1) bind<CLASS>(&CLASS::method, p1)


### PR DESCRIPTION
## Summary
- Eliminate `SESSION_ARGS`, `SESSION_ARGS_TYPE`, `PROTOCOL_ARGS`, and `PROTOCOL_ARGS_TYPE` macros
- Inline them directly into `BOUND_SESSION` and `BOUND_PROTOCOL` macros
- Reduces macro count from 4 to 2 per file

## Changes
**session.hpp:**
- `-12 lines` (4 macro definitions + 2 undefs removed)
- Simplified from 4 macros to 2

**protocol.hpp:**
- `-12 lines` (4 macro definitions + 2 undefs removed)
- Simplified from 4 macros to 2

## Total Impact
- **-24 lines of code**
- **Clearer code**: Eliminates intermediate macro layer
- **Same functionality**: No behavior changes
- **Easier to maintain**: Fewer macros to track

## Before
```cpp
#define SESSION_ARGS(handler, args) \
    std::forward<Handler>(handler), \
    shared_from_base<Session>(), \
    std::forward<Args>(args)...
#define BOUND_SESSION(handler, args) \
    std::bind_front(SESSION_ARGS(handler, args))
```

## After
```cpp
#define BOUND_SESSION(handler, args) \
    std::bind_front(std::forward<Handler>(handler), shared_from_base<Session>(), std::forward<Args>(args)...)
```