### PR TITLE
fix: enable WebAssembly builds for all branches

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -34,8 +34,12 @@ jobs:
 
   build-wasm:
     needs: [setup]
-    # Only build WASM for release branches on push (not on PR to avoid duplicate builds)
-    if: ${{ github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/hotfix') || startsWith(github.ref, 'refs/heads/dev-publish')) }}
+    # Run on all pushes and PRs to master (except PRs from release branches)
+    if: github.event_name == 'push' ||
+      (github.event_name == 'pull_request' &&
+       !startsWith(github.head_ref, 'release/') &&
+       !startsWith(github.head_ref, 'hotfix/') &&
+       !startsWith(github.head_ref, 'dev-publish/'))
     runs-on: ubuntu-latest
     name: WebAssembly (Emscripten)
 


### PR DESCRIPTION
## Problem
The `build-wasm.yml` workflow was only running for `release/**`, `hotfix/**`, and `dev-publish/**` branches, causing WASM builds to be skipped on `master` and regular PRs.

## Solution
Update the workflow condition to match `main.yml`:
- ✅ Run on **all** pushes (including master)
- ✅ Run on PRs to master (except from release branches)

## Before
```yaml
if: ${{ github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/hotfix') || startsWith(github.ref, 'refs/heads/dev-publish')) }}
```

## After
```yaml
if: github.event_name == 'push' ||
  (github.event_name == 'pull_request' &&
   !startsWith(github.head_ref, 'release/') &&
   !startsWith(github.head_ref, 'hotfix/') &&
   !startsWith(github.head_ref, 'dev-publish/'))
```

## Impact
- WASM builds will now run on master pushes
- WASM builds will run on regular PRs
- Consistent with main workflow behavior