### PR TITLE
test: update remaining modules for new base encoding API

### DIFF
--- a/src/blockchain/test/block_chain.cpp
+++ b/src/blockchain/test/block_chain.cpp
@@ -73,10 +73,10 @@ bool create_database(database::settings& out_database) {
 }
 
 domain::chain::block read_block(const std::string hex) {
-    data_chunk data;
-    REQUIRE(decode_base16(data, hex));
+    auto const data = decode_base16(hex);
+    REQUIRE(data);
     domain::chain::block result;
-    REQUIRE(kd::entity_from_data(result, data));
+    REQUIRE(kd::entity_from_data(result, *data));
     return result;
 }
 

--- a/src/blockchain/test/block_pool.cpp
+++ b/src/blockchain/test/block_pool.cpp
@@ -64,12 +64,12 @@ block_const_ptr make_block(uint32_t id, size_t height) {
 
 // construct
 
-TEST_CASE("block pool  construct  zero depth  sets  maximum value", "[block pool tests]") {
+TEST_CASE("block pool construct zero depth sets maximum value", "[block pool tests]") {
     block_pool_fixture instance(0);
     REQUIRE(instance.maximum_depth() == max_size_t);
 }
 
-TEST_CASE("block pool  construct  nonzero depth  round trips", "[block pool tests]") {
+TEST_CASE("block pool construct nonzero depth round trips", "[block pool tests]") {
     static size_t const expected = 42;
     block_pool_fixture instance(expected);
     REQUIRE(instance.maximum_depth() == expected);
@@ -77,7 +77,7 @@ TEST_CASE("block pool  construct  nonzero depth  round trips", "[block pool test
 
 // add1
 
-TEST_CASE("block pool  add1  one  single", "[block pool tests]") {
+TEST_CASE("block pool add1 one single", "[block pool tests]") {
     block_pool_fixture instance(0);
     static size_t const height = 42;
     auto const block1 = make_block(1, height);
@@ -92,7 +92,7 @@ TEST_CASE("block pool  add1  one  single", "[block pool tests]") {
     REQUIRE(entry->first == height);
 }
 
-TEST_CASE("block pool  add1  twice  single", "[block pool tests]") {
+TEST_CASE("block pool add1 twice single", "[block pool tests]") {
     block_pool instance(0);
     auto const block = std::make_shared<const domain::message::block>();
 
@@ -101,7 +101,7 @@ TEST_CASE("block pool  add1  twice  single", "[block pool tests]") {
     REQUIRE(instance.size() == 1u);
 }
 
-TEST_CASE("block pool  add1  two different blocks with same hash  first retained", "[block pool tests]") {
+TEST_CASE("block pool add1 two different blocks with same hash first retained", "[block pool tests]") {
     block_pool_fixture instance(0);
     static size_t const height1a = 42;
     auto const block1a = make_block(1, height1a);
@@ -119,7 +119,7 @@ TEST_CASE("block pool  add1  two different blocks with same hash  first retained
     REQUIRE(entry->second.block() == block1a);
 }
 
-TEST_CASE("block pool  add1  two distinct hash  two", "[block pool tests]") {
+TEST_CASE("block pool add1 two distinct hash two", "[block pool tests]") {
     block_pool_fixture instance(0);
     static size_t const height1 = 42;
     static size_t const height2 = height1 + 1u;
@@ -144,13 +144,13 @@ TEST_CASE("block pool  add1  two distinct hash  two", "[block pool tests]") {
 
 // add2
 
-TEST_CASE("block pool  add2  empty  empty", "[block pool tests]") {
+TEST_CASE("block pool add2 empty empty", "[block pool tests]") {
     block_pool instance(0);
     instance.add(std::make_shared<block_const_ptr_list const>());
     REQUIRE(instance.size() == 0u);
 }
 
-TEST_CASE("block pool  add2  distinct  expected", "[block pool tests]") {
+TEST_CASE("block pool add2 distinct expected", "[block pool tests]") {
     block_pool_fixture instance(0);
     auto const block1 = make_block(1, 42);
     auto const block2 = make_block(2, 43);
@@ -173,7 +173,7 @@ TEST_CASE("block pool  add2  distinct  expected", "[block pool tests]") {
 
 // remove
 
-TEST_CASE("block pool  remove  empty  unchanged", "[block pool tests]") {
+TEST_CASE("block pool remove empty unchanged", "[block pool tests]") {
     block_pool instance(0);
     auto const block1 = make_block(1, 42);
     instance.add(block1);
@@ -183,7 +183,7 @@ TEST_CASE("block pool  remove  empty  unchanged", "[block pool tests]") {
     REQUIRE(instance.size() == 1u);
 }
 
-TEST_CASE("block pool  remove  all distinct  empty", "[block pool tests]") {
+TEST_CASE("block pool remove all distinct empty", "[block pool tests]") {
     block_pool_fixture instance(0);
     auto const block1 = make_block(1, 42);
     auto const block2 = make_block(2, 43);
@@ -197,7 +197,7 @@ TEST_CASE("block pool  remove  all distinct  empty", "[block pool tests]") {
     REQUIRE(instance.size() == 0u);
 }
 
-TEST_CASE("block pool  remove  all connected  empty", "[block pool tests]") {
+TEST_CASE("block pool remove all connected empty", "[block pool tests]") {
     block_pool instance(0);
     auto const block1 = make_block(1, 42);
     auto const block2 = make_block(2, 43, block1);
@@ -211,7 +211,7 @@ TEST_CASE("block pool  remove  all connected  empty", "[block pool tests]") {
     REQUIRE(instance.size() == 0u);
 }
 
-TEST_CASE("block pool  remove  subtree  reorganized", "[block pool tests]") {
+TEST_CASE("block pool remove subtree reorganized", "[block pool tests]") {
     block_pool_fixture instance(0);
     auto const block1 = make_block(1, 42);
     auto const block2 = make_block(2, 43, block1);
@@ -247,13 +247,13 @@ TEST_CASE("block pool  remove  subtree  reorganized", "[block pool tests]") {
 
 // prune
 
-TEST_CASE("block pool  prune  empty zero zero  empty", "[block pool tests]") {
+TEST_CASE("block pool prune empty zero zero empty", "[block pool tests]") {
     block_pool_fixture instance(0);
     instance.prune(0);
     REQUIRE(instance.size() == 0u);
 }
 
-TEST_CASE("block pool  prune  all current  unchanged", "[block pool tests]") {
+TEST_CASE("block pool prune all current unchanged", "[block pool tests]") {
     block_pool_fixture instance(10);
     auto const block1 = make_block(1, 42);
     auto const block2 = make_block(2, 43);
@@ -273,7 +273,7 @@ TEST_CASE("block pool  prune  all current  unchanged", "[block pool tests]") {
     REQUIRE(instance.size() == 5u);
 }
 
-TEST_CASE("block pool  prune  one expired  one deleted", "[block pool tests]") {
+TEST_CASE("block pool prune one expired one deleted", "[block pool tests]") {
     block_pool_fixture instance(10);
     auto const block1 = make_block(1, 42);
     auto const block2 = make_block(2, 43);
@@ -293,7 +293,7 @@ TEST_CASE("block pool  prune  one expired  one deleted", "[block pool tests]") {
     REQUIRE(instance.size() == 4u);
 }
 
-TEST_CASE("block pool  prune  whole branch expired  whole branch deleted", "[block pool tests]") {
+TEST_CASE("block pool prune whole branch expired whole branch deleted", "[block pool tests]") {
     block_pool_fixture instance(10);
 
     // branch1
@@ -317,7 +317,7 @@ TEST_CASE("block pool  prune  whole branch expired  whole branch deleted", "[blo
     REQUIRE(instance.size() == 3u);
 }
 
-TEST_CASE("block pool  prune  partial branch expired  partial branch deleted", "[block pool tests]") {
+TEST_CASE("block pool prune partial branch expired partial branch deleted", "[block pool tests]") {
     block_pool_fixture instance(10);
 
     // branch1
@@ -371,14 +371,14 @@ TEST_CASE("block pool  prune  partial branch expired  partial branch deleted", "
 
 // filter
 
-TEST_CASE("block pool  filter  empty  empty", "[block pool tests]") {
+TEST_CASE("block pool filter empty empty", "[block pool tests]") {
     block_pool_fixture instance(0);
     auto const message = std::make_shared<domain::message::get_data>();
     instance.filter(message);
     REQUIRE(message->inventories().empty());
 }
 
-TEST_CASE("block pool  filter  empty filter  unchanged", "[block pool tests]") {
+TEST_CASE("block pool filter empty filter unchanged", "[block pool tests]") {
     block_pool_fixture instance(0);
     auto const block1 = make_block(1, 42);
     auto const block2 = make_block(2, 42);
@@ -389,7 +389,7 @@ TEST_CASE("block pool  filter  empty filter  unchanged", "[block pool tests]") {
     REQUIRE(message->inventories().empty());
 }
 
-TEST_CASE("block pool  filter  matched blocks  non blocks and mismatches remain", "[block pool tests]") {
+TEST_CASE("block pool filter matched blocks non blocks and mismatches remain", "[block pool tests]") {
     block_pool_fixture instance(0);
     auto const block1 = make_block(1, 42);
     auto const block2 = make_block(2, 43);
@@ -418,13 +418,13 @@ TEST_CASE("block pool  filter  matched blocks  non blocks and mismatches remain"
 
 // exists
 
-TEST_CASE("block pool  exists  empty  false", "[block pool tests]") {
+TEST_CASE("block pool exists empty false", "[block pool tests]") {
     block_pool_fixture instance(0);
     auto const block1 = make_block(1, 42);
     REQUIRE( ! instance.exists(block1));
 }
 
-TEST_CASE("block pool  exists  not empty mismatch  false", "[block pool tests]") {
+TEST_CASE("block pool exists not empty mismatch false", "[block pool tests]") {
     block_pool_fixture instance(0);
     auto const block1 = make_block(1, 42);
     auto const block2 = make_block(2, 43, block1);
@@ -432,7 +432,7 @@ TEST_CASE("block pool  exists  not empty mismatch  false", "[block pool tests]")
     REQUIRE( ! instance.exists(block2));
 }
 
-TEST_CASE("block pool  exists  match  true", "[block pool tests]") {
+TEST_CASE("block pool exists match true", "[block pool tests]") {
     block_pool_fixture instance(0);
     auto const block1 = make_block(1, 42);
     instance.add(block1);
@@ -441,13 +441,13 @@ TEST_CASE("block pool  exists  match  true", "[block pool tests]") {
 
 // parent
 
-TEST_CASE("block pool  parent  empty  false", "[block pool tests]") {
+TEST_CASE("block pool parent empty false", "[block pool tests]") {
     block_pool_fixture instance(0);
     auto const block1 = make_block(1, 42);
     REQUIRE( ! instance.parent(block1));
 }
 
-TEST_CASE("block pool  parent  nonempty mismatch   false", "[block pool tests]") {
+TEST_CASE("block pool parent nonempty mismatch false", "[block pool tests]") {
     block_pool_fixture instance(0);
     auto const block1 = make_block(1, 42);
     auto const block2 = make_block(2, 43);
@@ -456,7 +456,7 @@ TEST_CASE("block pool  parent  nonempty mismatch   false", "[block pool tests]")
     REQUIRE( ! instance.parent(block2));
 }
 
-TEST_CASE("block pool  parent  match   true", "[block pool tests]") {
+TEST_CASE("block pool parent match true", "[block pool tests]") {
     block_pool_fixture instance(0);
     auto const block1 = make_block(1, 42);
     auto const block2 = make_block(2, 43, block1);
@@ -467,7 +467,7 @@ TEST_CASE("block pool  parent  match   true", "[block pool tests]") {
 
 // get_path
 
-TEST_CASE("block pool  get path  empty  self", "[block pool tests]") {
+TEST_CASE("block pool get path empty self", "[block pool tests]") {
     block_pool instance(0);
     auto const block1 = make_block(1, 42);
     auto const path = instance.get_path(block1);
@@ -475,7 +475,7 @@ TEST_CASE("block pool  get path  empty  self", "[block pool tests]") {
     REQUIRE(path->blocks()->front() == block1);
 }
 
-TEST_CASE("block pool  get path  exists  empty", "[block pool tests]") {
+TEST_CASE("block pool get path exists empty", "[block pool tests]") {
     block_pool instance(0);
     auto const block1 = make_block(1, 42);
     instance.add(block1);
@@ -483,7 +483,7 @@ TEST_CASE("block pool  get path  exists  empty", "[block pool tests]") {
     REQUIRE(path->size() == 0u);
 }
 
-TEST_CASE("block pool  get path  disconnected  self", "[block pool tests]") {
+TEST_CASE("block pool get path disconnected self", "[block pool tests]") {
     block_pool_fixture instance(0);
     auto const block1 = make_block(1, 42);
     auto const block2 = make_block(2, 43);
@@ -498,7 +498,7 @@ TEST_CASE("block pool  get path  disconnected  self", "[block pool tests]") {
     REQUIRE(path->blocks()->front() == block3);
 }
 
-TEST_CASE("block pool  get path  connected one path  expected path", "[block pool tests]") {
+TEST_CASE("block pool get path connected one path expected path", "[block pool tests]") {
     block_pool_fixture instance(0);
     auto const block1 = make_block(1, 42);
     auto const block2 = make_block(2, 43, block1);
@@ -521,7 +521,7 @@ TEST_CASE("block pool  get path  connected one path  expected path", "[block poo
     REQUIRE((*path->blocks())[4] == block5);
 }
 
-TEST_CASE("block pool  get path  connected multiple paths  expected path", "[block pool tests]") {
+TEST_CASE("block pool get path connected multiple paths expected path", "[block pool tests]") {
     block_pool_fixture instance(0);
 
     auto const block1 = make_block(1, 42);
@@ -565,7 +565,7 @@ TEST_CASE("block pool  get path  connected multiple paths  expected path", "[blo
     REQUIRE((*path2->blocks())[4] == block15);
 }
 
-TEST_CASE("block pool  get path  connected multiple sub branches  expected path", "[block pool tests]") {
+TEST_CASE("block pool get path connected multiple sub branches expected path", "[block pool tests]") {
     block_pool_fixture instance(0);
 
     // root branch

--- a/src/blockchain/test/branch.cpp
+++ b/src/blockchain/test/branch.cpp
@@ -35,12 +35,12 @@ public:
 
 // hash
 
-TEST_CASE("branch  hash  default  null hash", "[branch tests]") {
+TEST_CASE("branch hash default null hash", "[branch tests]") {
     branch instance;
     REQUIRE(instance.hash() == null_hash);
 }
 
-TEST_CASE("branch  hash  one block  only previous block hash", "[branch tests]") {
+TEST_CASE("branch hash one block only previous block hash", "[branch tests]") {
     DECLARE_BLOCK(block, 0);
     DECLARE_BLOCK(block, 1);
 
@@ -52,7 +52,7 @@ TEST_CASE("branch  hash  one block  only previous block hash", "[branch tests]")
     REQUIRE(instance.hash() == expected);
 }
 
-TEST_CASE("branch  hash  two blocks  first previous block hash", "[branch tests]") {
+TEST_CASE("branch hash two blocks first previous block hash", "[branch tests]") {
     branch instance;
     DECLARE_BLOCK(top, 42);
     DECLARE_BLOCK(block, 0);
@@ -70,12 +70,12 @@ TEST_CASE("branch  hash  two blocks  first previous block hash", "[branch tests]
 
 // height/set_height
 
-TEST_CASE("branch  height  default  zero", "[branch tests]") {
+TEST_CASE("branch height default zero", "[branch tests]") {
     branch instance;
     REQUIRE(instance.height() == 0);
 }
 
-TEST_CASE("branch  set height  round trip  unchanged", "[branch tests]") {
+TEST_CASE("branch set height round trip unchanged", "[branch tests]") {
     static size_t const expected = 42;
     branch instance;
     instance.set_height(expected);
@@ -84,19 +84,19 @@ TEST_CASE("branch  set height  round trip  unchanged", "[branch tests]") {
 
 // index_of
 
-TEST_CASE("branch  index of  one  zero", "[branch tests]") {
+TEST_CASE("branch index of one zero", "[branch tests]") {
     branch_fixture instance;
     instance.set_height(0);
     REQUIRE(instance.index_of(1) == 0u);
 }
 
-TEST_CASE("branch  index of  two  one", "[branch tests]") {
+TEST_CASE("branch index of two one", "[branch tests]") {
     branch_fixture instance;
     instance.set_height(0);
     REQUIRE(instance.index_of(2) == 1u);
 }
 
-TEST_CASE("branch  index of  value  expected", "[branch tests]") {
+TEST_CASE("branch index of value expected", "[branch tests]") {
     branch_fixture instance;
     instance.set_height(42);
     REQUIRE(instance.index_of(53) == 10u);
@@ -104,19 +104,19 @@ TEST_CASE("branch  index of  value  expected", "[branch tests]") {
 
 // height_at
 
-TEST_CASE("branch  height at  zero  one", "[branch tests]") {
+TEST_CASE("branch height at zero one", "[branch tests]") {
     branch_fixture instance;
     instance.set_height(0);
     REQUIRE(instance.height_at(0) == 1u);
 }
 
-TEST_CASE("branch  height at  one  two", "[branch tests]") {
+TEST_CASE("branch height at one two", "[branch tests]") {
     branch_fixture instance;
     instance.set_height(0);
     REQUIRE(instance.height_at(1) == 2u);
 }
 
-TEST_CASE("branch  height at  value  expected", "[branch tests]") {
+TEST_CASE("branch height at value expected", "[branch tests]") {
     branch_fixture instance;
     instance.set_height(42);
     REQUIRE(instance.height_at(10) == 53u);
@@ -124,19 +124,19 @@ TEST_CASE("branch  height at  value  expected", "[branch tests]") {
 
 // size
 
-TEST_CASE("branch  size  empty  zero", "[branch tests]") {
+TEST_CASE("branch size empty zero", "[branch tests]") {
     branch instance;
     REQUIRE(instance.size() == 0);
 }
 
 // empty
 
-TEST_CASE("branch  empty  default  true", "[branch tests]") {
+TEST_CASE("branch empty default true", "[branch tests]") {
     branch instance;
     REQUIRE(instance.empty());
 }
 
-TEST_CASE("branch  empty  push one  false", "[branch tests]") {
+TEST_CASE("branch empty push one false", "[branch tests]") {
     branch instance;
     DECLARE_BLOCK(block, 0);
     REQUIRE(instance.push_front(block0));
@@ -145,12 +145,12 @@ TEST_CASE("branch  empty  push one  false", "[branch tests]") {
 
 // blocks
 
-TEST_CASE("branch  blocks  default  empty", "[branch tests]") {
+TEST_CASE("branch blocks default empty", "[branch tests]") {
     branch instance;
     REQUIRE(instance.blocks()->empty());
 }
 
-TEST_CASE("branch  blocks  one  empty", "[branch tests]") {
+TEST_CASE("branch blocks one empty", "[branch tests]") {
     branch instance;
     DECLARE_BLOCK(block, 0);
     REQUIRE(instance.push_front(block0));
@@ -160,7 +160,7 @@ TEST_CASE("branch  blocks  one  empty", "[branch tests]") {
 
 // push_front
 
-TEST_CASE("branch  push front  one  success", "[branch tests]") {
+TEST_CASE("branch push front one success", "[branch tests]") {
     branch_fixture instance;
     DECLARE_BLOCK(block, 0);
     REQUIRE(instance.push_front(block0));
@@ -169,7 +169,7 @@ TEST_CASE("branch  push front  one  success", "[branch tests]") {
     REQUIRE((*instance.blocks())[0] == block0);
 }
 
-TEST_CASE("branch  push front  two linked  success", "[branch tests]") {
+TEST_CASE("branch push front two linked success", "[branch tests]") {
     branch_fixture instance;
     DECLARE_BLOCK(block, 0);
     DECLARE_BLOCK(block, 1);
@@ -184,7 +184,7 @@ TEST_CASE("branch  push front  two linked  success", "[branch tests]") {
     REQUIRE((*instance.blocks())[1] == block1);
 }
 
-TEST_CASE("branch  push front  two unlinked  link failure", "[branch tests]") {
+TEST_CASE("branch push front two unlinked link failure", "[branch tests]") {
     branch_fixture instance;
     DECLARE_BLOCK(block, 0);
     DECLARE_BLOCK(block, 1);
@@ -200,12 +200,12 @@ TEST_CASE("branch  push front  two unlinked  link failure", "[branch tests]") {
 
 // top
 
-TEST_CASE("branch  top  default  nullptr", "[branch tests]") {
+TEST_CASE("branch top default nullptr", "[branch tests]") {
     branch instance;
     REQUIRE( ! instance.top());
 }
 
-TEST_CASE("branch  top  two blocks  expected", "[branch tests]") {
+TEST_CASE("branch top two blocks expected", "[branch tests]") {
     branch_fixture instance;
     DECLARE_BLOCK(block, 0);
     DECLARE_BLOCK(block, 1);
@@ -221,12 +221,12 @@ TEST_CASE("branch  top  two blocks  expected", "[branch tests]") {
 
 // top_height
 
-TEST_CASE("branch  top height  default  0", "[branch tests]") {
+TEST_CASE("branch top height default 0", "[branch tests]") {
     branch instance;
     REQUIRE(instance.top_height() == 0u);
 }
 
-TEST_CASE("branch  top height  two blocks  expected", "[branch tests]") {
+TEST_CASE("branch top height two blocks expected", "[branch tests]") {
     branch_fixture instance;
     DECLARE_BLOCK(block, 0);
     DECLARE_BLOCK(block, 1);
@@ -245,12 +245,12 @@ TEST_CASE("branch  top height  two blocks  expected", "[branch tests]") {
 
 // work
 
-TEST_CASE("branch  work  default  zero", "[branch tests]") {
+TEST_CASE("branch work default zero", "[branch tests]") {
     branch instance;
     REQUIRE(instance.work() == 0);
 }
 
-TEST_CASE("branch  work  two blocks  expected", "[branch tests]") {
+TEST_CASE("branch work two blocks expected", "[branch tests]") {
     branch instance;
     DECLARE_BLOCK(block, 0);
     DECLARE_BLOCK(block, 1);

--- a/src/blockchain/test/mempool_tests.cpp
+++ b/src/blockchain/test/mempool_tests.cpp
@@ -39,17 +39,15 @@ void add_state(transaction& tx) {
 }
 
 transaction get_tx(std::string const& hex) {
-    data_chunk data;
-    decode_base16(data, hex);
-    auto tx = transaction::factory_from_data(data);
+    auto const data = decode_base16(hex);
+    auto tx = transaction::factory_from_data(*data);
     add_state(tx);
     return tx;
 }
 
 transaction get_tx_from_mempool(mining::mempool const& mp, std::unordered_map<domain::chain::point, domain::chain::output> const& internal_utxo, std::string const& hex) {
-    data_chunk data;
-    decode_base16(data, hex);
-    auto tx = transaction::factory_from_data(data);
+    auto const data = decode_base16(hex);
+    auto tx = transaction::factory_from_data(*data);
     add_state(tx);
 
     for (auto& i : tx.inputs()) {
@@ -76,9 +74,8 @@ transaction get_tx_from_mempool(mining::mempool const& mp, std::unordered_map<do
 }
 
 domain::chain::block get_block(std::string const& hex) {
-    data_chunk data;
-    decode_base16(data, hex);
-    auto blk = domain::chain::block::factory_from_data(data);
+    auto const data = decode_base16(hex);
+    auto blk = domain::chain::block::factory_from_data(*data);
     // add_state(tx);
     return blk;
 }

--- a/src/blockchain/test/utxo.cpp
+++ b/src/blockchain/test/utxo.cpp
@@ -83,10 +83,10 @@ bool create_database(database::settings& out_database) {
 }
 
 domain::chain::block read_block(const std::string hex) {
-    data_chunk data;
-    REQUIRE(decode_base16(data, hex));
+    auto const data = decode_base16(hex);
+    REQUIRE(data);
     domain::chain::block result;
-    REQUIRE(kd::entity_from_data(result, data));
+    REQUIRE(kd::entity_from_data(result, *data));
     return result;
 }
 

--- a/src/blockchain/test/validate_block.cpp
+++ b/src/blockchain/test/validate_block.cpp
@@ -12,7 +12,7 @@ using namespace kd::machine;
 
 // Start Test Suite: validate block tests
 
-TEST_CASE("validate block  native  block 438513 tx  valid", "[validate block tests]") {
+TEST_CASE("validate block native block 438513 tx valid", "[validate block tests]") {
     //// DEBUG [blockchain] Input validation failed (stack false)
     //// forks        : 62
     //// outpoint     : 8e51d775e0896e03149d585c0655b3001da0c55068b0885139ac6ec34cf76ba0:0
@@ -25,20 +25,20 @@ TEST_CASE("validate block  native  block 438513 tx  valid", "[validate block tes
     static auto const encoded_script = "a914faa558780a5767f9e3be14992a578fc1cbcf483087";
     static auto const encoded_tx = "0100000001a06bf74cc36eac395188b06850c5a01d00b355065c589d14036e89e075d7518e000000009d483045022100ba555ac17a084e2a1b621c2171fa563bc4fb75cd5c0968153f44ba7203cb876f022036626f4579de16e3ad160df01f649ffb8dbf47b504ee56dc3ad7260af24ca0db0101004c50632102768e47607c52e581595711e27faffa7cb646b4f481fe269bd49691b2fbc12106ad6704355e2658b1756821028a5af8284a12848d69a25a0ac5cea20be905848eb645fd03d3b065df88a9117cacfeffffff0158920100000000001976a9149d86f66406d316d44d58cbf90d71179dd8162dd388ac355e2658";
 
-    data_chunk decoded_tx;
-    REQUIRE(decode_base16(decoded_tx, encoded_tx));
+    auto const decoded_tx = decode_base16(encoded_tx);
+    REQUIRE(decoded_tx);
 
-    data_chunk decoded_script;
-    REQUIRE(decode_base16(decoded_script, encoded_script));
+    auto const decoded_script = decode_base16(encoded_script);
+    REQUIRE(decoded_script);
 
     transaction tx;
-    REQUIRE(kd::entity_from_data(tx, decoded_tx));
+    REQUIRE(kd::entity_from_data(tx, *decoded_tx));
 
     auto const& input = tx.inputs()[index];
     auto& prevout = input.previous_output().validation.cache;
 
     prevout.set_value(0);
-    prevout.set_script(kd::create<script>(decoded_script, false));
+    prevout.set_script(kd::create<script>(*decoded_script, false));
 
     REQUIRE(prevout.script().is_valid());
 
@@ -49,7 +49,7 @@ TEST_CASE("validate block  native  block 438513 tx  valid", "[validate block tes
 }
 
 #if defined(KTH_CURRENCY_BCH)
-TEST_CASE("validate block  native  block 520679 tx  valid", "[validate block tests]") {
+TEST_CASE("validate block native block 520679 tx valid", "[validate block tests]") {
     //// DEBUG [blockchain] Input validation failed (stack false)
     //// forks        : 62 (?)
     //// outpoint     : dae852c88a00e95141cfe924ac6667a91af87431988d23eff268ea3509d6d83c:1
@@ -69,20 +69,20 @@ TEST_CASE("validate block  native  block 520679 tx  valid", "[validate block tes
     native_forks |= domain::machine::rule_fork::bch_uahf;
     native_forks |= domain::machine::rule_fork::bch_daa_cw144;
 
-    data_chunk decoded_tx;
-    REQUIRE(decode_base16(decoded_tx, encoded_tx));
+    auto const decoded_tx = decode_base16(encoded_tx);
+    REQUIRE(decoded_tx);
 
-    data_chunk decoded_script;
-    REQUIRE(decode_base16(decoded_script, encoded_script));
+    auto const decoded_script = decode_base16(encoded_script);
+    REQUIRE(decoded_script);
 
     transaction tx;
-    REQUIRE(kd::entity_from_data(tx, decoded_tx));
+    REQUIRE(kd::entity_from_data(tx, *decoded_tx));
 
     auto const& input = tx.inputs()[index];
     auto& prevout = input.previous_output().validation.cache;
 
     prevout.set_value(25533210);
-    prevout.set_script(kd::create<script>(decoded_script, false));
+    prevout.set_script(kd::create<script>(*decoded_script, false));
     REQUIRE(prevout.script().is_valid());
 
     auto const result = validate_input::verify_script(tx, index, native_forks);
@@ -90,7 +90,7 @@ TEST_CASE("validate block  native  block 520679 tx  valid", "[validate block tes
 }
 
 
-TEST_CASE("validate block  2018NOV  block 520679 tx  valid", "[validate block tests]") {
+TEST_CASE("validate block 2018NOV block 520679 tx valid", "[validate block tests]") {
     //// DEBUG [blockchain] Input validation failed (stack false)
     // forks        : 1073973119
     // outpoint     : 208fc2edc6fbf4c6cf7fb3ac0c7a1cb23f88fc3ddcced6423ad02d429acb2d07:0
@@ -118,20 +118,20 @@ TEST_CASE("validate block  2018NOV  block 520679 tx  valid", "[validate block te
     native_forks |= domain::machine::rule_fork::bch_pisano;
     // native_forks |= domain::machine::rule_fork::cash_segwit_recovery;
 
-    data_chunk decoded_tx;
-    REQUIRE(decode_base16(decoded_tx, encoded_tx));
+    auto const decoded_tx = decode_base16(encoded_tx);
+    REQUIRE(decoded_tx);
 
-    data_chunk decoded_script;
-    REQUIRE(decode_base16(decoded_script, encoded_script));
+    auto const decoded_script = decode_base16(encoded_script);
+    REQUIRE(decoded_script);
 
     transaction tx;
-    REQUIRE(kd::entity_from_data(tx, decoded_tx));
+    REQUIRE(kd::entity_from_data(tx, *decoded_tx));
 
     auto const& input = tx.inputs()[index];
     auto& prevout = input.previous_output().validation.cache;
 
     prevout.set_value(value);
-    prevout.set_script(kd::create<script>(decoded_script, false));
+    prevout.set_script(kd::create<script>(*decoded_script, false));
     REQUIRE(prevout.script().is_valid());
 
     auto const result = validate_input::verify_script(tx, index, native_forks);

--- a/src/c-api/console/main.cpp
+++ b/src/c-api/console/main.cpp
@@ -703,10 +703,13 @@ int main(int /*argc*/, char* /*argv*/[]) {
 
     std::string raw = "0200000001ffecbd2b832ea847a7da905a40d5abaff8323cc18ff3121532f6fe781ce79f6e000000008b483045022100a26515b4bb5f3eb0259c0cc0806b4d8096f91a801ee9b15ced76f2537f7de94b02205becd631fe0ae232e4453f1b4a8a5375e4caec62e3971dbfe5a6d86b2538dcf64141044636673164f4b636d560cb4192cb07aa62054154f1a7a99a694b235f8fba56950b34e6ab55d58991470a13ca59330bc6339a2f72eb6f9204a64a1a538ddff4fbffffffff0290d00300000000001976a9144913233162944e9239637f998235d76e1601b1cf88ac80d1f008000000001976a914cc1d800e7f83edd96a0340a4e269b2956f636e3f88ac00000000";
 
-    kth::data_chunk chunk;
-    kth::decode_base16(chunk,raw);
+    auto chunk = kth::decode_base16(raw);
+    if (!chunk) {
+        printf("decode_base16 failed\n");
+        return 0;
+    }
 
-    kth_transaction_t tx = kth_chain_transaction_factory_from_data(1,chunk.data(),chunk.size());
+    kth_transaction_t tx = kth_chain_transaction_factory_from_data(1,chunk->data(),chunk->size());
 
 
     auto ret = kth_chain_organize_transaction_sync(chain,tx);

--- a/src/c-api/console/print_headers.cpp
+++ b/src/c-api/console/print_headers.cpp
@@ -506,10 +506,13 @@ int main(int /*argc*/, char* /*argv*/[]) {
 
     std::string raw = "0200000001ffecbd2b832ea847a7da905a40d5abaff8323cc18ff3121532f6fe781ce79f6e000000008b483045022100a26515b4bb5f3eb0259c0cc0806b4d8096f91a801ee9b15ced76f2537f7de94b02205becd631fe0ae232e4453f1b4a8a5375e4caec62e3971dbfe5a6d86b2538dcf64141044636673164f4b636d560cb4192cb07aa62054154f1a7a99a694b235f8fba56950b34e6ab55d58991470a13ca59330bc6339a2f72eb6f9204a64a1a538ddff4fbffffffff0290d00300000000001976a9144913233162944e9239637f998235d76e1601b1cf88ac80d1f008000000001976a914cc1d800e7f83edd96a0340a4e269b2956f636e3f88ac00000000";
 
-    kth::data_chunk chunk;
-    kth::decode_base16(chunk,raw);
+    auto chunk = kth::decode_base16(raw);
+    if (!chunk) {
+        printf("decode_base16 failed\n");
+        return 0;
+    }
 
-    kth_transaction_t tx = kth_chain_transaction_factory_from_data(1,chunk.data(),chunk.size());
+    kth_transaction_t tx = kth_chain_transaction_factory_from_data(1,chunk->data(),chunk->size());
 
 
     auto ret = kth_chain_organize_transaction_sync(chain,tx);

--- a/src/c-api/console/test_2025_issue.cpp
+++ b/src/c-api/console/test_2025_issue.cpp
@@ -44,9 +44,11 @@ void print_hex(uint8_t const* data, size_t n) {
 }
 
 kth::data_chunk to_data(std::string const& hex) {
-    kth::data_chunk data;
-    kth::decode_base16(data, hex);
-    return data;
+    auto data = kth::decode_base16(hex);
+    if (!data) {
+        return kth::data_chunk{};
+    }
+    return *data;
 }
 
 int main() {

--- a/src/consensus/test/consensus__script_error_to_verify_result.cpp
+++ b/src/consensus/test/consensus__script_error_to_verify_result.cpp
@@ -16,7 +16,7 @@ using namespace kth::consensus;
 
 // Logical result
 
-TEST_CASE("consensus script error to verify result OK  eval true", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result OK eval true", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::OK) == verify_result_eval_true);
 #else
@@ -24,7 +24,7 @@ TEST_CASE("consensus script error to verify result OK  eval true", "[consensus s
 #endif
 }
 
-TEST_CASE("consensus script error to verify result EVAL FALSE  eval false", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result EVAL FALSE eval false", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::EVAL_FALSE) == verify_result_eval_false);
 #else
@@ -34,7 +34,7 @@ TEST_CASE("consensus script error to verify result EVAL FALSE  eval false", "[co
 
 // Max size errors.
 
-TEST_CASE("consensus script error to verify result SCRIPT SIZE  script size", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result SCRIPT SIZE script size", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::SCRIPT_SIZE) == verify_result_script_size);
 #else
@@ -42,7 +42,7 @@ TEST_CASE("consensus script error to verify result SCRIPT SIZE  script size", "[
 #endif
 }
 
-TEST_CASE("consensus script error to verify result PUSH SIZE  push size", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result PUSH SIZE push size", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::PUSH_SIZE) == verify_result_push_size);
 #else
@@ -50,7 +50,7 @@ TEST_CASE("consensus script error to verify result PUSH SIZE  push size", "[cons
 #endif
 }
 
-TEST_CASE("consensus script error to verify result OP COUNT  op count", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result OP COUNT op count", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::OP_COUNT) == verify_result_op_count);
 #else
@@ -58,7 +58,7 @@ TEST_CASE("consensus script error to verify result OP COUNT  op count", "[consen
 #endif
 }
 
-TEST_CASE("consensus script error to verify result STACK SIZE  stack size", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result STACK SIZE stack size", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::STACK_SIZE) == verify_result_stack_size);
 #else
@@ -66,7 +66,7 @@ TEST_CASE("consensus script error to verify result STACK SIZE  stack size", "[co
 #endif
 }
 
-TEST_CASE("consensus script error to verify result SIG COUNT  sig count", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result SIG COUNT sig count", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::SIG_COUNT) == verify_result_sig_count);
 #else
@@ -74,7 +74,7 @@ TEST_CASE("consensus script error to verify result SIG COUNT  sig count", "[cons
 #endif
 }
 
-TEST_CASE("consensus script error to verify result PUBKEY COUNT  pubkey count", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result PUBKEY COUNT pubkey count", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::PUBKEY_COUNT) == verify_result_pubkey_count);
 #else
@@ -84,7 +84,7 @@ TEST_CASE("consensus script error to verify result PUBKEY COUNT  pubkey count", 
 
 // Failed verify operations
 
-TEST_CASE("consensus script error to verify result VERIFY  verify", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result VERIFY verify", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::VERIFY) == verify_result_verify);
 #else
@@ -92,7 +92,7 @@ TEST_CASE("consensus script error to verify result VERIFY  verify", "[consensus 
 #endif
 }
 
-TEST_CASE("consensus script error to verify result EQUALVERIFY  equalverify", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result EQUALVERIFY equalverify", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::EQUALVERIFY) == verify_result_equalverify);
 #else
@@ -100,7 +100,7 @@ TEST_CASE("consensus script error to verify result EQUALVERIFY  equalverify", "[
 #endif
 }
 
-TEST_CASE("consensus script error to verify result CHECKMULTISIGVERIFY  checkmultisigverify", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result CHECKMULTISIGVERIFY checkmultisigverify", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::CHECKMULTISIGVERIFY) == verify_result_checkmultisigverify);
 #else
@@ -108,7 +108,7 @@ TEST_CASE("consensus script error to verify result CHECKMULTISIGVERIFY  checkmul
 #endif
 }
 
-TEST_CASE("consensus script error to verify result CHECKSIGVERIFY  checksigverify", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result CHECKSIGVERIFY checksigverify", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::CHECKSIGVERIFY) == verify_result_checksigverify);
 #else
@@ -116,7 +116,7 @@ TEST_CASE("consensus script error to verify result CHECKSIGVERIFY  checksigverif
 #endif
 }
 
-TEST_CASE("consensus script error to verify result NUMEQUALVERIFY  numequalverify", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result NUMEQUALVERIFY numequalverify", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::NUMEQUALVERIFY) == verify_result_numequalverify);
 #else
@@ -126,7 +126,7 @@ TEST_CASE("consensus script error to verify result NUMEQUALVERIFY  numequalverif
 
 // Logical/Format/Canonical errors
 
-TEST_CASE("consensus script error to verify result BAD OPCODE  bad opcode", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result BAD OPCODE bad opcode", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::BAD_OPCODE) == verify_result_bad_opcode);
 #else
@@ -134,7 +134,7 @@ TEST_CASE("consensus script error to verify result BAD OPCODE  bad opcode", "[co
 #endif
 }
 
-TEST_CASE("consensus script error to verify result DISABLED OPCODE  disabled opcode", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result DISABLED OPCODE disabled opcode", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::DISABLED_OPCODE) == verify_result_disabled_opcode);
 #else
@@ -142,7 +142,7 @@ TEST_CASE("consensus script error to verify result DISABLED OPCODE  disabled opc
 #endif
 }
 
-TEST_CASE("consensus script error to verify result INVALID STACK OPERATION  invalid stack operation", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result INVALID STACK OPERATION invalid stack operation", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::INVALID_STACK_OPERATION) == verify_result_invalid_stack_operation);
 #else
@@ -150,7 +150,7 @@ TEST_CASE("consensus script error to verify result INVALID STACK OPERATION  inva
 #endif
 }
 
-TEST_CASE("consensus script error to verify result INVALID ALTSTACK OPERATION  invalid altstack operation", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result INVALID ALTSTACK OPERATION invalid altstack operation", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::INVALID_ALTSTACK_OPERATION) == verify_result_invalid_altstack_operation);
 #else
@@ -158,7 +158,7 @@ TEST_CASE("consensus script error to verify result INVALID ALTSTACK OPERATION  i
 #endif
 }
 
-TEST_CASE("consensus script error to verify result UNBALANCED CONDITIONAL  unbalanced conditional", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result UNBALANCED CONDITIONAL unbalanced conditional", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::UNBALANCED_CONDITIONAL) == verify_result_unbalanced_conditional);
 #else
@@ -168,7 +168,7 @@ TEST_CASE("consensus script error to verify result UNBALANCED CONDITIONAL  unbal
 
 // BIP65
 
-TEST_CASE("consensus script error to verify result NEGATIVE LOCKTIME  sig hashtype", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result NEGATIVE LOCKTIME sig hashtype", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::NEGATIVE_LOCKTIME) == verify_result_negative_locktime);
 #else
@@ -176,7 +176,7 @@ TEST_CASE("consensus script error to verify result NEGATIVE LOCKTIME  sig hashty
 #endif
 }
 
-TEST_CASE("consensus script error to verify result ERR UNSATISFIED LOCKTIME  err sig der", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result ERR UNSATISFIED LOCKTIME err sig der", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::UNSATISFIED_LOCKTIME) == verify_result_unsatisfied_locktime);
 #else
@@ -186,7 +186,7 @@ TEST_CASE("consensus script error to verify result ERR UNSATISFIED LOCKTIME  err
 
 // BIP62
 
-TEST_CASE("consensus script error to verify result SIG HASHTYPE  sig hashtype", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result SIG HASHTYPE sig hashtype", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::SIG_HASHTYPE) == verify_result_sig_hashtype);
 #else
@@ -194,7 +194,7 @@ TEST_CASE("consensus script error to verify result SIG HASHTYPE  sig hashtype", 
 #endif
 }
 
-TEST_CASE("consensus script error to verify result ERR SIG DER  err sig der", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result ERR SIG DER err sig der", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::SIG_DER) == verify_result_sig_der);
 #else
@@ -202,7 +202,7 @@ TEST_CASE("consensus script error to verify result ERR SIG DER  err sig der", "[
 #endif
 }
 
-TEST_CASE("consensus script error to verify result ERR MINIMALDATA  err minimaldata", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result ERR MINIMALDATA err minimaldata", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::MINIMALDATA) == verify_result_minimaldata);
 #else
@@ -210,7 +210,7 @@ TEST_CASE("consensus script error to verify result ERR MINIMALDATA  err minimald
 #endif
 }
 
-TEST_CASE("consensus script error to verify result SIG PUSHONLY  sig pushonly", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result SIG PUSHONLY sig pushonly", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::SIG_PUSHONLY) == verify_result_sig_pushonly);
 #else
@@ -218,7 +218,7 @@ TEST_CASE("consensus script error to verify result SIG PUSHONLY  sig pushonly", 
 #endif
 }
 
-TEST_CASE("consensus script error to verify result SIG HIGH S  sig high s", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result SIG HIGH S sig high s", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::SIG_HIGH_S) == verify_result_sig_high_s);
 #else
@@ -227,12 +227,12 @@ TEST_CASE("consensus script error to verify result SIG HIGH S  sig high s", "[co
 }
 
 #if ! defined(KTH_CURRENCY_BCH)         //BIP 147
-TEST_CASE("consensus script error to verify result SIG NULLDUMMY  sig nulldummy", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result SIG NULLDUMMY sig nulldummy", "[consensus script error to verify result]") {
     REQUIRE(script_error_to_verify_result(SCRIPT_ERR_SIG_NULLDUMMY) == verify_result_sig_nulldummy);
 }
 #endif
 
-TEST_CASE("consensus script error to verify result PUBKEYTYPE  pubkeytype", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result PUBKEYTYPE pubkeytype", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::PUBKEYTYPE) == verify_result_pubkeytype);
 #else
@@ -240,7 +240,7 @@ TEST_CASE("consensus script error to verify result PUBKEYTYPE  pubkeytype", "[co
 #endif
 }
 
-TEST_CASE("consensus script error to verify result CLEANSTACK  cleanstack", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result CLEANSTACK cleanstack", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::CLEANSTACK) == verify_result_cleanstack);
 #else
@@ -248,7 +248,7 @@ TEST_CASE("consensus script error to verify result CLEANSTACK  cleanstack", "[co
 #endif
 }
 
-TEST_CASE("consensus script error to verify result MINIMALIF  minimalif", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result MINIMALIF minimalif", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::MINIMALIF) == verify_result_minimalif);
 #else
@@ -256,7 +256,7 @@ TEST_CASE("consensus script error to verify result MINIMALIF  minimalif", "[cons
 #endif
 }
 
-TEST_CASE("consensus script error to verify result SIG NULLFAIL  nullfail", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result SIG NULLFAIL nullfail", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::SIG_NULLFAIL) == verify_result_sig_nullfail);
 #else
@@ -266,7 +266,7 @@ TEST_CASE("consensus script error to verify result SIG NULLFAIL  nullfail", "[co
 
 // Softfork safeness
 
-TEST_CASE("consensus script error to verify result  DISCOURAGE UPGRADABLE NOPS   discourage upgradable nops", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result DISCOURAGE UPGRADABLE NOPS discourage upgradable nops", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::DISCOURAGE_UPGRADABLE_NOPS) == verify_result_discourage_upgradable_nops);
 #else
@@ -275,44 +275,44 @@ TEST_CASE("consensus script error to verify result  DISCOURAGE UPGRADABLE NOPS  
 }
 
 #if ! defined(KTH_CURRENCY_BCH)
-TEST_CASE("consensus script error to verify result  DISCOURAGE UPGRADABLE WITNESS PROGRAM   discourage upgradable witness program", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result DISCOURAGE UPGRADABLE WITNESS PROGRAM discourage upgradable witness program", "[consensus script error to verify result]") {
     REQUIRE(script_error_to_verify_result(SCRIPT_ERR_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM) == verify_result_discourage_upgradable_witness_program);
 }
 
 // Segregated witness
 
-TEST_CASE("consensus script error to verify result  WITNESS PROGRAM WRONG LENGTH   witness program wrong length", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result WITNESS PROGRAM WRONG LENGTH witness program wrong length", "[consensus script error to verify result]") {
     REQUIRE(script_error_to_verify_result(SCRIPT_ERR_WITNESS_PROGRAM_WRONG_LENGTH) == verify_result_witness_program_wrong_length);
 }
 
-TEST_CASE("consensus script error to verify result  WITNESS PROGRAM WITNESS EMPTY   witness program empty witness", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result WITNESS PROGRAM WITNESS EMPTY witness program empty witness", "[consensus script error to verify result]") {
     REQUIRE(script_error_to_verify_result(SCRIPT_ERR_WITNESS_PROGRAM_WITNESS_EMPTY) == verify_result_witness_program_empty_witness);
 }
 
-TEST_CASE("consensus script error to verify result  WITNESS PROGRAM MISMATCH   witness program mismatch", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result WITNESS PROGRAM MISMATCH witness program mismatch", "[consensus script error to verify result]") {
     REQUIRE(script_error_to_verify_result(SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH) == verify_result_witness_program_mismatch);
 }
 
-TEST_CASE("consensus script error to verify result  WITNESS MALLEATED   witness malleated", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result WITNESS MALLEATED witness malleated", "[consensus script error to verify result]") {
     REQUIRE(script_error_to_verify_result(SCRIPT_ERR_WITNESS_MALLEATED) == verify_result_witness_malleated);
 }
 
-TEST_CASE("consensus script error to verify result  WITNESS MALLEATED P2SH   witness malleated p2sh", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result WITNESS MALLEATED P2SH witness malleated p2sh", "[consensus script error to verify result]") {
     REQUIRE(script_error_to_verify_result(SCRIPT_ERR_WITNESS_MALLEATED_P2SH) == verify_result_witness_malleated_p2sh);
 }
 
-TEST_CASE("consensus script error to verify result  WITNESS UNEXPECTED   witness unexpected", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result WITNESS UNEXPECTED witness unexpected", "[consensus script error to verify result]") {
     REQUIRE(script_error_to_verify_result(SCRIPT_ERR_WITNESS_UNEXPECTED) == verify_result_witness_unexpected);
 }
 
-TEST_CASE("consensus script error to verify result  WITNESS PUBKEYTYPE   witness pubkeytype", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result WITNESS PUBKEYTYPE witness pubkeytype", "[consensus script error to verify result]") {
     REQUIRE(script_error_to_verify_result(SCRIPT_ERR_WITNESS_PUBKEYTYPE) == verify_result_witness_pubkeytype);
 }
 #endif
 
 // Other
 
-TEST_CASE("consensus script error to verify result OP RETURN  op return", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result OP RETURN op return", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::OP_RETURN) == verify_result_op_return);
 #else
@@ -320,7 +320,7 @@ TEST_CASE("consensus script error to verify result OP RETURN  op return", "[cons
 #endif
 }
 
-TEST_CASE("consensus script error to verify result UNKNOWN ERROR  unknown error", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result UNKNOWN ERROR unknown error", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::UNKNOWN) == verify_result_unknown_error);
 #else
@@ -328,7 +328,7 @@ TEST_CASE("consensus script error to verify result UNKNOWN ERROR  unknown error"
 #endif
 }
 
-TEST_CASE("consensus script error to verify result ERROR COUNT  unknown error", "[consensus script error to verify result]") {
+TEST_CASE("consensus script error to verify result ERROR COUNT unknown error", "[consensus script error to verify result]") {
 #if defined(KTH_CURRENCY_BCH)
     REQUIRE(script_error_to_verify_result(ScriptError::ERROR_COUNT) == verify_result_unknown_error);
 #else

--- a/src/consensus/test/consensus__verify_flags_to_script_flags.cpp
+++ b/src/consensus/test/consensus__verify_flags_to_script_flags.cpp
@@ -16,62 +16,62 @@ using namespace kth::consensus;
 
 // Unnamed enum values require cast for boost comparison macros.
 
-TEST_CASE("consensus verify flags to script flags none  NONE", "[consensus verify flags to script flags]") {
+TEST_CASE("consensus verify flags to script flags none NONE", "[consensus verify flags to script flags]") {
     REQUIRE(verify_flags_to_script_flags(verify_flags_none) == (uint32_t)SCRIPT_VERIFY_NONE);
 }
 
-TEST_CASE("consensus verify flags to script flags p2sh  P2SH", "[consensus verify flags to script flags]") {
+TEST_CASE("consensus verify flags to script flags p2sh P2SH", "[consensus verify flags to script flags]") {
     REQUIRE(verify_flags_to_script_flags(verify_flags_p2sh) == (uint32_t)SCRIPT_VERIFY_P2SH);
 }
 
-TEST_CASE("consensus verify flags to script flags strictenc  STRICTENC", "[consensus verify flags to script flags]") {
+TEST_CASE("consensus verify flags to script flags strictenc STRICTENC", "[consensus verify flags to script flags]") {
     REQUIRE(verify_flags_to_script_flags(verify_flags_strictenc) == (uint32_t)SCRIPT_VERIFY_STRICTENC);
 }
 
-TEST_CASE("consensus verify flags to script flags dersig  DERSIG", "[consensus verify flags to script flags]") {
+TEST_CASE("consensus verify flags to script flags dersig DERSIG", "[consensus verify flags to script flags]") {
     REQUIRE(verify_flags_to_script_flags(verify_flags_dersig) == (uint32_t)SCRIPT_VERIFY_DERSIG);
 }
 
-TEST_CASE("consensus verify flags to script flags low s  LOW S", "[consensus verify flags to script flags]") {
+TEST_CASE("consensus verify flags to script flags low s LOW S", "[consensus verify flags to script flags]") {
     REQUIRE(verify_flags_to_script_flags(verify_flags_low_s) == (uint32_t)SCRIPT_VERIFY_LOW_S);
 }
 
 #if ! defined(KTH_CURRENCY_BCH)
-TEST_CASE("consensus verify flags to script flags nulldummy  NULLDUMMY", "[consensus verify flags to script flags]") {
+TEST_CASE("consensus verify flags to script flags nulldummy NULLDUMMY", "[consensus verify flags to script flags]") {
     REQUIRE(verify_flags_to_script_flags(verify_flags_nulldummy) == (uint32_t)SCRIPT_VERIFY_NULLDUMMY);
 }
 #endif
 
-TEST_CASE("consensus verify flags to script flags sigpushonly  SIGPUSHONLY", "[consensus verify flags to script flags]") {
+TEST_CASE("consensus verify flags to script flags sigpushonly SIGPUSHONLY", "[consensus verify flags to script flags]") {
     REQUIRE(verify_flags_to_script_flags(verify_flags_sigpushonly) == (uint32_t)SCRIPT_VERIFY_SIGPUSHONLY);
 }
 
-TEST_CASE("consensus verify flags to script flags minimaldata  MINIMALDATA", "[consensus verify flags to script flags]") {
+TEST_CASE("consensus verify flags to script flags minimaldata MINIMALDATA", "[consensus verify flags to script flags]") {
     REQUIRE(verify_flags_to_script_flags(verify_flags_minimaldata) == (uint32_t)SCRIPT_VERIFY_MINIMALDATA);
 }
 
-TEST_CASE("consensus verify flags to script flags discourage upgradable nops  DISCOURAGE UPGRADABLE NOPS", "[consensus verify flags to script flags]") {
+TEST_CASE("consensus verify flags to script flags discourage upgradable nops DISCOURAGE UPGRADABLE NOPS", "[consensus verify flags to script flags]") {
     REQUIRE(verify_flags_to_script_flags(verify_flags_discourage_upgradable_nops) == (uint32_t)SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS);
 }
 
-TEST_CASE("consensus verify flags to script flags cleanstack  CLEANSTACK", "[consensus verify flags to script flags]") {
+TEST_CASE("consensus verify flags to script flags cleanstack CLEANSTACK", "[consensus verify flags to script flags]") {
     REQUIRE(verify_flags_to_script_flags(verify_flags_cleanstack) == (uint32_t)SCRIPT_VERIFY_CLEANSTACK);
 }
 
-TEST_CASE("consensus verify flags to script flags checklocktimeverify  CHECKLOCKTIMEVERIFY", "[consensus verify flags to script flags]") {
+TEST_CASE("consensus verify flags to script flags checklocktimeverify CHECKLOCKTIMEVERIFY", "[consensus verify flags to script flags]") {
     REQUIRE(verify_flags_to_script_flags(verify_flags_checklocktimeverify) == (uint32_t)SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY);
 }
 
-TEST_CASE("consensus verify flags to script flags checksequenceverify  CHECKSEQUENCEVERIFY", "[consensus verify flags to script flags]") {
+TEST_CASE("consensus verify flags to script flags checksequenceverify CHECKSEQUENCEVERIFY", "[consensus verify flags to script flags]") {
     REQUIRE(verify_flags_to_script_flags(verify_flags_checksequenceverify) == (uint32_t)SCRIPT_VERIFY_CHECKSEQUENCEVERIFY);
 }
 
 #if ! defined(KTH_CURRENCY_BCH)
-TEST_CASE("consensus verify flags to script flags witness  WITNESS", "[consensus verify flags to script flags]") {
+TEST_CASE("consensus verify flags to script flags witness WITNESS", "[consensus verify flags to script flags]") {
     REQUIRE(verify_flags_to_script_flags(verify_flags_witness) == (uint32_t)SCRIPT_VERIFY_WITNESS);
 }
 
-TEST_CASE("consensus verify flags to script flags discourage upgradable witness program  DISCOURAGE UPGRADABLE WITNESS PROGRAM", "[consensus verify flags to script flags]") {
+TEST_CASE("consensus verify flags to script flags discourage upgradable witness program DISCOURAGE UPGRADABLE WITNESS PROGRAM", "[consensus verify flags to script flags]") {
     REQUIRE(verify_flags_to_script_flags(verify_flags_discourage_upgradable_witness_program) == (uint32_t)SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM);
 }
 #endif
@@ -85,18 +85,18 @@ TEST_CASE("consensus verify flags to script flags null fail NULLFAIL", "[consens
 }
 
 #if ! defined(KTH_CURRENCY_BCH)
-TEST_CASE("consensus verify flags to script flags witness public key compressed  PUBKEYTYPE", "[consensus verify flags to script flags]") {
+TEST_CASE("consensus verify flags to script flags witness public key compressed PUBKEYTYPE", "[consensus verify flags to script flags]") {
     REQUIRE(verify_flags_to_script_flags(verify_flags_witness_public_key_compressed) == (uint32_t)SCRIPT_VERIFY_WITNESS_PUBKEYTYPE);
 }
 #endif
 
 #if ! defined(KTH_CURRENCY_BCH)
-TEST_CASE("consensus verify flags to script flags const scriptcode  SCRIPTCODE", "[consensus verify flags to script flags]") {
+TEST_CASE("consensus verify flags to script flags const scriptcode SCRIPTCODE", "[consensus verify flags to script flags]") {
     REQUIRE(verify_flags_to_script_flags(verify_flags_const_scriptcode) == (uint32_t)SCRIPT_VERIFY_CONST_SCRIPTCODE);
 }
 #endif
 
-TEST_CASE("consensus verify flags to script flags all  all", "[consensus verify flags to script flags]") {
+TEST_CASE("consensus verify flags to script flags all all", "[consensus verify flags to script flags]") {
     const uint32_t all_verify_flags =
           verify_flags_none
         | verify_flags_p2sh

--- a/src/database/test/data_base.cpp
+++ b/src/database/test/data_base.cpp
@@ -17,10 +17,10 @@ using namespace boost::system;
 using namespace std::filesystem;
 
 block read_block(const std::string hex) {
-    data_chunk data;
-    REQUIRE(decode_base16(data, hex));
+    auto const data = decode_base16(hex);
+    REQUIRE(data);
     block result;
-    REQUIRE(result.from_data(data));
+    REQUIRE(result.from_data(*data));
     return result;
 }
 

--- a/src/database/test/history_database.cpp
+++ b/src/database/test/history_database.cpp
@@ -34,7 +34,7 @@ BOOST_FIXTURE_TEST_SUITE(database_tests, history_database_directory_setup_fixtur
 #ifdef KTH_DB_HISTORY
 TEST_CASE("history database  test", "[None]")
 {
-    const short_hash key1 = base16_literal("a006500b7ddfd568e2b036c65a4f4d6aaa0cbd9b");
+    const short_hash key1 = "a006500b7ddfd568e2b036c65a4f4d6aaa0cbd9b"_base16;
     output_point out11{ hash_literal("4129e76f363f9742bc98dd3d40c99c9066e4d53b8e10e5097bd6f7b5059d7c53"), 110 };
     size_t const out_h11 = 110;
     const uint64_t value11 = 4;
@@ -50,7 +50,7 @@ TEST_CASE("history database  test", "[None]")
     input_point spend13{ hash_literal("3cc768bbaef30587c72c6eba8dbf6aeec4ef24172ae6fe357f2e24c2b0fa44d5"), 0 };
     size_t const spend_h13 = 320;
 
-    const short_hash key2 = base16_literal("9c6b3bdaa612ceab88d49d4431ed58f26e69b90d");
+    const short_hash key2 = "9c6b3bdaa612ceab88d49d4431ed58f26e69b90d"_base16;
     output_point out21{ hash_literal("80d9e7012b5b171bf78e75b52d2d149580d9e7012b5b171bf78e75b52d2d1495"), 9 };
     size_t const out_h21 = 3982;
     const uint64_t value21 = 65;
@@ -61,12 +61,12 @@ TEST_CASE("history database  test", "[None]")
     input_point spend22{ hash_literal("3cc768bbaef30587c72c6eba8dbfffffc4ef24172ae6fe357f2e24c2b0fa44d5"), 0 };
     size_t const spend_h22 = 900;
 
-    const short_hash key3 = base16_literal("3eb84f6a98478e516325b70fecf9903e1ce7528b");
+    const short_hash key3 = "3eb84f6a98478e516325b70fecf9903e1ce7528b"_base16;
     output_point out31{ hash_literal("d90aba96944cac3e715047256f7016d1d90aba96944cac3e715047256f7016d1"), 0 };
     size_t const out_h31 = 378;
     const uint64_t value31 = 34;
 
-    const short_hash key4 = base16_literal("d60db39ca8ce4caf0f7d2b7d3111535d9543473f");
+    const short_hash key4 = "d60db39ca8ce4caf0f7d2b7d3111535d9543473f"_base16;
     ////output_point out42{ hash_literal("aaaaaaaaaaacac3e715047256f7016d1d90aaa96944cac3e715047256f7016d1"), 0};
     size_t const out_h41 = 74448;
     const uint64_t value41 = 990;

--- a/src/database/test/internal_database.cpp
+++ b/src/database/test/internal_database.cpp
@@ -42,9 +42,8 @@ struct internal_database_directory_setup_fixture {
 };
 
 domain::chain::block get_block(std::string const& enc) {
-    data_chunk data;
-    decode_base16(data, enc);
-    byte_reader reader(data);
+    auto const data = decode_base16(enc);
+    byte_reader reader(*data);
     auto res = domain::chain::block::from_data(reader);
     if ( ! res) {
         return domain::chain::block{};
@@ -1406,10 +1405,10 @@ TEST_CASE("internal database  test tx address", "[None]") {
 
 std::println("*************************************************************");
 
-data_chunk wire_tx1;
-REQUIRE(decode_base16(wire_tx1, "0100000001a6b97044d03da79c005b20ea9c0e1a6d9dc12d9f7b91a5911c9030a439eed8f5000000004948304502206e21798a42fae0e854281abd38bacd1aeed3ee3738d9e1446618c4571d1090db022100e2ac980643b0b82c0e88ffdfec6b64e3e6ba35e7ba5fdd7d5d6cc8d25c6b241501ffffffff0100f2052a010000001976a914404371705fa9bd789a2fcd52d2c580b65d35549d88ac00000000"));
+auto wire_tx1 = decode_base16("0100000001a6b97044d03da79c005b20ea9c0e1a6d9dc12d9f7b91a5911c9030a439eed8f5000000004948304502206e21798a42fae0e854281abd38bacd1aeed3ee3738d9e1446618c4571d1090db022100e2ac980643b0b82c0e88ffdfec6b64e3e6ba35e7ba5fdd7d5d6cc8d25c6b241501ffffffff0100f2052a010000001976a914404371705fa9bd789a2fcd52d2c580b65d35549d88ac00000000");
+REQUIRE(wire_tx1);
 transaction tx1;
-REQUIRE(tx1.from_data(wire_tx1, true));
+REQUIRE(tx1.from_data(*wire_tx1, true));
 
 REQUIRE(tx1.is_valid());
 

--- a/src/domain/test/chain/block.cpp
+++ b/src/domain/test/chain/block.cpp
@@ -51,14 +51,14 @@ TEST_CASE("block locator size positive backoff returns log plus eleven", "[chain
 
 TEST_CASE("block locator heights zero backoff returns top to zero", "[chain block]") {
     constexpr size_t top = 7u;
-    constexpr chain::block::indexes expected{7u, 6u, 5u, 4u, 3u, 2u, 1u, 0u};
+    chain::block::indexes const expected{7u, 6u, 5u, 4u, 3u, 2u, 1u, 0u};
     auto const result = chain::block::locator_heights(top);
     REQUIRE(expected.size() == result.size());
     REQUIRE(expected == result);
 }
 
 TEST_CASE("block locator heights positive backoff returns top plus log offset to zero", "[chain block]") {
-    constexpr chain::block::indexes expected {
+    chain::block::indexes const expected {
         138u, 137u, 136u, 135u, 134u, 133u, 132u, 131u, 130u,
         129u, 128u, 126u, 122u, 114u, 98u, 66u, 2u, 0u
     };
@@ -596,7 +596,7 @@ TEST_CASE("block  operator boolean not equals  duplicates  returns false", "[blo
             chain::transaction(2, 32, {}, {}),
             chain::transaction(4, 16, {}, {})
         }
-    );
+    };
 
     chain::block const instance(expected);
     REQUIRE( ! (instance != expected));
@@ -665,8 +665,8 @@ TEST_CASE("validate block  is distinct tx set  partialy distinct not adjacent by
 #if defined(KTH_CURRENCY_BCH)
 TEST_CASE("validate block is cash pow valid true", "[block is distinct transaction set]") {
     constexpr uint32_t old_bits = 402736949;
-    constexpr domain::chain::compact bits(old_bits);
-    constexpr uint256_t target(bits);
+    domain::chain::compact const bits(old_bits);
+    uint256_t const target(bits);
     REQUIRE(domain::chain::compact(domain::chain::chain_state::difficulty_adjustment_cash(target)).normal() == 402757890);
 }
 #endif  //KTH_CURRENCY_BCH

--- a/src/infrastructure/test/network_address.cpp
+++ b/src/infrastructure/test/network_address.cpp
@@ -10,7 +10,8 @@ using namespace kth::infrastructure;
 
 using message::network_address;
 
-namesspace {
+namespace {
+    
 //This is defined in Domain <kth/domain/message/version.hpp>
 constexpr uint32_t version_level_minimum = 31402;
 

--- a/src/network/test/p2p.cpp
+++ b/src/network/test/p2p.cpp
@@ -165,7 +165,7 @@ TEST_CASE("empty test", "[empty tests]") {
 
 // Start Test Suite: p2p tests
 
-TEST_CASE("p2p  top block  default  zero null hash", "[p2p tests]") {
+TEST_CASE("p2p top block default zero null hash", "[p2p tests]") {
     print_headers(TEST_NAME);
     network::settings const configuration;
     p2p network(configuration);
@@ -173,7 +173,7 @@ TEST_CASE("p2p  top block  default  zero null hash", "[p2p tests]") {
     REQUIRE(network.top_block().hash() == null_hash);
 }
 
-TEST_CASE("p2p  set top block1  values  expected", "[p2p tests]") {
+TEST_CASE("p2p set top block1 values expected", "[p2p tests]") {
     print_headers(TEST_NAME);
     network::settings const configuration;
     p2p network(configuration);
@@ -184,7 +184,7 @@ TEST_CASE("p2p  set top block1  values  expected", "[p2p tests]") {
     REQUIRE(network.top_block().height() == expected_height);
 }
 
-TEST_CASE("p2p  set top block2  values  expected", "[p2p tests]") {
+TEST_CASE("p2p set top block2 values expected", "[p2p tests]") {
     print_headers(TEST_NAME);
     network::settings const configuration;
     p2p network(configuration);
@@ -196,14 +196,14 @@ TEST_CASE("p2p  set top block2  values  expected", "[p2p tests]") {
     REQUIRE(network.top_block().height() == expected.height());
 }
 
-TEST_CASE("p2p  start  no sessions  start success", "[p2p tests]") {
+TEST_CASE("p2p start no sessions start success", "[p2p tests]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_NO_CONNECTIONS(configuration);
     p2p network(configuration);
     REQUIRE(start_result(network) == error::success);
 }
 
-TEST_CASE("p2p  start  no connections  start stop success", "[p2p tests]") {
+TEST_CASE("p2p start no connections start stop success", "[p2p tests]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_NO_CONNECTIONS(configuration);
     p2p network(configuration);
@@ -211,7 +211,7 @@ TEST_CASE("p2p  start  no connections  start stop success", "[p2p tests]") {
     REQUIRE(network.stop());
 }
 
-TEST_CASE("p2p  start  no sessions  start success start operation fail", "[p2p tests]") {
+TEST_CASE("p2p start no sessions start success start operation fail", "[p2p tests]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_NO_CONNECTIONS(configuration);
     p2p network(configuration);
@@ -229,7 +229,7 @@ TEST_CASE("p2p  start  no sessions  start success start operation fail", "[p2p t
 ////    REQUIRE(start_result(network) == error::success);
 ////}
 
-TEST_CASE("p2p  start  seed session handshake timeout  start peer throttling stop success", "[p2p tests]") {
+TEST_CASE("p2p start seed session handshake timeout start peer throttling stop success", "[p2p tests]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_ONE_SEED(configuration);
     configuration.channel_handshake_seconds = 0;
@@ -244,7 +244,7 @@ TEST_CASE("p2p  start  seed session handshake timeout  start peer throttling sto
     REQUIRE(network.stop());
 }
 
-TEST_CASE("p2p  start  seed session connect timeout  start peer throttling stop success", "[p2p tests]") {
+TEST_CASE("p2p start seed session connect timeout start peer throttling stop success", "[p2p tests]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_ONE_SEED(configuration);
     configuration.connect_timeout_seconds = 0;
@@ -253,7 +253,7 @@ TEST_CASE("p2p  start  seed session connect timeout  start peer throttling stop 
     REQUIRE(network.stop());
 }
 
-TEST_CASE("p2p  start  seed session germination timeout  start peer throttling stop success", "[p2p tests]") {
+TEST_CASE("p2p start seed session germination timeout start peer throttling stop success", "[p2p tests]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_ONE_SEED(configuration);
     configuration.channel_germination_seconds = 0;
@@ -262,7 +262,7 @@ TEST_CASE("p2p  start  seed session germination timeout  start peer throttling s
     REQUIRE(network.stop());
 }
 
-TEST_CASE("p2p  start  seed session inactivity timeout  start peer throttling stop success", "[p2p tests]") {
+TEST_CASE("p2p start seed session inactivity timeout start peer throttling stop success", "[p2p tests]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_ONE_SEED(configuration);
     configuration.channel_inactivity_minutes = 0;
@@ -271,7 +271,7 @@ TEST_CASE("p2p  start  seed session inactivity timeout  start peer throttling st
     REQUIRE(network.stop());
 }
 
-TEST_CASE("p2p  start  seed session expiration timeout  start peer throttling stop success", "[p2p tests]") {
+TEST_CASE("p2p start seed session expiration timeout start peer throttling stop success", "[p2p tests]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_ONE_SEED(configuration);
     configuration.channel_expiration_minutes = 0;
@@ -295,7 +295,7 @@ TEST_CASE("p2p  start  seed session expiration timeout  start peer throttling st
 ////    REQUIRE(network.stop());
 ////}
 
-TEST_CASE("p2p  start  outbound no seeds  success", "[p2p tests]") {
+TEST_CASE("p2p start outbound no seeds success", "[p2p tests]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_NO_CONNECTIONS(configuration);
     configuration.outbound_connections = 1;
@@ -303,7 +303,7 @@ TEST_CASE("p2p  start  outbound no seeds  success", "[p2p tests]") {
     REQUIRE(start_result(network) == error::success);
 }
 
-TEST_CASE("p2p  connect  not started  service stopped", "[p2p tests]") {
+TEST_CASE("p2p connect not started service stopped", "[p2p tests]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_NO_CONNECTIONS(configuration);
     p2p network(configuration);
@@ -311,7 +311,7 @@ TEST_CASE("p2p  connect  not started  service stopped", "[p2p tests]") {
     REQUIRE(connect_result(network, host) == error::service_stopped);
 }
 
-TEST_CASE("p2p  connect  started  success", "[p2p tests]") {
+TEST_CASE("p2p connect started success", "[p2p tests]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_NO_CONNECTIONS(configuration);
     p2p network(configuration);
@@ -335,7 +335,7 @@ TEST_CASE("p2p  connect  started  success", "[p2p tests]") {
 ////    REQUIRE(connect_result(network, host) == error::address_in_use);
 ////}
 
-TEST_CASE("p2p  subscribe  stopped  service stopped", "[p2p tests]") {
+TEST_CASE("p2p subscribe stopped service stopped", "[p2p tests]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_NO_CONNECTIONS(configuration);
     p2p network(configuration);
@@ -344,7 +344,7 @@ TEST_CASE("p2p  subscribe  stopped  service stopped", "[p2p tests]") {
     REQUIRE(subscribe_result(network) == error::service_stopped);
 }
 
-TEST_CASE("p2p  subscribe  started stop  service stopped", "[p2p tests]") {
+TEST_CASE("p2p subscribe started stop service stopped", "[p2p tests]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_NO_CONNECTIONS(configuration);
     p2p network(configuration);
@@ -361,7 +361,7 @@ TEST_CASE("p2p  subscribe  started stop  service stopped", "[p2p tests]") {
     network.subscribe_connection(handler);
 }
 
-TEST_CASE("p2p  subscribe  started connect1  success", "[p2p tests]") {
+TEST_CASE("p2p subscribe started connect1 success", "[p2p tests]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_NO_CONNECTIONS(configuration);
     p2p network(configuration);
@@ -370,7 +370,7 @@ TEST_CASE("p2p  subscribe  started connect1  success", "[p2p tests]") {
     REQUIRE(subscribe_connect1_result(network, host) == error::success);
 }
 
-TEST_CASE("p2p  subscribe  started connect2  success", "[p2p tests]") {
+TEST_CASE("p2p subscribe started connect2 success", "[p2p tests]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_NO_CONNECTIONS(configuration);
     p2p network(configuration);
@@ -379,7 +379,7 @@ TEST_CASE("p2p  subscribe  started connect2  success", "[p2p tests]") {
     REQUIRE(subscribe_connect2_result(network, host) == error::success);
 }
 
-TEST_CASE("p2p  broadcast  ping two distinct hosts  two sends and successful completion", "[p2p tests]") {
+TEST_CASE("p2p broadcast ping two distinct hosts two sends and successful completion", "[p2p tests]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_NO_CONNECTIONS(configuration);
     p2p network(configuration);


### PR DESCRIPTION
## Summary

Update tests in blockchain, consensus, database, network, and c-api:

- Adapt tests to use `std::expected`-based `decode_base16`
- Convert `#define` macros to `constexpr char[]` arrays
- Fix test names with double spaces
- Update test assertions for new API

## Dependencies

- Based on #126 (domain tests)

## Test Plan

- [ ] All tests pass across all modules