### PR TITLE
refactor: adapt domain module to new base encoding API

### DIFF
--- a/src/domain/include/kth/domain/config/header.hpp
+++ b/src/domain/include/kth/domain/config/header.hpp
@@ -5,8 +5,9 @@
 #ifndef KTH_HEADER_HPP
 #define KTH_HEADER_HPP
 
-#include <iostream>
+#include <expected>
 #include <string>
+#include <system_error>
 
 #include <kth/domain/chain/header.hpp>
 #include <kth/domain/define.hpp>
@@ -19,12 +20,6 @@ namespace kth::domain::config {
  */
 struct KD_API header {
     header() = default;
-
-    /**
-     * Initialization constructor.
-     * @param[in]  hexcode  The value to initialize with.
-     */
-    header(std::string const& hexcode);
 
     /**
      * Initialization constructor.
@@ -45,26 +40,21 @@ struct KD_API header {
     operator chain::header const&() const;
 
     /**
-     * Overload stream in. Throws if input is invalid.
-     * @param[in]   input     The input stream to read the value from.
-     * @param[out]  argument  The object to receive the read value.
-     * @return                The input stream reference.
+     * Parse a base16 string into a header object.
+     * @param[in]  text  The base16 encoded string to parse.
+     * @return           The parsed header object or an error.
      */
-    friend std::istream& operator>>(std::istream& input, header& argument);
+    [[nodiscard]] static
+    std::expected<header, std::error_code> from_string(std::string_view text) noexcept;
 
     /**
-     * Overload stream out.
-     * @param[in]   output    The output stream to write the value to.
-     * @param[out]  argument  The object from which to obtain the value.
-     * @return                The output stream reference.
+     * Serialize the value to a base16 encoded string.
+     * @return  The base16 encoded string.
      */
-    friend std::ostream& operator<<(std::ostream& output,
-                                    header const& argument);
+    [[nodiscard]]
+    std::string to_string() const;
 
 private:
-    /**
-     * The state of this object's header data.
-     */
     chain::header value_;
 };
 

--- a/src/domain/include/kth/domain/config/transaction.hpp
+++ b/src/domain/include/kth/domain/config/transaction.hpp
@@ -5,8 +5,9 @@
 #ifndef KTH_TRANSACTION_HPP
 #define KTH_TRANSACTION_HPP
 
-#include <iostream>
+#include <expected>
 #include <string>
+#include <system_error>
 
 #include <kth/domain/chain/transaction.hpp>
 #include <kth/domain/define.hpp>
@@ -19,12 +20,6 @@ namespace kth::domain::config {
  */
 struct KD_API transaction {
     transaction() = default;
-
-    /**
-     * Initialization constructor.
-     * @param[in]  hexcode  The value to initialize with.
-     */
-    transaction(std::string const& hexcode);
 
     /**
      * Initialization constructor.
@@ -51,27 +46,21 @@ struct KD_API transaction {
     operator chain::transaction const&() const;
 
     /**
-     * Overload stream in. Throws if input is invalid.
-     * @param[in]   input     The input stream to read the value from.
-     * @param[out]  argument  The object to receive the read value.
-     * @return                The input stream reference.
+     * Parse a base16 string into a transaction object.
+     * @param[in]  text  The base16 encoded string to parse.
+     * @return           The parsed transaction object or an error.
      */
-    friend std::istream& operator>>(std::istream& input,
-                                    transaction& argument);
+    [[nodiscard]] static
+    std::expected<transaction, std::error_code> from_string(std::string_view text) noexcept;
 
     /**
-     * Overload stream out.
-     * @param[in]   output    The output stream to write the value to.
-     * @param[out]  argument  The object from which to obtain the value.
-     * @return                The output stream reference.
+     * Serialize the value to a base16 encoded string.
+     * @return  The base16 encoded string.
      */
-    friend std::ostream& operator<<(std::ostream& output,
-                                    transaction const& argument);
+    [[nodiscard]]
+    std::string to_string() const;
 
 private:
-    /**
-     * The state of this object's transaction data.
-     */
     chain::transaction value_;
 };
 

--- a/src/domain/include/kth/domain/utility/property_tree.hpp
+++ b/src/domain/include/kth/domain/utility/property_tree.hpp
@@ -22,7 +22,6 @@ namespace pt = boost::property_tree;
 
 namespace kth::domain::config {
 
-class base2;
 class wrapper;
 
 /**

--- a/src/domain/src/chain/block.cpp
+++ b/src/domain/src/chain/block.cpp
@@ -291,10 +291,10 @@ void block::set_transactions(transaction::list&& value) {
 //-----------------------------------------------------------------------------
 
 chain::block genesis_generic(std::string const& raw_data) {
-    data_chunk data;
-    decode_base16(data, raw_data);
+    auto data = decode_base16(raw_data);
+    KTH_ASSERT(data);
 
-    byte_reader reader(data);
+    byte_reader reader(*data);
     auto genesis = block::from_data(reader);
 
     KTH_ASSERT(genesis);

--- a/src/domain/src/config/ec_private.cpp
+++ b/src/domain/src/config/ec_private.cpp
@@ -19,7 +19,12 @@ namespace kth::domain::config {
 // ec_secret base16 format is private to bx.
 static
 bool decode_secret(ec_secret& secret, std::string const& encoded) {
-    return decode_base16(secret, encoded) && verify(secret);
+    auto result = decode_base16<ec_secret_size>(encoded);
+    if ( ! result) {
+        return false;
+    }
+    secret = *result;
+    return verify(secret);
 }
 
 ec_private::ec_private(std::string const& hexcode) {

--- a/src/domain/src/config/endorsement.cpp
+++ b/src/domain/src/config/endorsement.cpp
@@ -21,13 +21,12 @@ namespace kth::domain::config {
 static
 bool decode_endorsement(kth::endorsement& endorsement,
                                std::string const& encoded) {
-    kth::endorsement decoded;
-    if ( ! decode_base16(decoded, encoded) ||
-        (decoded.size() > max_endorsement_size)) {
+    auto decoded = decode_base16(encoded);
+    if ( ! decoded || decoded->size() > max_endorsement_size) {
         return false;
     }
 
-    endorsement = decoded;
+    endorsement = std::move(*decoded);
     return true;
 }
 

--- a/src/domain/src/config/output.cpp
+++ b/src/domain/src/config/output.cpp
@@ -88,13 +88,13 @@ std::istream& operator>>(std::istream& input, output& argument) {
             BOOST_THROW_EXCEPTION(invalid_option_value(tuple));
         }
 
-        data_chunk seed;
-        if ( ! decode_base16(seed, tokens[2]) || seed.size() < minimum_seed_size) {
+        auto seed = decode_base16(tokens[2]);
+        if ( ! seed || seed->size() < minimum_seed_size) {
             BOOST_THROW_EXCEPTION(invalid_option_value(tuple));
         }
 
         ec_secret ephemeral_secret;
-        if ( ! create_stealth_data(argument.script_, ephemeral_secret, stealth.filter(), seed)) {
+        if ( ! create_stealth_data(argument.script_, ephemeral_secret, stealth.filter(), *seed)) {
             BOOST_THROW_EXCEPTION(invalid_option_value(tuple));
         }
 
@@ -112,12 +112,12 @@ std::istream& operator>>(std::istream& input, output& argument) {
     // The target must be a serialized script.
     // Note that it is possible for a base16 encoded script to be interpreted
     // as an address above. That is unlikely but considered intended behavior.
-    data_chunk decoded;
-    if ( ! decode_base16(decoded, target)) {
+    auto decoded = decode_base16(target);
+    if ( ! decoded) {
         BOOST_THROW_EXCEPTION(invalid_option_value(target));
     }
 
-    argument.script_ = script(decoded);
+    argument.script_ = script(*decoded);
     return input;
 }
 

--- a/src/domain/src/machine/opcode.cpp
+++ b/src/domain/src/machine/opcode.cpp
@@ -713,12 +713,12 @@ bool opcode_from_hexadecimal(opcode& out_code, std::string const& value) {
         return false;
     }
 
-    data_chunk out;
-    if ( ! decode_base16(out, std::string(value.begin() + 2, value.end()))) {
+    auto out = decode_base16(std::string(value.begin() + 2, value.end()));
+    if ( ! out) {
         return false;
     }
 
-    out_code = static_cast<opcode>(out.front());
+    out_code = static_cast<opcode>(out->front());
     return true;
 }
 

--- a/src/domain/src/machine/operation.cpp
+++ b/src/domain/src/machine/operation.cpp
@@ -98,14 +98,17 @@ bool operation::from_string(std::string const& mnemonic) {
 
         if (parts.size() == 1) {
             // Extract operation using nominal data size encoding.
-            if (decode_base16(data_, parts[0])) {
+            if (auto decoded = decode_base16(parts[0])) {
+                data_ = std::move(*decoded);
                 code_ = nominal_opcode_from_data(data_);
                 valid_ = true;
             }
         } else if (parts.size() == 2) {
             // Extract operation using explicit data size encoding.
-            valid_ = decode_base16(data_, parts[1]) &&
-                     opcode_from_data_prefix(code_, parts[0], data_);
+            if (auto decoded = decode_base16(parts[1])) {
+                data_ = std::move(*decoded);
+                valid_ = opcode_from_data_prefix(code_, parts[0], data_);
+            }
         }
     } else if (is_text_token(mnemonic)) {
         auto const text = trim_token(mnemonic);

--- a/src/domain/src/utility/property_tree.cpp
+++ b/src/domain/src/utility/property_tree.cpp
@@ -20,6 +20,7 @@
 #include <kth/infrastructure/config/base16.hpp>
 #include <kth/infrastructure/config/hash160.hpp>
 #include <kth/infrastructure/config/hash256.hpp>
+#include <kth/infrastructure/formats/base_16.hpp>
 #include <kth/infrastructure/utility/collection.hpp>
 
 namespace kth::domain::config {
@@ -211,7 +212,7 @@ ptree property_tree(const std::vector<config::transaction>& transactions, bool j
 ptree property_list(const wallet::wrapped_data& wrapper) {
     ptree tree;
     tree.put("checksum", wrapper.checksum);
-    tree.put("payload", base16(wrapper.payload));
+    tree.put("payload", kth::encode_base16(wrapper.payload));
     tree.put("version", wrapper.version);
     return tree;
 }

--- a/src/domain/src/wallet/ec_public.cpp
+++ b/src/domain/src/wallet/ec_public.cpp
@@ -66,12 +66,12 @@ ec_public ec_public::from_private(ec_private const& secret) {
 }
 
 ec_public ec_public::from_string(std::string const& base16) {
-    data_chunk decoded;
-    if ( ! decode_base16(decoded, base16)) {
+    auto decoded = decode_base16(base16);
+    if ( ! decoded) {
         return ec_public();
     }
 
-    return ec_public(decoded);
+    return ec_public(*decoded);
 }
 
 ec_public ec_public::from_data(data_chunk const& decoded) {


### PR DESCRIPTION
## Summary

Adapt domain code to use the new `std::expected`-based `decode_base16` API from infrastructure module.

- Update config classes (header, transaction, ec_private, endorsement, output)
- Update chain/block.cpp, machine/opcode.cpp, machine/operation.cpp
- Update wallet/ec_public.cpp and utility/property_tree.cpp

## Dependencies

- Based on #123 (infrastructure API changes)

## Test Plan

- [ ] Build passes
- [ ] All existing tests pass (after test PRs are merged)