### PR TITLE
test: update infrastructure tests for new base encoding API

### DIFF
--- a/src/infrastructure/test/config/authority.cpp
+++ b/src/infrastructure/test/config/authority.cpp
@@ -475,6 +475,7 @@ TEST_CASE("authority  inequality  ipv6 ipv6  false", "[authority  inequality]") 
 // Start Test Suite: authority  construct
 
 #if ! defined(__EMSCRIPTEN__)
+
 TEST_CASE("authority  construct  bogus ip  throws invalid option", "[authority  construct]") {
     REQUIRE_THROWS_AS([](){authority host("bogus");}(), invalid_option_value);
 }
@@ -490,7 +491,9 @@ TEST_CASE("authority should throw invalid option exception for invalid IPv6", "[
 TEST_CASE("authority  construct  invalid port  throws invalid option", "[authority  construct]") {
     REQUIRE_THROWS_AS([](){authority host("[::]:12345678901");}(), invalid_option_value);
 }
+
 #else
+
 TEST_CASE("authority  construct  bogus ip  throws invalid option", "[authority  construct]") {
     REQUIRE_THROWS_AS([](){authority host("bogus");}(), std::invalid_argument);
 }
@@ -506,6 +509,7 @@ TEST_CASE("authority  construct  invalid ipv6  throws invalid option", "[authori
 TEST_CASE("authority  construct  invalid port  throws invalid option", "[authority  construct]") {
     REQUIRE_THROWS_AS([](){authority host("[::]:12345678901");}(), std::invalid_argument);
 }
+
 #endif
 
 // End Test Suite

--- a/src/infrastructure/test/config/base58.cpp
+++ b/src/infrastructure/test/config/base58.cpp
@@ -8,34 +8,35 @@
 using namespace kth;
 using namespace kth::infrastructure::config;
 
-#define BASE58_ENCODED_A "vYxp6yFC7qiVtK1RcGQQt3L6EqTc8YhEDLnSMLqDvp8D"
-#define BASE58_DECODED_A \
-{{ \
-    0x03, 0x1b, 0xab, 0x84, 0xe6, 0x87, 0xe3, 0x65, 0x14, 0xee, 0xaf, 0x5a, \
-    0x01, 0x7c, 0x30, 0xd3, 0x2c, 0x1f, 0x59, 0xdd, 0x4e, 0xa6, 0x62, 0x9d, \
-    0xa7, 0x97, 0x0c, 0xa3, 0x74, 0x51, 0x3d, 0xd0,  0x06 \
-}}
+constexpr auto base58_encoded_a = "vYxp6yFC7qiVtK1RcGQQt3L6EqTc8YhEDLnSMLqDvp8D";
+constexpr auto base58_decoded_a = std::to_array<uint8_t>({
+    0x03, 0x1b, 0xab, 0x84, 0xe6, 0x87, 0xe3, 0x65, 0x14, 0xee, 0xaf, 0x5a,
+    0x01, 0x7c, 0x30, 0xd3, 0x2c, 0x1f, 0x59, 0xdd, 0x4e, 0xa6, 0x62, 0x9d,
+    0xa7, 0x97, 0x0c, 0xa3, 0x74, 0x51, 0x3d, 0xd0, 0x06
+});
 
 // Start Test Suite: base58 tests
 
-TEST_CASE("base58  constructor  default  does not throw", "[base58 tests]") {
+TEST_CASE("base58 default constructor does not throw", "[base58]") {
     REQUIRE_NOTHROW(base58());
 }
 
-TEST_CASE("base58  constructor  valid string cast  decodes", "[base58 tests]") {
-    data_chunk const original(BASE58_DECODED_A);
-    data_chunk const instance(base58(BASE58_ENCODED_A));
-    REQUIRE(original == instance);
+TEST_CASE("base58 from_string valid string decodes", "[base58]") {
+    auto const result = base58::from_string(base58_encoded_a);
+    REQUIRE(result.has_value());
+    REQUIRE(std::ranges::equal(base58_decoded_a, result->data()));
 }
 
-////TEST_CASE("base58  constructor  bogus string  throws invalid option", "[base58 tests]")
-////{
-////    //BX_REQUIRE_THROW_INVALID_OPTION_VALUE(base58("bo-gus"));
-////}
+TEST_CASE("base58 from_string invalid string returns error", "[base58]") {
+    auto const result = base58::from_string("bo-gus");
+    REQUIRE( ! result.has_value());
+    REQUIRE(result.error() == std::make_error_code(std::errc::invalid_argument));
+}
 
-////TEST_CASE("base58  constructor  copy address primitives  round trips", "[base58 tests]")
-////{
-////    //BX_SERIALIZE_COPY_ROUND_TRIP(base58, BASE58_ENCODED_A);
-////}
+TEST_CASE("base58 round trip from_string to_string", "[base58]") {
+    auto const result = base58::from_string(base58_encoded_a);
+    REQUIRE(result.has_value());
+    REQUIRE(result->to_string() == base58_encoded_a);
+}
 
 // End Test Suite

--- a/src/infrastructure/test/config/checkpoint.cpp
+++ b/src/infrastructure/test/config/checkpoint.cpp
@@ -24,11 +24,11 @@ using namespace boost::program_options;
 
 // Start Test Suite: checkpoint tests
 
-#define CHECKPOINT_HASH_A "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
-#define CHECKPOINT_A CHECKPOINT_HASH_A ":0"
-#define CHECKPOINT_B "0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d:11111"
-#define CHECKPOINT_C "000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6:33333"
-#define CHECKPOINT_ABC CHECKPOINT_A "\n" CHECKPOINT_B "\n" CHECKPOINT_C
+constexpr char checkpoint_hash_a[] = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
+constexpr char checkpoint_a[] = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f:0";
+constexpr char checkpoint_b[] = "0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d:11111";
+constexpr char checkpoint_c[] = "000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6:33333";
+constexpr char checkpoint_abc[] = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f:0\n0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d:11111\n000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6:33333";
 
 // ------------------------------------------------------------------------- //
 
@@ -41,21 +41,21 @@ TEST_CASE("checkpoint construct  default  null hash", "[checkpoint construct]") 
 }
 
 TEST_CASE("checkpoint construct  copy  expected", "[checkpoint construct]") {
-    checkpoint const check1(CHECKPOINT_C);
+    checkpoint const check1(checkpoint_c);
     checkpoint const check2(check1);
     REQUIRE(check2.height() == check1.height());
     REQUIRE(encode_hash(check2.hash()) == encode_hash(check1.hash()));
 }
 
 TEST_CASE("checkpoint construct  string  expected", "[checkpoint construct]") {
-    checkpoint const genesis(CHECKPOINT_B);
+    checkpoint const genesis(checkpoint_b);
     REQUIRE(genesis.height() == 11111u);
-    REQUIRE(genesis.to_string() == CHECKPOINT_B);
+    REQUIRE(genesis.to_string() == checkpoint_b);
 }
 
 TEST_CASE("checkpoint construct  digest  expected", "[checkpoint construct]") {
     size_t const expected_height = 42;
-    auto const expected_hash = CHECKPOINT_HASH_A;
+    auto const expected_hash = checkpoint_hash_a;
     hash_digest digest;
     kth::decode_hash(digest, expected_hash);
     checkpoint const genesis(digest, expected_height);
@@ -67,19 +67,19 @@ TEST_CASE("checkpoint construct  digest  expected", "[checkpoint construct]") {
 //TODO(fernando): fix these tests
 // TEST_CASE("checkpoint construct  invalid height value  throws invalid option value", "[checkpoint construct]") {
 //     // 2^64
-//     // REQUIRE_THROWS_AS([](){checkpoint(CHECKPOINT_HASH_A ":18446744073709551616");}, invalid_option_value);
+//     // REQUIRE_THROWS_AS([](){checkpoint(checkpoint_hash_a ":18446744073709551616");}, invalid_option_value);
 
-//     auto cp = checkpoint(CHECKPOINT_HASH_A ":18446744073709551616");
+//     auto cp = checkpoint(checkpoint_hash_a ":18446744073709551616");
 //     cp.height();
 // }
 
 // TEST_CASE("checkpoint construct  invalid height characters  throws invalid option value", "[checkpoint construct]") {
 //     // 21 characters
-//     REQUIRE_THROWS_AS([](){checkpoint(CHECKPOINT_HASH_A ":1000000000100000000001");}, invalid_option_value);
+//     REQUIRE_THROWS_AS([](){checkpoint(checkpoint_hash_a ":1000000000100000000001");}, invalid_option_value);
 // }
 
 // TEST_CASE("checkpoint construct  bogus height characters  throws invalid option value", "[checkpoint construct]") {
-//     REQUIRE_THROWS_AS([](){checkpoint(CHECKPOINT_HASH_A ":xxx");}, invalid_option_value);
+//     REQUIRE_THROWS_AS([](){checkpoint(checkpoint_hash_a ":xxx");}, invalid_option_value);
 // }
 
 // TEST_CASE("checkpoint construct  bogus line hash  throws invalid option value", "[checkpoint construct]") {
@@ -98,9 +98,9 @@ TEST_CASE("checkpoint construct  digest  expected", "[checkpoint construct]") {
 
 TEST_CASE("checkpoint istream  empty  expected", "[checkpoint istream]") {
     checkpoint deserialized;
-    std::stringstream serialized(CHECKPOINT_A);
+    std::stringstream serialized(checkpoint_a);
     serialized >> deserialized;
-    REQUIRE(deserialized.to_string() == CHECKPOINT_A);
+    REQUIRE(deserialized.to_string() == checkpoint_a);
 }
 
 // End Test Suite
@@ -111,9 +111,9 @@ TEST_CASE("checkpoint istream  empty  expected", "[checkpoint istream]") {
 
 static
 checkpoint::list const test_checkpoints_list({
-    checkpoint{CHECKPOINT_A},
-    checkpoint{CHECKPOINT_B},
-    checkpoint{CHECKPOINT_C}
+    checkpoint{checkpoint_a},
+    checkpoint{checkpoint_b},
+    checkpoint{checkpoint_c}
 });
 
 TEST_CASE("checkpoint  ostream  empty  expected", "[checkpoint  ostream]") {
@@ -125,12 +125,12 @@ TEST_CASE("checkpoint  ostream  empty  expected", "[checkpoint  ostream]") {
 TEST_CASE("checkpoint  ostream  populated  expected", "[checkpoint  ostream]") {
     std::stringstream serialized;
     serialized << test_checkpoints_list;
-    REQUIRE(serialized.str() == CHECKPOINT_ABC);
+    REQUIRE(serialized.str() == checkpoint_abc);
 }
 
 TEST_CASE("checkpoint  ostream  boost lexical cast  expected", "[checkpoint  ostream]") {
     auto const serialized = boost::lexical_cast<std::string>(test_checkpoints_list);
-    REQUIRE(serialized == CHECKPOINT_ABC);
+    REQUIRE(serialized == checkpoint_abc);
 }
 
 // End Test Suite

--- a/src/infrastructure/test/formats/base_16.cpp
+++ b/src/infrastructure/test/formats/base_16.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <array>
 #include <test_helpers.hpp>
 #include <kth/infrastructure.hpp>
 
@@ -9,56 +10,131 @@ using namespace kth;
 
 // Start Test Suite: base 16 tests
 
-TEST_CASE("infrastructure base16 literal compilation", "[infrastructure][base16]") {
-    auto result = base16_literal("01ff42bc");
-    const byte_array<4> expected
-    {
-        {
-            0x01, 0xff, 0x42, 0xbc
-        }
-    };
-    REQUIRE(result == expected);
+TEST_CASE("base16 decode basic", "[infrastructure][base16]") {
+    constexpr auto expected = std::to_array<uint8_t>({0x01, 0xff, 0x42, 0xbc});
+
+    static_assert("01ff42bc"_base16 == expected);
+
+    auto const result = decode_base16("01ff42bc");
+    REQUIRE(result);
+    REQUIRE(*result == to_chunk(expected));
 }
 
-TEST_CASE("infrastructure base16 decode odd length string should fail", "[infrastructure][base16]") {
-    auto const& hex_str = "10a7fd15cb45bda9e90e19a15";
-    data_chunk data;
-    REQUIRE(!decode_base16(data, hex_str));
+TEST_CASE("base16 decode deadbeef", "[infrastructure][base16]") {
+    constexpr auto expected = std::to_array<uint8_t>({0xde, 0xad, 0xbe, 0xef});
+
+    static_assert("deadbeef"_base16 == expected);
+
+    auto const result = decode_base16("deadbeef");
+    REQUIRE(result);
+    REQUIRE(*result == to_chunk(expected));
 }
 
-TEST_CASE("infrastructure base16 encode and decode short hash", "[infrastructure][base16]") {
-    auto const& hex_str = "f85beb6356d0813ddb0dbb14230a249fe931a135";
-    short_hash hash;
-    REQUIRE(decode_base16(hash, hex_str));
-    REQUIRE(encode_base16(hash) == hex_str);
-    short_hash const expected
-    {
-        {
-           0xf8, 0x5b, 0xeb, 0x63, 0x56, 0xd0, 0x81, 0x3d, 0xdb, 0x0d,
-           0xbb, 0x14, 0x23, 0x0a, 0x24, 0x9f, 0xe9, 0x31, 0xa1, 0x35
-        }
-    };
-    REQUIRE(hash == expected);
+TEST_CASE("base16 decode single zero byte", "[infrastructure][base16]") {
+    constexpr auto expected = std::to_array<uint8_t>({0x00});
+
+    static_assert("00"_base16 == expected);
+
+    auto const result = decode_base16("00");
+    REQUIRE(result);
+    REQUIRE(*result == to_chunk(expected));
 }
 
-// TODO: this should be tested for correctness, not just round-tripping.
-TEST_CASE("infrastructure base16 encode and decode round trip", "[infrastructure][base16]") {
-    auto const& hex_str = "10a7fd15cb45bda9e90e19a15f";
-    data_chunk data;
-    REQUIRE(decode_base16(data, hex_str));
-    REQUIRE(encode_base16(data) == hex_str);
+TEST_CASE("base16 decode single ff byte", "[infrastructure][base16]") {
+    constexpr auto expected = std::to_array<uint8_t>({0xff});
+
+    static_assert("ff"_base16 == expected);
+
+    auto const result = decode_base16("ff");
+    REQUIRE(result);
+    REQUIRE(*result == to_chunk(expected));
 }
 
-TEST_CASE("infrastructure base16 decode to fixed size array", "[infrastructure][base16]") {
-    byte_array<4> converted;
-    REQUIRE(decode_base16(converted, "01ff42bc"));
-    const byte_array<4> expected
-    {
-        {
-            0x01, 0xff, 0x42, 0xbc
-        }
-    };
-    REQUIRE(converted == expected);
+TEST_CASE("base16 decode empty", "[infrastructure][base16]") {
+    constexpr auto expected = std::array<uint8_t, 0>{};
+
+    static_assert(""_base16 == expected);
+
+    auto const result = decode_base16("");
+    REQUIRE(result);
+    REQUIRE(result->empty());
+}
+
+TEST_CASE("base16 decode uppercase", "[infrastructure][base16]") {
+    constexpr auto expected = std::to_array<uint8_t>({0xde, 0xad, 0xbe, 0xef});
+
+    static_assert("DEADBEEF"_base16 == expected);
+
+    auto const result = decode_base16("DEADBEEF");
+    REQUIRE(result);
+    REQUIRE(*result == to_chunk(expected));
+}
+
+TEST_CASE("base16 decode mixed case", "[infrastructure][base16]") {
+    constexpr auto expected = std::to_array<uint8_t>({0xde, 0xad, 0xbe, 0xef});
+
+    static_assert("DeAdBeEf"_base16 == expected);
+
+    auto const result = decode_base16("DeAdBeEf");
+    REQUIRE(result);
+    REQUIRE(*result == to_chunk(expected));
+}
+
+TEST_CASE("base16 decode odd length string should fail", "[infrastructure][base16]") {
+    auto const result = decode_base16("10a7fd15cb45bda9e90e19a15");
+    REQUIRE( ! result);
+    REQUIRE(result.error() == base16_errc::odd_length);
+}
+
+TEST_CASE("base16 decode invalid character should fail", "[infrastructure][base16]") {
+    auto const result = decode_base16("deadbeXf");
+    REQUIRE( ! result);
+    REQUIRE(result.error() == base16_errc::invalid_character);
+}
+
+TEST_CASE("base16 encode and decode short hash", "[infrastructure][base16]") {
+    constexpr auto expected = std::to_array<uint8_t>({
+        0xf8, 0x5b, 0xeb, 0x63, 0x56, 0xd0, 0x81, 0x3d, 0xdb, 0x0d,
+        0xbb, 0x14, 0x23, 0x0a, 0x24, 0x9f, 0xe9, 0x31, 0xa1, 0x35});
+    constexpr auto hex_str = "f85beb6356d0813ddb0dbb14230a249fe931a135";
+
+    static_assert("f85beb6356d0813ddb0dbb14230a249fe931a135"_base16 == expected);
+
+    auto const result = decode_base16(hex_str);
+    REQUIRE(result);
+    REQUIRE(*result == to_chunk(expected));
+    REQUIRE(encode_base16(*result) == hex_str);
+}
+
+TEST_CASE("base16 encode and decode round trip", "[infrastructure][base16]") {
+    constexpr auto expected = std::to_array<uint8_t>({
+        0x10, 0xa7, 0xfd, 0x15, 0xcb, 0x45, 0xbd, 0xa9,
+        0xe9, 0x0e, 0x19, 0xa1, 0x5f
+});
+    constexpr auto hex_str = "10a7fd15cb45bda9e90e19a15f";
+
+    static_assert("10a7fd15cb45bda9e90e19a15f"_base16 == expected);
+
+    auto const result = decode_base16(hex_str);
+    REQUIRE(result);
+    REQUIRE(*result == to_chunk(expected));
+    REQUIRE(encode_base16(*result) == hex_str);
+}
+
+TEST_CASE("base16 decode to fixed size array", "[infrastructure][base16]") {
+    constexpr auto expected = std::to_array<uint8_t>({0x01, 0xff, 0x42, 0xbc});
+
+    static_assert("01ff42bc"_base16 == expected);
+
+    auto const result = decode_base16<4>("01ff42bc");
+    REQUIRE(result);
+    REQUIRE(*result == expected);
+}
+
+TEST_CASE("base16 decode to fixed size array wrong size should fail", "[infrastructure][base16]") {
+    auto const result = decode_base16<4>("01ff42");  // 3 bytes, expected 4
+    REQUIRE( ! result);
+    REQUIRE(result.error() == base16_errc::odd_length);
 }
 
 // End Test Suite

--- a/src/infrastructure/test/formats/base_58.cpp
+++ b/src/infrastructure/test/formats/base_58.cpp
@@ -10,11 +10,12 @@ using namespace kth;
 // Start Test Suite: base 58 tests
 
 void encdec_test(std::string const& hex, std::string const& encoded) {
-    data_chunk data, decoded;
-    REQUIRE(decode_base16(data, hex));
-    REQUIRE(encode_base58(data) == encoded);
+    auto const data = decode_base16(hex);
+    REQUIRE(data);
+    REQUIRE(encode_base58(*data) == encoded);
+    data_chunk decoded;
     REQUIRE(decode_base58(decoded, encoded));
-    REQUIRE(decoded == data);
+    REQUIRE(decoded == *data);
 }
 
 TEST_CASE("infrastructure base58 encode and decode various test vectors", "[infrastructure][base58]") {

--- a/src/infrastructure/test/formats/base_encoding_benchmarks.cpp
+++ b/src/infrastructure/test/formats/base_encoding_benchmarks.cpp
@@ -76,33 +76,28 @@ void benchmark_base16() {
     // Decoding benchmarks
     Bench().title("Base16 Decoding").relative(true)
         .run("decode 32B (hash)", [&] {
-            data_chunk result;
             ankerl::nanobench::doNotOptimizeAway(
-                decode_base16(result, small_encoded)
+                decode_base16(small_encoded)
             );
         })
         .run("decode 256B", [&] {
-            data_chunk result;
             ankerl::nanobench::doNotOptimizeAway(
-                decode_base16(result, medium_encoded)
+                decode_base16(medium_encoded)
             );
         })
         .run("decode 1KB", [&] {
-            data_chunk result;
             ankerl::nanobench::doNotOptimizeAway(
-                decode_base16(result, large_encoded)
+                decode_base16(large_encoded)
             );
         })
         .run("decode 16KB", [&] {
-            data_chunk result;
             ankerl::nanobench::doNotOptimizeAway(
-                decode_base16(result, xl_encoded)
+                decode_base16(xl_encoded)
             );
         })
         .run("decode 64KB", [&] {
-            data_chunk result;
             ankerl::nanobench::doNotOptimizeAway(
-                decode_base16(result, xxl_encoded)
+                decode_base16(xxl_encoded)
             );
         });
 }
@@ -345,8 +340,7 @@ void benchmark_cross_encoding() {
     // Compare decoding speeds
     Bench().title("Decoding Comparison (256B)").relative(true)
         .run("Base16", [&] {
-            data_chunk result;
-            ankerl::nanobench::doNotOptimizeAway(decode_base16(result, enc16));
+            ankerl::nanobench::doNotOptimizeAway(decode_base16(enc16));
         })
         .run("Base58", [&] {
             data_chunk result;

--- a/src/infrastructure/test/math/elliptic_curve.cpp
+++ b/src/infrastructure/test/math/elliptic_curve.cpp
@@ -10,110 +10,95 @@ using namespace kth;
 // Start Test Suite: elliptic curve tests
 
 // Scenario 1
-#define SECRET1 "8010b1bb119ad37d4b65a1022a314897b1b3614b345974332cb1b9582cf03536"
-#define COMPRESSED1 "0309ba8621aefd3b6ba4ca6d11a4746e8df8d35d9b51b383338f627ba7fc732731"
-#define UNCOMPRESSED1 "0409ba8621aefd3b6ba4ca6d11a4746e8df8d35d9b51b383338f627ba7fc7327318c3a6ec6acd33c36328b8fb4349b31671bcd3a192316ea4f6236ee1ae4a7d8c9"
+constexpr auto secret1 = "8010b1bb119ad37d4b65a1022a314897b1b3614b345974332cb1b9582cf03536"_base16;
+constexpr auto compressed1 = "0309ba8621aefd3b6ba4ca6d11a4746e8df8d35d9b51b383338f627ba7fc732731";
+constexpr auto uncompressed1 = "0409ba8621aefd3b6ba4ca6d11a4746e8df8d35d9b51b383338f627ba7fc7327318c3a6ec6acd33c36328b8fb4349b31671bcd3a192316ea4f6236ee1ae4a7d8c9";
 
 // Scenario 2
-#define COMPRESSED2 "03bc88a1bd6ebac38e9a9ed58eda735352ad10650e235499b7318315cc26c9b55b"
-#define SIGHASH2 "ed8f9b40c2d349c8a7e58cebe79faa25c21b6bb85b874901f72a1b3f1ad0a67f"
-#define SIGNATURE2 "3045022100bc494fbd09a8e77d8266e2abdea9aef08b9e71b451c7d8de9f63cda33a62437802206b93edd6af7c659db42c579eb34a3a4cb60c28b5a6bc86fd5266d42f6b8bb67d"
+constexpr auto compressed2 = "03bc88a1bd6ebac38e9a9ed58eda735352ad10650e235499b7318315cc26c9b55b"_base16;
+constexpr char sighash2_hex[] = "ed8f9b40c2d349c8a7e58cebe79faa25c21b6bb85b874901f72a1b3f1ad0a67f";
+constexpr auto der_signature2 = "3045022100bc494fbd09a8e77d8266e2abdea9aef08b9e71b451c7d8de9f63cda33a62437802206b93edd6af7c659db42c579eb34a3a4cb60c28b5a6bc86fd5266d42f6b8bb67d";
 
-// Scenario 3
-#define SECRET3 "ce8f4b713ffdd2658900845251890f30371856be201cd1f5b3d970f793634333"
-#define SIGHASH3 "f89572635651b2e4f89778350616989183c98d1a721c911324bf9f17a0cf5bf0"
+// Scenario 3 - these use hash_literal() which reverses bytes
+constexpr char secret3_hex[] = "ce8f4b713ffdd2658900845251890f30371856be201cd1f5b3d970f793634333";
+constexpr char sighash3_hex[] = "f89572635651b2e4f89778350616989183c98d1a721c911324bf9f17a0cf5bf0";
+constexpr auto ec_signature3 = "17b7b25c48e4ed2bd43369fa282f608b4329d96409860ce832fd5497b65fe663b901e34dff5291868c4401c8c1c6ed23b1887139cc4cd6884f38b9d936356131"_base16;
+constexpr auto der_signature3 = "3044022063e65fb69754fd32e80c860964d929438b602f28fa6933d42bede4485cb2b717022031613536d9b9384f88d64ccc397188b123edc6c1c801448c869152ff4de301b9";
 
-#define EC_SIGNATURE3 "17b7b25c48e4ed2bd43369fa282f608b4329d96409860ce832fd5497b65fe663b901e34dff5291868c4401c8c1c6ed23b1887139cc4cd6884f38b9d936356131"
-#define DER_SIGNATURE3 "3044022063e65fb69754fd32e80c860964d929438b602f28fa6933d42bede4485cb2b717022031613536d9b9384f88d64ccc397188b123edc6c1c801448c869152ff4de301b9"
-
-// #if defined(KTH_CURRENCY_BCH)
-// #define EC_SIGNATURE3 "17b7b25c48e4ed2bd43369fa282f608b4329d96409860ce832fd5497b65fe663b901e34dff5291868c4401c8c1c6ed23b1887139cc4cd6884f38b9d936356131"
-// #define DER_SIGNATURE3 "3044022063e65fb69754fd32e80c860964d929438b602f28fa6933d42bede4485cb2b717022031613536d9b9384f88d64ccc397188b123edc6c1c801448c869152ff4de301b9"
-// #else
-// #define EC_SIGNATURE3 "4832febef8b31c7c922a15cb4063a43ab69b099bba765e24facef50dfbb4d057928ed5c6b6886562c2fe6972fd7c7f462e557129067542cce6b37d72e5ea5037"
-// #define DER_SIGNATURE3 "3044022057d0b4fb0df5cefa245e76ba9b099bb63aa46340cb152a927c1cb3f8befe324802203750eae5727db3e6cc4275062971552e467f7cfd7269fec2626588b6c6d58e92"
-// #endif //KTH_CURRENCY_BCH
-
-
-TEST_CASE("elliptic curve  secret to public  positive  test", "[elliptic curve tests]") {
+TEST_CASE("elliptic curve secret to public positive test", "[elliptic curve tests]") {
     ec_compressed point;
-    REQUIRE(secret_to_public(point, base16_literal(SECRET1)));
-    REQUIRE(encode_base16(point) == COMPRESSED1);
+    REQUIRE(secret_to_public(point, secret1));
+    REQUIRE(encode_base16(point) == compressed1);
 }
 
-TEST_CASE("elliptic curve  decompress  positive  test", "[elliptic curve tests]") {
+TEST_CASE("elliptic curve decompress positive test", "[elliptic curve tests]") {
     ec_uncompressed uncompressed;
-    REQUIRE(decompress(uncompressed, base16_literal(COMPRESSED1)));
-    REQUIRE(encode_base16(uncompressed) == UNCOMPRESSED1);
+    auto const comp = decode_base16<ec_compressed_size>(compressed1);
+    REQUIRE(comp);
+    REQUIRE(decompress(uncompressed, *comp));
+    REQUIRE(encode_base16(uncompressed) == uncompressed1);
 }
 
-TEST_CASE("elliptic curve  sign  positive  test", "[elliptic curve tests]") {
+TEST_CASE("elliptic curve sign positive test", "[elliptic curve tests]") {
     ec_signature signature;
-    ec_secret const secret = hash_literal(SECRET3);
-    hash_digest const sighash = hash_literal(SIGHASH3);
-    REQUIRE(sign_ecdsa(signature, secret, sighash));
-
-    auto const result = encode_base16(signature);
-    REQUIRE(result == EC_SIGNATURE3);
+    ec_secret const secret3 = hash_literal(secret3_hex);
+    hash_digest const sighash3 = hash_literal(sighash3_hex);
+    REQUIRE(sign_ecdsa(signature, secret3, sighash3));
+    REQUIRE(signature == ec_signature3);
 }
 
-TEST_CASE("elliptic curve  encode signature  positive  test", "[elliptic curve tests]") {
+TEST_CASE("elliptic curve encode signature positive test", "[elliptic curve tests]") {
     der_signature out;
-    const ec_signature signature = base16_literal(EC_SIGNATURE3);
-    REQUIRE(encode_signature(out, signature));
+    REQUIRE(encode_signature(out, ec_signature3));
 
     auto const result = encode_base16(out);
-    REQUIRE(result == DER_SIGNATURE3);
+    REQUIRE(result == der_signature3);
 }
 
-TEST_CASE("elliptic curve  sign  round trip positive  test", "[elliptic curve tests]") {
+TEST_CASE("elliptic curve sign round trip positive test", "[elliptic curve tests]") {
     ec_compressed point;
     ec_signature signature;
     data_chunk const data{ 'd', 'a', 't', 'a' };
     hash_digest const hash = bitcoin_hash(data);
-    ec_secret const secret = hash_literal(SECRET1);
-    REQUIRE(secret_to_public(point, secret));
-    REQUIRE(sign_ecdsa(signature, secret, hash));
+    REQUIRE(secret_to_public(point, secret1));
+    REQUIRE(sign_ecdsa(signature, secret1, hash));
     REQUIRE(verify_signature(point, hash, signature));
 }
 
-TEST_CASE("elliptic curve  sign  round trip negative  test", "[elliptic curve tests]") {
+TEST_CASE("elliptic curve sign round trip negative test", "[elliptic curve tests]") {
     ec_compressed point;
     ec_signature signature;
     data_chunk const data{ 'd', 'a', 't', 'a' };
     hash_digest hash = bitcoin_hash(data);
-    ec_secret const secret = base16_literal(SECRET1);
-    REQUIRE(secret_to_public(point, secret));
-    REQUIRE(sign_ecdsa(signature, secret, hash));
+    REQUIRE(secret_to_public(point, secret1));
+    REQUIRE(sign_ecdsa(signature, secret1, hash));
 
     // Invalidate the positive test.
     hash[0] = 0;
     REQUIRE( ! verify_signature(point, hash, signature));
 }
 
-TEST_CASE("elliptic curve  verify signature  positive  test", "[elliptic curve tests]") {
+TEST_CASE("elliptic curve verify signature positive test", "[elliptic curve tests]") {
     ec_signature signature;
     static auto const strict = false;
-    hash_digest const sighash = hash_literal(SIGHASH2);
-    const ec_compressed point = base16_literal(COMPRESSED2);
-    der_signature distinguished;
-    REQUIRE(decode_base16(distinguished, SIGNATURE2));
-    REQUIRE(parse_signature(signature, distinguished, strict));
-    REQUIRE(verify_signature(point, sighash, signature));
+    hash_digest const sighash = hash_literal(sighash2_hex);
+    auto const distinguished = decode_base16(der_signature2);
+    REQUIRE(distinguished);
+    REQUIRE(parse_signature(signature, *distinguished, strict));
+    REQUIRE(verify_signature(compressed2, sighash, signature));
 }
 
-TEST_CASE("elliptic curve  verify signature  negative  test", "[elliptic curve tests]") {
+TEST_CASE("elliptic curve verify signature negative test", "[elliptic curve tests]") {
     ec_signature signature;
     static auto const strict = false;
-    hash_digest const sighash = hash_literal(SIGHASH2);
-    const ec_compressed point = base16_literal(COMPRESSED2);
-    der_signature distinguished;
-    REQUIRE(decode_base16(distinguished, SIGNATURE2));
-    REQUIRE(parse_signature(signature, distinguished, strict));
+    hash_digest const sighash = hash_literal(sighash2_hex);
+    auto const distinguished = decode_base16(der_signature2);
+    REQUIRE(distinguished);
+    REQUIRE(parse_signature(signature, *distinguished, strict));
 
     // Invalidate the positive test.
     signature[10] = 110;
-    REQUIRE( ! verify_signature(point, sighash, signature));
+    REQUIRE( ! verify_signature(compressed2, sighash, signature));
 }
 
 TEST_CASE("elliptic curve  ec add  positive  test", "[elliptic curve tests]") {
@@ -132,7 +117,7 @@ TEST_CASE("elliptic curve  ec add  positive  test", "[elliptic curve tests]") {
 
 TEST_CASE("elliptic curve  ec add  negative  test", "[elliptic curve tests]") {
     // = n - 1
-    ec_secret secret1 = base16_literal("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140");
+    ec_secret secret1 = "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140"_base16;
     ec_secret secret2{ { 0 } };
     secret2[31] = 1;
     ec_compressed public1;

--- a/src/infrastructure/test/math/hash.cpp
+++ b/src/infrastructure/test/math/hash.cpp
@@ -13,23 +13,23 @@ using namespace kth;
 
 TEST_CASE("sha1 hash test", "[hash tests]") {
     for (auto const& result: sha1_tests) {
-        data_chunk data;
-        REQUIRE(decode_base16(data, result.input));
-        REQUIRE(encode_base16(sha1_hash(data)) == result.result);
+        auto const data = decode_base16(result.input);
+        REQUIRE(data);
+        REQUIRE(encode_base16(sha1_hash(*data)) == result.result);
     }
 }
 
 TEST_CASE("ripemd hash test", "[hash tests]") {
     for (auto const& result: ripemd_tests) {
-        data_chunk data;
-        REQUIRE(decode_base16(data, result.input));
-        REQUIRE(encode_base16(ripemd160_hash(data)) == result.result);
+        auto const data = decode_base16(result.input);
+        REQUIRE(data);
+        REQUIRE(encode_base16(ripemd160_hash(*data)) == result.result);
     }
 
     auto const ripemd_hash1 = bitcoin_short_hash(to_array(110));
     REQUIRE(encode_base16(ripemd_hash1) == "17d040b739d639c729daaf627eaff88cfe4207f4");
 
-    auto const ripemd_hash2 = bitcoin_short_hash(base16_literal("020641fde3a85beb8321033516de7ec01c35de96e945bf76c3768784a905471986"));
+    auto const ripemd_hash2 = bitcoin_short_hash("020641fde3a85beb8321033516de7ec01c35de96e945bf76c3768784a905471986"_base16);
     REQUIRE(encode_base16(ripemd_hash2) == "c23e37c6fad06deab545f952992c8f28cb02bbe5");
 }
 

--- a/src/infrastructure/test/network_address.cpp
+++ b/src/infrastructure/test/network_address.cpp
@@ -10,6 +10,7 @@ using namespace kth::infrastructure;
 
 using message::network_address;
 
+namesspace {
 //This is defined in Domain <kth/domain/message/version.hpp>
 constexpr uint32_t version_level_minimum = 31402;
 
@@ -17,6 +18,8 @@ bool equal(network_address const& x, network_address const& y, bool with_timesta
     bool matches_timestamp = with_timestamp ? (x.timestamp() == y.timestamp()) : true;
     return matches_timestamp && (x == y);
 }
+
+} // anonymous namespace
 
 // Start Test Suite: network address tests
 
@@ -26,12 +29,18 @@ TEST_CASE("network address  constructor 1  always  invalid", "[network address t
 }
 
 TEST_CASE("network address  constructor 2  always  equals params", "[network address tests]") {
-    uint32_t timestamp = 734678u;
-    uint64_t services = 5357534u;
-    uint16_t port = 123u;
-    const message::ip_address ip = base16_literal("127544abcdefa7b6d3e91486c57000aa");
+    constexpr uint32_t timestamp = 734678u;
+    constexpr uint64_t services = 5357534u;
+    constexpr uint16_t port = 123u;
+    constexpr message::ip_address ip = "127544abcdefa7b6d3e91486c57000aa"_base16;
 
-    network_address instance(timestamp, services, ip, port);
+    network_address const instance {
+        timestamp, 
+        services, 
+        ip, 
+        port
+    };
+
     REQUIRE(instance.is_valid());
     REQUIRE(ip == instance.ip());
     REQUIRE(port == instance.port());
@@ -40,39 +49,46 @@ TEST_CASE("network address  constructor 2  always  equals params", "[network add
 }
 
 TEST_CASE("network address  constructor 3  always  equals params", "[network address tests]") {
-    uint32_t timestamp = 734678u;
-    uint64_t services = 5357534u;
-    uint16_t port = 123u;
+    constexpr uint32_t timestamp = 734678u;
+    constexpr uint64_t services = 5357534u;
+    constexpr uint16_t port = 123u;
 
-    network_address instance(timestamp, services, base16_literal("127544abcdefa7b6d3e91486c57000aa"), port);
+    network_address const instance {
+        timestamp, 
+        services, 
+        "127544abcdefa7b6d3e91486c57000aa"_base16, 
+        port
+    };
 
     REQUIRE(instance.is_valid());
 }
 
 TEST_CASE("network address  constructor 4  always  equals params", "[network address tests]") {
-    network_address const expected{
+    network_address const expected {
         734678u,
         5357534u,
-        base16_literal("127544abcdefa7b6d3e91486c57000aa"),
-        123u};
+        "127544abcdefa7b6d3e91486c57000aa"_base16,
+        123u
+    };
 
     REQUIRE(expected.is_valid());
 
-    network_address instance(expected);
+    network_address const instance(expected);
     REQUIRE(instance.is_valid());
     REQUIRE(expected == instance);
 }
 
 TEST_CASE("network address  constructor 5  always  equals params", "[network address tests]") {
-    network_address expected{
+    network_address expected {
         734678u,
         5357534u,
-        base16_literal("127544abcdefa7b6d3e91486c57000aa"),
-        123u};
+        "127544abcdefa7b6d3e91486c57000aa"_base16,
+        123u
+    };
 
     REQUIRE(expected.is_valid());
 
-    network_address instance(std::move(expected));
+    network_address const instance(std::move(expected));
     REQUIRE(instance.is_valid());
 }
 
@@ -85,11 +101,12 @@ TEST_CASE("network address from data insufficient bytes  failure", "[network add
 }
 
 TEST_CASE("network address  from data 1  without timestamp  success", "[network address tests]") {
-    network_address const expected{
+    network_address const expected {
         734678u,
         5357534u,
-        base16_literal("127544abcdefa7b6d3e91486c57000aa"),
-        123u};
+        "127544abcdefa7b6d3e91486c57000aa"_base16,
+        123u
+    };
 
     auto const data = expected.to_data(version_level_minimum, false);
     byte_reader reader(data);
@@ -102,15 +119,14 @@ TEST_CASE("network address  from data 1  without timestamp  success", "[network 
 }
 
 TEST_CASE("network address  from data 2  without timestamp  success", "[network address tests]") {
-    network_address const expected{
+    network_address const expected {
         734678u,
         5357534u,
-        base16_literal("127544abcdefa7b6d3e91486c57000aa"),
-        123u};
+        "127544abcdefa7b6d3e91486c57000aa"_base16,
+        123u
+    };
 
     auto const data = expected.to_data(version_level_minimum, false);
-    data_source istream(data);
-    istream_reader source(istream);
     byte_reader reader(data);
     auto const result = network_address::from_data(reader, version_level_minimum, false);
 
@@ -121,11 +137,12 @@ TEST_CASE("network address  from data 2  without timestamp  success", "[network 
 }
 
 TEST_CASE("network address  from data 3  without timestamp  success", "[network address tests]") {
-    network_address const expected{
+    network_address const expected {
         734678u,
         5357534u,
-        base16_literal("127544abcdefa7b6d3e91486c57000aa"),
-        123u};
+        "127544abcdefa7b6d3e91486c57000aa"_base16,
+        123u
+    };
 
     auto const data = expected.to_data(version_level_minimum, false);
     byte_reader reader(data);
@@ -138,11 +155,12 @@ TEST_CASE("network address  from data 3  without timestamp  success", "[network 
 }
 
 TEST_CASE("network address  from data 1  with timestamp  success", "[network address tests]") {
-    network_address const expected{
+    network_address const expected {
         734678u,
         5357534u,
-        base16_literal("127544abcdefa7b6d3e91486c57000aa"),
-        123u};
+        "127544abcdefa7b6d3e91486c57000aa"_base16,
+        123u
+    };
 
     auto const data = expected.to_data(version_level_minimum, true);
     byte_reader reader(data);
@@ -155,11 +173,12 @@ TEST_CASE("network address  from data 1  with timestamp  success", "[network add
 }
 
 TEST_CASE("network address  from data 2  with timestamp  success", "[network address tests]") {
-    network_address const expected{
+    network_address const expected {
         734678u,
         5357534u,
-        base16_literal("127544abcdefa7b6d3e91486c57000aa"),
-        123u};
+        "127544abcdefa7b6d3e91486c57000aa"_base16,
+        123u
+    };
 
     auto const data = expected.to_data(version_level_minimum, true);
     byte_reader reader(data);
@@ -172,11 +191,12 @@ TEST_CASE("network address  from data 2  with timestamp  success", "[network add
 }
 
 TEST_CASE("network address  from data 3  with timestamp  success", "[network address tests]") {
-    network_address const expected{
+    network_address const expected {
         734678u,
         5357534u,
-        base16_literal("127544abcdefa7b6d3e91486c57000aa"),
-        123u};
+        "127544abcdefa7b6d3e91486c57000aa"_base16,
+        123u
+    };
 
     auto const data = expected.to_data(version_level_minimum, true);
     byte_reader reader(data);
@@ -189,18 +209,19 @@ TEST_CASE("network address  from data 3  with timestamp  success", "[network add
 }
 
 TEST_CASE("network address  timestamp accessor  always  returns initialized value", "[network address tests]") {
-    uint32_t const timestamp = 734678u;
-    network_address instance(
+    constexpr uint32_t timestamp = 734678u;
+    network_address const instance {
         timestamp,
         5357534u,
-        base16_literal("127544abcdefa7b6d3e91486c57000aa"),
-        123u);
+        "127544abcdefa7b6d3e91486c57000aa"_base16,
+        123u
+    };
 
     REQUIRE(timestamp == instance.timestamp());
 }
 
 TEST_CASE("network address  timestamp setter  roundtrip  success", "[network address tests]") {
-    uint32_t const timestamp = 734678u;
+    constexpr uint32_t timestamp = 734678u;
     network_address instance;
     REQUIRE(timestamp != instance.timestamp());
     instance.set_timestamp(timestamp);
@@ -208,18 +229,19 @@ TEST_CASE("network address  timestamp setter  roundtrip  success", "[network add
 }
 
 TEST_CASE("network address  services accessor  always  returns initialized value", "[network address tests]") {
-    uint32_t const services = 5357534u;
-    network_address instance(
+    constexpr uint32_t services = 5357534u;
+    network_address instance {
         734678u,
         services,
-        base16_literal("127544abcdefa7b6d3e91486c57000aa"),
-        123u);
+        "127544abcdefa7b6d3e91486c57000aa"_base16,
+        123u
+    };
 
     REQUIRE(services == instance.services());
 }
 
 TEST_CASE("network address  services setter  roundtrip  success", "[network address tests]") {
-    uint64_t const services = 6842368u;
+    constexpr uint64_t services = 6842368u;
     network_address instance;
     REQUIRE(services != instance.services());
     instance.set_services(services);
@@ -227,19 +249,20 @@ TEST_CASE("network address  services setter  roundtrip  success", "[network addr
 }
 
 TEST_CASE("network address  ip accessor  always  returns initialized value", "[network address tests]") {
-    const message::ip_address ip = base16_literal("127544abcdefa7b6d3e91486c57000aa");
+    constexpr message::ip_address ip = "127544abcdefa7b6d3e91486c57000aa"_base16;
 
-    network_address instance(
+    network_address const instance {
         734678u,
         5357534u,
         ip,
-        123u);
+        123u
+    };
 
     REQUIRE(ip == instance.ip());
 }
 
 TEST_CASE("network address  ip setter 1  roundtrip  success", "[network address tests]") {
-    const message::ip_address ip = base16_literal("127544abcdefa7b6d3e91486c57000aa");
+    constexpr message::ip_address ip = "127544abcdefa7b6d3e91486c57000aa"_base16;
 
     network_address instance;
     REQUIRE(ip != instance.ip());
@@ -248,27 +271,28 @@ TEST_CASE("network address  ip setter 1  roundtrip  success", "[network address 
 }
 
 TEST_CASE("network address  ip setter 2  roundtrip  success", "[network address tests]") {
-    const message::ip_address ip = base16_literal("127544abcdefa7b6d3e91486c57000aa");
+    constexpr message::ip_address ip = "127544abcdefa7b6d3e91486c57000aa"_base16;
 
     network_address instance;
     REQUIRE(ip != instance.ip());
-    instance.set_ip(base16_literal("127544abcdefa7b6d3e91486c57000aa"));
+    instance.set_ip("127544abcdefa7b6d3e91486c57000aa"_base16);
     REQUIRE(ip == instance.ip());
 }
 
 TEST_CASE("network address  port accessor  always  returns initialized value", "[network address tests]") {
-    uint16_t const port = 123u;
-    network_address instance(
+    constexpr uint16_t port = 123u;
+    network_address const instance {
         734678u,
         5357534u,
-        base16_literal("127544abcdefa7b6d3e91486c57000aa"),
-        port);
+        "127544abcdefa7b6d3e91486c57000aa"_base16,
+        port
+    };
 
     REQUIRE(port == instance.port());
 }
 
 TEST_CASE("network address  port setter  roundtrip  success", "[network address tests]") {
-    uint16_t const port = 853u;
+    constexpr uint16_t port = 853u;
     network_address instance;
     REQUIRE(port != instance.port());
     instance.set_port(port);
@@ -276,11 +300,12 @@ TEST_CASE("network address  port setter  roundtrip  success", "[network address 
 }
 
 TEST_CASE("network address  operator assign equals 1  always  matches equivalent", "[network address tests]") {
-    network_address value(
+    network_address const value {
         14356u,
         54676843u,
-        base16_literal("127544abcdefa7b6d3e91486c57000aa"),
-        1500u);
+        "127544abcdefa7b6d3e91486c57000aa"_base16,
+        1500u
+    };
 
     REQUIRE(value.is_valid());
 
@@ -292,11 +317,12 @@ TEST_CASE("network address  operator assign equals 1  always  matches equivalent
 }
 
 TEST_CASE("network address  operator assign equals 2  always  matches equivalent", "[network address tests]") {
-    network_address const value(
+    network_address const value {
         14356u,
         54676843u,
-        base16_literal("127544abcdefa7b6d3e91486c57000aa"),
-        1500u);
+        "127544abcdefa7b6d3e91486c57000aa"_base16,
+        1500u
+    };
 
     REQUIRE(value.is_valid());
 
@@ -309,69 +335,74 @@ TEST_CASE("network address  operator assign equals 2  always  matches equivalent
 }
 
 TEST_CASE("network address  operator boolean equals  duplicates  returns true", "[network address tests]") {
-    network_address const expected(
+    network_address const expected {
         14356u,
         54676843u,
-        base16_literal("127544abcdefa7b6d3e91486c57000aa"),
-        1500u);
+        "127544abcdefa7b6d3e91486c57000aa"_base16,
+        1500u
+    };
 
-    network_address instance(expected);
+    network_address const instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("network address  operator boolean equals  differs timestamp  returns true", "[network address tests]") {
-    network_address const expected(
+    network_address const expected {
         14356u,
         54676843u,
-        base16_literal("127544abcdefa7b6d3e91486c57000aa"),
-        1500u);
+        "127544abcdefa7b6d3e91486c57000aa"_base16,
+        1500u
+    };
 
-    network_address instance(643u, expected.services(),
-                                      expected.ip(), expected.port());
+    network_address const instance(643u, expected.services(), expected.ip(), expected.port());
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("network address  operator boolean equals  differs  returns false", "[network address tests]") {
-    network_address const expected(
+    network_address const expected {
         14356u,
         54676843u,
-        base16_literal("127544abcdefa7b6d3e91486c57000aa"),
-        1500u);
+        "127544abcdefa7b6d3e91486c57000aa"_base16,
+        1500u
+    };
 
-    network_address instance;
+    network_address const instance;
     REQUIRE(instance != expected);
 }
 
 TEST_CASE("network address  operator boolean not equals  duplicates  returns false", "[network address tests]") {
-    network_address const expected(
+    network_address const expected {
         14356u,
         54676843u,
-        base16_literal("127544abcdefa7b6d3e91486c57000aa"),
-        1500u);
+        "127544abcdefa7b6d3e91486c57000aa"_base16,
+        1500u
+    };
 
-    network_address instance(expected);
+    network_address const instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("network address  operator boolean not equals  differs timestamp  returns false", "[network address tests]") {
-    network_address const expected(
+    network_address const expected {
         14356u,
         54676843u,
-        base16_literal("127544abcdefa7b6d3e91486c57000aa"),
-        1500u);
+        "127544abcdefa7b6d3e91486c57000aa"_base16,
+        1500u
+    };
 
-    network_address instance(643u, expected.services(), expected.ip(), expected.port());
+    network_address const instance(643u, expected.services(), expected.ip(), expected.port());
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("network address  operator boolean not equals  differs  returns true", "[network address tests]") {
-    network_address const expected(
+    network_address const expected {
         14356u,
         54676843u,
-        base16_literal("127544abcdefa7b6d3e91486c57000aa"),
-        1500u);
+        "127544abcdefa7b6d3e91486c57000aa"_base16,
+        1500u
+    };
 
-    network_address instance;
+    network_address const instance;
     REQUIRE(instance != expected);
 }
 

--- a/src/infrastructure/test/unicode/unicode.cpp
+++ b/src/infrastructure/test/unicode/unicode.cpp
@@ -16,13 +16,13 @@ using namespace kth;
 
 // github.com/bitcoin/bips/blob/master/bip-0038.mediawiki
 TEST_CASE("infrastructure unicode to normal nfc form validation", "[infrastructure][unicode]") {
-    data_chunk original;
-    REQUIRE(decode_base16(original, "cf92cc8100f0909080f09f92a9"));
-    std::string original_string(original.begin(), original.end());
+    auto const original = decode_base16("cf92cc8100f0909080f09f92a9");
+    REQUIRE(original);
+    std::string original_string(original->begin(), original->end());
 
-    data_chunk normal;
-    REQUIRE(decode_base16(normal, "cf9300f0909080f09f92a9"));
-    std::string expected_normal_string(normal.begin(), normal.end());
+    auto const normal = decode_base16("cf9300f0909080f09f92a9");
+    REQUIRE(normal);
+    std::string expected_normal_string(normal->begin(), normal->end());
 
     auto const derived_normal_string = kth::to_normal_nfc_form(original_string);
     REQUIRE(expected_normal_string == derived_normal_string);

--- a/src/infrastructure/test/wallet/hd_private.cpp
+++ b/src/infrastructure/test/wallet/hd_private.cpp
@@ -12,20 +12,20 @@ using namespace kth::infrastructure::wallet;
 
 // TODO: test altchain
 
-#define SHORT_SEED "000102030405060708090a0b0c0d0e0f"
-#define LONG_SEED "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542"
+constexpr char short_seed[] = "000102030405060708090a0b0c0d0e0f";
+constexpr char long_seed[] = "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542";
 
-TEST_CASE("hd private  encoded  round trip  expected", "[hd private tests]") {
+TEST_CASE("hd private encoded round trip expected", "[hd private tests]") {
     static auto const encoded = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi";
     hd_private const key(encoded);
     REQUIRE(key.encoded() == encoded);
 }
 
-TEST_CASE("hd private  derive private  short seed  expected", "[hd private tests]") {
-    data_chunk seed;
-    REQUIRE(decode_base16(seed, SHORT_SEED));
+TEST_CASE("hd private derive private short seed expected", "[hd private tests]") {
+    auto const seed = decode_base16(short_seed);
+    REQUIRE(seed);
 
-    hd_private const m(seed, hd_private::mainnet);
+    hd_private const m(*seed, hd_private::mainnet);
     auto const m0h = m.derive_private(hd_first_hardened_key);
     auto const m0h1 = m0h.derive_private(1);
     auto const m0h12h = m0h1.derive_private(2 + hd_first_hardened_key);
@@ -40,11 +40,11 @@ TEST_CASE("hd private  derive private  short seed  expected", "[hd private tests
     REQUIRE(m0h12h2x.encoded() == "xprvA41z7zogVVwxVSgdKUHDy1SKmdb533PjDz7J6N6mV6uS3ze1ai8FHa8kmHScGpWmj4WggLyQjgPie1rFSruoUihUZREPSL39UNdE3BBDu76");
 }
 
-TEST_CASE("hd private  derive public  short seed  expected", "[hd private tests]") {
-    data_chunk seed;
-    REQUIRE(decode_base16(seed, SHORT_SEED));
+TEST_CASE("hd private derive public short seed expected", "[hd private tests]") {
+    auto const seed = decode_base16(short_seed);
+    REQUIRE(seed);
 
-    hd_private const m(seed, hd_private::mainnet);
+    hd_private const m(*seed, hd_private::mainnet);
     auto const m0h = m.derive_private(hd_first_hardened_key);
     auto const m0h1 = m0h.derive_private(1);
     auto const m0h12h = m0h1.derive_private(2 + hd_first_hardened_key);
@@ -66,11 +66,11 @@ TEST_CASE("hd private  derive public  short seed  expected", "[hd private tests]
     REQUIRE(m0h12h2x_pub.encoded() == "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy");
 }
 
-TEST_CASE("hd private  derive private  long seed  expected", "[hd private tests]") {
-    data_chunk seed;
-    REQUIRE(decode_base16(seed, LONG_SEED));
+TEST_CASE("hd private derive private long seed expected", "[hd private tests]") {
+    auto const seed = decode_base16(long_seed);
+    REQUIRE(seed);
 
-    hd_private const m(seed, hd_private::mainnet);
+    hd_private const m(*seed, hd_private::mainnet);
     auto const m0 = m.derive_private(0);
     auto const m0xH = m0.derive_private(2147483647 + hd_first_hardened_key);
     auto const m0xH1 = m0xH.derive_private(1);
@@ -85,11 +85,11 @@ TEST_CASE("hd private  derive private  long seed  expected", "[hd private tests]
     REQUIRE(m0xH1yH2.encoded() == "xprvA2nrNbFZABcdryreWet9Ea4LvTJcGsqrMzxHx98MMrotbir7yrKCEXw7nadnHM8Dq38EGfSh6dqA9QWTyefMLEcBYJUuekgW4BYPJcr9E7j");
 }
 
-TEST_CASE("hd private  derive public  long seed  expected", "[hd private tests]") {
-    data_chunk seed;
-    REQUIRE(decode_base16(seed, LONG_SEED));
+TEST_CASE("hd private derive public long seed expected", "[hd private tests]") {
+    auto const seed = decode_base16(long_seed);
+    REQUIRE(seed);
 
-    hd_private const m(seed, hd_private::mainnet);
+    hd_private const m(*seed, hd_private::mainnet);
     auto const m0 = m.derive_private(0);
     auto const m0xH = m0.derive_private(2147483647 + hd_first_hardened_key);
     auto const m0xH1 = m0xH.derive_private(1);

--- a/src/infrastructure/test/wallet/hd_public.cpp
+++ b/src/infrastructure/test/wallet/hd_public.cpp
@@ -12,29 +12,29 @@ using namespace kth::infrastructure::wallet;
 
 // TODO: test altchain
 
-#define SHORT_SEED "000102030405060708090a0b0c0d0e0f"
-#define LONG_SEED "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542"
+constexpr char short_seed[] = "000102030405060708090a0b0c0d0e0f";
+constexpr char long_seed[] = "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542";
 
-TEST_CASE("hd public  derive public  invalid  false", "[hd public tests]") {
-    data_chunk seed;
-    REQUIRE(decode_base16(seed, SHORT_SEED));
+TEST_CASE("hd public derive public invalid false", "[hd public tests]") {
+    auto const seed = decode_base16(short_seed);
+    REQUIRE(seed);
 
-    hd_private const m(seed, hd_private::mainnet);
+    hd_private const m(*seed, hd_private::mainnet);
     hd_public const m_pub = m;
     REQUIRE( ! m_pub.derive_public(hd_first_hardened_key));
 }
 
-TEST_CASE("hd public  encoded  round trip  expected", "[hd public tests]") {
+TEST_CASE("hd public encoded round trip expected", "[hd public tests]") {
     static auto const encoded = "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8";
     hd_public const key(encoded);
     REQUIRE(key.encoded() == encoded);
 }
 
-TEST_CASE("hd public  derive public  short seed  expected", "[hd public tests]") {
-    data_chunk seed;
-    REQUIRE(decode_base16(seed, SHORT_SEED));
+TEST_CASE("hd public derive public short seed expected", "[hd public tests]") {
+    auto const seed = decode_base16(short_seed);
+    REQUIRE(seed);
 
-    hd_private const m(seed, hd_private::mainnet);
+    hd_private const m(*seed, hd_private::mainnet);
     auto const m0h = m.derive_private(hd_first_hardened_key);
     auto const m0h1 = m0h.derive_private(1);
 
@@ -53,11 +53,11 @@ TEST_CASE("hd public  derive public  short seed  expected", "[hd public tests]")
     REQUIRE(m0h12h2x_pub.encoded() == "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy");
 }
 
-TEST_CASE("hd public  derive public  long seed  expected", "[hd public tests]") {
-    data_chunk seed;
-    REQUIRE(decode_base16(seed, LONG_SEED));
+TEST_CASE("hd public derive public long seed expected", "[hd public tests]") {
+    auto const seed = decode_base16(long_seed);
+    REQUIRE(seed);
 
-    hd_private const m(seed, hd_private::mainnet);
+    hd_private const m(*seed, hd_private::mainnet);
     auto const m0 = m.derive_private(0);
     auto const m0xH = m0.derive_private(2147483647 + hd_first_hardened_key);
     auto const m0xH1 = m0xH.derive_private(1);

--- a/src/infrastructure/test/wallet/mnemonic.cpp
+++ b/src/infrastructure/test/wallet/mnemonic.cpp
@@ -45,48 +45,48 @@ TEST_CASE("infrastructure mnemonic decode with bx test vectors", "[infrastructur
 
 TEST_CASE("infrastructure mnemonic create from entropy trezor vectors", "[infrastructure][mnemonic]") {
     for (mnemonic_result const& vector : mnemonic_trezor_vectors) {
-        data_chunk entropy;
-        decode_base16(entropy, vector.entropy);
-        auto const mnemonic = create_mnemonic(entropy, vector.language);
+        auto const entropy = decode_base16(vector.entropy);
+        REQUIRE(entropy);
+        auto const mnemonic = create_mnemonic(*entropy, vector.language);
         REQUIRE(mnemonic.size() > 0);
         REQUIRE(join(mnemonic, ",") == vector.mnemonic);
         REQUIRE(validate_mnemonic(mnemonic));
     }
 }
 
-TEST_CASE("mnemonic  create mnemonic  bx", "[mnemonic tests]") {
+TEST_CASE("mnemonic create mnemonic bx", "[mnemonic tests]") {
     for (const mnemonic_result& vector: mnemonic_bx_new_vectors) {
-        data_chunk entropy;
-        decode_base16(entropy, vector.entropy);
-        auto const mnemonic = create_mnemonic(entropy, vector.language);
+        auto const entropy = decode_base16(vector.entropy);
+        REQUIRE(entropy);
+        auto const mnemonic = create_mnemonic(*entropy, vector.language);
         REQUIRE(mnemonic.size() > 0);
         REQUIRE(join(mnemonic, ",") == vector.mnemonic);
         REQUIRE(validate_mnemonic(mnemonic));
     }
 }
 
-TEST_CASE("mnemonic  validate mnemonic  invalid", "[mnemonic tests]") {
+TEST_CASE("mnemonic validate mnemonic invalid", "[mnemonic tests]") {
     for (auto const& mnemonic: invalid_mnemonic_tests) {
         auto const words = split(mnemonic, ",");
         REQUIRE( ! validate_mnemonic(words));
     }
 }
 
-TEST_CASE("mnemonic  create mnemonic  tiny", "[mnemonic tests]") {
+TEST_CASE("mnemonic create mnemonic tiny", "[mnemonic tests]") {
     data_chunk const entropy(4, 0xa9);
     auto const mnemonic = create_mnemonic(entropy);
     REQUIRE(mnemonic.size() == 3u);
     REQUIRE(validate_mnemonic(mnemonic));
 }
 
-TEST_CASE("mnemonic  create mnemonic  giant", "[mnemonic tests]") {
+TEST_CASE("mnemonic create mnemonic giant", "[mnemonic tests]") {
     data_chunk const entropy(1024, 0xa9);
     auto const mnemonic = create_mnemonic(entropy);
     REQUIRE(mnemonic.size() == 768u);
     REQUIRE(validate_mnemonic(mnemonic));
 }
 
-TEST_CASE("mnemonic  dictionary  en es  no intersection", "[mnemonic tests]") {
+TEST_CASE("mnemonic dictionary en es no intersection", "[mnemonic tests]") {
     auto const& english = language::en;
     auto const& spanish = language::es;
     size_t intersection = 0;
@@ -100,7 +100,7 @@ TEST_CASE("mnemonic  dictionary  en es  no intersection", "[mnemonic tests]") {
     REQUIRE(intersection == 0u);
 }
 
-TEST_CASE("mnemonic  dictionary  en it  no intersection", "[mnemonic tests]") {
+TEST_CASE("mnemonic dictionary en it no intersection", "[mnemonic tests]") {
     auto const& english = language::en;
     auto const& italian = language::it;
     size_t intersection = 0;
@@ -114,7 +114,7 @@ TEST_CASE("mnemonic  dictionary  en it  no intersection", "[mnemonic tests]") {
     REQUIRE(intersection == 0u);
 }
 
-TEST_CASE("mnemonic  dictionary  fr es  no intersection", "[mnemonic tests]") {
+TEST_CASE("mnemonic dictionary fr es no intersection", "[mnemonic tests]") {
     auto const& french = language::fr;
     auto const& spanish = language::es;
     size_t intersection = 0;
@@ -128,7 +128,7 @@ TEST_CASE("mnemonic  dictionary  fr es  no intersection", "[mnemonic tests]") {
     REQUIRE(intersection == 0u);
 }
 
-TEST_CASE("mnemonic  dictionary  it es  no intersection", "[mnemonic tests]") {
+TEST_CASE("mnemonic dictionary it es no intersection", "[mnemonic tests]") {
     auto const& italian = language::it;
     auto const& spanish = language::es;
     size_t intersection = 0;
@@ -142,7 +142,7 @@ TEST_CASE("mnemonic  dictionary  it es  no intersection", "[mnemonic tests]") {
     REQUIRE(intersection == 0u);
 }
 
-TEST_CASE("mnemonic  dictionary  fr it  no intersection", "[mnemonic tests]") {
+TEST_CASE("mnemonic dictionary fr it no intersection", "[mnemonic tests]") {
     auto const& french = language::fr;
     auto const& italian = language::it;
     size_t intersection = 0;
@@ -156,7 +156,7 @@ TEST_CASE("mnemonic  dictionary  fr it  no intersection", "[mnemonic tests]") {
     REQUIRE(intersection == 0u);
 }
 
-TEST_CASE("mnemonic  dictionary  cs ru  no intersection", "[mnemonic tests]") {
+TEST_CASE("mnemonic dictionary cs ru no intersection", "[mnemonic tests]") {
     auto const& czech = language::cs;
     auto const& russian = language::ru;
     size_t intersection = 0;
@@ -170,7 +170,7 @@ TEST_CASE("mnemonic  dictionary  cs ru  no intersection", "[mnemonic tests]") {
     REQUIRE(intersection == 0u);
 }
 
-TEST_CASE("mnemonic  dictionary  cs uk  no intersection", "[mnemonic tests]") {
+TEST_CASE("mnemonic dictionary cs uk no intersection", "[mnemonic tests]") {
     auto const& czech = language::cs;
     auto const& ukranian = language::uk;
     size_t intersection = 0;
@@ -184,7 +184,7 @@ TEST_CASE("mnemonic  dictionary  cs uk  no intersection", "[mnemonic tests]") {
     REQUIRE(intersection == 0u);
 }
 
-TEST_CASE("mnemonic  dictionary  zh Hans Hant  intersection", "[mnemonic tests]") {
+TEST_CASE("mnemonic dictionary zh Hans Hant intersection", "[mnemonic tests]") {
     auto const& simplified = language::zh_Hans;
     auto const& traditional = language::zh_Hant;
     size_t intersection = 0;


### PR DESCRIPTION
## Summary

- Adapt tests to use `std::expected`-based `decode_base16`
- Convert `#define` macros to `constexpr char[]` arrays
- Fix test names with double spaces
- Update test assertions for new API

## Dependencies

- Based on #124 (domain implementation)

## Test Plan

- [ ] All infrastructure tests pass