### PR TITLE
refactor: add _hash UDL and migrate from hash_literal()

### DIFF
--- a/src/blockchain/test/block_entry.cpp
+++ b/src/blockchain/test/block_entry.cpp
@@ -12,8 +12,8 @@ using namespace kth::blockchain;
 
 // Start Test Suite: block entry tests
 
-static auto const hash42 = hash_literal("4242424242424242424242424242424242424242424242424242424242424242");
-static auto const default_block_hash = hash_literal("14508459b221041eab257d2baaa7459775ba748246c8403609eb708f0e57e74b");
+static auto const hash42 = "4242424242424242424242424242424242424242424242424242424242424242"_hash;
+static auto const default_block_hash = "14508459b221041eab257d2baaa7459775ba748246c8403609eb708f0e57e74b"_hash;
 
 // construct1/block
 

--- a/src/blockchain/test/transaction_entry.cpp
+++ b/src/blockchain/test/transaction_entry.cpp
@@ -17,7 +17,7 @@ using namespace kd::machine;
 // Start Test Suite: transaction entry tests
 
 static
-auto const default_tx_hash = hash_literal("f702453dd03b0f055e5437d76128141803984fb10acb85fc3b2184fae2f3fa78");
+auto const default_tx_hash = "f702453dd03b0f055e5437d76128141803984fb10acb85fc3b2184fae2f3fa78"_hash;
 
 static
 chain_state::data data() {

--- a/src/database/test/history_database.cpp
+++ b/src/database/test/history_database.cpp
@@ -35,39 +35,39 @@ BOOST_FIXTURE_TEST_SUITE(database_tests, history_database_directory_setup_fixtur
 TEST_CASE("history database  test", "[None]")
 {
     const short_hash key1 = "a006500b7ddfd568e2b036c65a4f4d6aaa0cbd9b"_base16;
-    output_point out11{ hash_literal("4129e76f363f9742bc98dd3d40c99c9066e4d53b8e10e5097bd6f7b5059d7c53"), 110 };
+    output_point out11{ "4129e76f363f9742bc98dd3d40c99c9066e4d53b8e10e5097bd6f7b5059d7c53"_hash, 110 };
     size_t const out_h11 = 110;
     const uint64_t value11 = 4;
-    output_point out12{ hash_literal("eefa5d23968584be9d8d064bcf99c24666e4d53b8e10e5097bd6f7b5059d7c53"), 4 };
+    output_point out12{ "eefa5d23968584be9d8d064bcf99c24666e4d53b8e10e5097bd6f7b5059d7c53"_hash, 4 };
     size_t const out_h12 = 120;
     const uint64_t value12 = 8;
-    output_point out13{ hash_literal("4129e76f363f9742bc98dd3d40c99c90eefa5d23968584be9d8d064bcf99c246"), 8 };
+    output_point out13{ "4129e76f363f9742bc98dd3d40c99c90eefa5d23968584be9d8d064bcf99c246"_hash, 8 };
     size_t const out_h13 = 222;
     const uint64_t value13 = 6;
 
-    input_point spend11{ hash_literal("4742b3eac32d35961f9da9d42d495ff1d90aba96944cac3e715047256f7016d1"), 0 };
+    input_point spend11{ "4742b3eac32d35961f9da9d42d495ff1d90aba96944cac3e715047256f7016d1"_hash, 0 };
     size_t const spend_h11 = 115;
-    input_point spend13{ hash_literal("3cc768bbaef30587c72c6eba8dbf6aeec4ef24172ae6fe357f2e24c2b0fa44d5"), 0 };
+    input_point spend13{ "3cc768bbaef30587c72c6eba8dbf6aeec4ef24172ae6fe357f2e24c2b0fa44d5"_hash, 0 };
     size_t const spend_h13 = 320;
 
     const short_hash key2 = "9c6b3bdaa612ceab88d49d4431ed58f26e69b90d"_base16;
-    output_point out21{ hash_literal("80d9e7012b5b171bf78e75b52d2d149580d9e7012b5b171bf78e75b52d2d1495"), 9 };
+    output_point out21{ "80d9e7012b5b171bf78e75b52d2d149580d9e7012b5b171bf78e75b52d2d1495"_hash, 9 };
     size_t const out_h21 = 3982;
     const uint64_t value21 = 65;
-    output_point out22{ hash_literal("4742b3eac32d35961f9da9d42d495ff13cc768bbaef30587c72c6eba8dbf6aee"), 0 };
+    output_point out22{ "4742b3eac32d35961f9da9d42d495ff13cc768bbaef30587c72c6eba8dbf6aee"_hash, 0 };
     size_t const out_h22 = 78;
     const uint64_t value22 = 9;
 
-    input_point spend22{ hash_literal("3cc768bbaef30587c72c6eba8dbfffffc4ef24172ae6fe357f2e24c2b0fa44d5"), 0 };
+    input_point spend22{ "3cc768bbaef30587c72c6eba8dbfffffc4ef24172ae6fe357f2e24c2b0fa44d5"_hash, 0 };
     size_t const spend_h22 = 900;
 
     const short_hash key3 = "3eb84f6a98478e516325b70fecf9903e1ce7528b"_base16;
-    output_point out31{ hash_literal("d90aba96944cac3e715047256f7016d1d90aba96944cac3e715047256f7016d1"), 0 };
+    output_point out31{ "d90aba96944cac3e715047256f7016d1d90aba96944cac3e715047256f7016d1"_hash, 0 };
     size_t const out_h31 = 378;
     const uint64_t value31 = 34;
 
     const short_hash key4 = "d60db39ca8ce4caf0f7d2b7d3111535d9543473f"_base16;
-    ////output_point out42{ hash_literal("aaaaaaaaaaacac3e715047256f7016d1d90aaa96944cac3e715047256f7016d1"), 0};
+    ////output_point out42{ "aaaaaaaaaaacac3e715047256f7016d1d90aaa96944cac3e715047256f7016d1"_hash, 0};
     size_t const out_h41 = 74448;
     const uint64_t value41 = 990;
 

--- a/src/database/test/spend_database.cpp
+++ b/src/database/test/spend_database.cpp
@@ -32,15 +32,15 @@ BOOST_FIXTURE_TEST_SUITE(database_tests, spend_database_directory_setup_fixture)
 
 #ifdef KTH_DB_SPEND
 TEST_CASE("spend database  test", "[None]") {
-    domain::chain::output_point key1{ hash_literal("4129e76f363f9742bc98dd3d40c99c9066e4d53b8e10e5097bd6f7b5059d7c53"), 110 };
-    domain::chain::output_point key2{ hash_literal("eefa5d23968584be9d8d064bcf99c24666e4d53b8e10e5097bd6f7b5059d7c53"), 4 };
-    domain::chain::output_point key3{ hash_literal("4129e76f363f9742bc98dd3d40c99c90eefa5d23968584be9d8d064bcf99c246"), 8 };
-    domain::chain::output_point key4{ hash_literal("80d9e7012b5b171bf78e75b52d2d149580d9e7012b5b171bf78e75b52d2d1495"), 9 };
+    domain::chain::output_point key1{ "4129e76f363f9742bc98dd3d40c99c9066e4d53b8e10e5097bd6f7b5059d7c53"_hash, 110 };
+    domain::chain::output_point key2{ "eefa5d23968584be9d8d064bcf99c24666e4d53b8e10e5097bd6f7b5059d7c53"_hash, 4 };
+    domain::chain::output_point key3{ "4129e76f363f9742bc98dd3d40c99c90eefa5d23968584be9d8d064bcf99c246"_hash, 8 };
+    domain::chain::output_point key4{ "80d9e7012b5b171bf78e75b52d2d149580d9e7012b5b171bf78e75b52d2d1495"_hash, 9 };
 
-    domain::chain::input_point value1{ hash_literal("4742b3eac32d35961f9da9d42d495ff1d90aba96944cac3e715047256f7016d1"), 1 };
-    domain::chain::input_point value2{ hash_literal("d90aba96944cac3e715047256f7016d1d90aba96944cac3e715047256f7016d1"), 2 };
-    domain::chain::input_point value3{ hash_literal("3cc768bbaef30587c72c6eba8dbf6aeec4ef24172ae6fe357f2e24c2b0fa44d5"), 3 };
-    domain::chain::input_point value4{ hash_literal("4742b3eac32d35961f9da9d42d495ff13cc768bbaef30587c72c6eba8dbf6aee"), 4 };
+    domain::chain::input_point value1{ "4742b3eac32d35961f9da9d42d495ff1d90aba96944cac3e715047256f7016d1"_hash, 1 };
+    domain::chain::input_point value2{ "d90aba96944cac3e715047256f7016d1d90aba96944cac3e715047256f7016d1"_hash, 2 };
+    domain::chain::input_point value3{ "3cc768bbaef30587c72c6eba8dbf6aeec4ef24172ae6fe357f2e24c2b0fa44d5"_hash, 3 };
+    domain::chain::input_point value4{ "4742b3eac32d35961f9da9d42d495ff13cc768bbaef30587c72c6eba8dbf6aee"_hash, 4 };
 
     store::create(DIRECTORY "/spend");
     spend_database db(DIRECTORY "/spend", 1000, 50);

--- a/src/domain/src/chain/script.cpp
+++ b/src/domain/src/chain/script.cpp
@@ -48,7 +48,7 @@ namespace kth::domain::chain {
 
 // bit.ly/2cPazSa
 static
-auto const one_hash = hash_literal("0000000000000000000000000000000000000000000000000000000000000001"); //NOLINT
+auto const one_hash = "0000000000000000000000000000000000000000000000000000000000000001"_hash; //NOLINT
 
 // Constructors.
 //-----------------------------------------------------------------------------

--- a/src/domain/src/chain/script_basis.cpp
+++ b/src/domain/src/chain/script_basis.cpp
@@ -47,7 +47,7 @@ namespace kth::domain::chain {
 
 // bit.ly/2cPazSa
 static
-auto const one_hash = hash_literal("0000000000000000000000000000000000000000000000000000000000000001"); //NOLINT
+auto const one_hash = "0000000000000000000000000000000000000000000000000000000000000001"_hash; //NOLINT
 
 // Constructors.
 //-----------------------------------------------------------------------------

--- a/src/domain/test/chain/block.cpp
+++ b/src/domain/test/chain/block.cpp
@@ -77,8 +77,8 @@ TEST_CASE("block constructor 1 always invalid", "[chain block]") {
 TEST_CASE("block constructor 2 always equals params", "[chain block]") {
     chain::header const header {
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u
@@ -99,8 +99,8 @@ TEST_CASE("block constructor 2 always equals params", "[chain block]") {
 TEST_CASE("block constructor 3 always equals params", "[chain block]") {
     chain::header const header {
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u
@@ -129,8 +129,8 @@ TEST_CASE("block constructor 3 always equals params", "[chain block]") {
 TEST_CASE("block constructor 4 always equals params", "[chain block]") {
     chain::header const header {
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u
@@ -153,8 +153,8 @@ TEST_CASE("block constructor 4 always equals params", "[chain block]") {
 TEST_CASE("block constructor 5 always equals params", "[chain block]") {
     chain::header const header {
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u
@@ -410,8 +410,8 @@ TEST_CASE("block  generate merkle root  block with multiple transactions  matche
 TEST_CASE("block  header accessor  always  returns initialized value", "[block generate merkle root]") {
     chain::header const header {
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u
@@ -430,8 +430,8 @@ TEST_CASE("block  header accessor  always  returns initialized value", "[block g
 TEST_CASE("block  header setter 1  roundtrip  success", "[block generate merkle root]") {
     chain::header const header {
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u
@@ -446,8 +446,8 @@ TEST_CASE("block  header setter 1  roundtrip  success", "[block generate merkle 
 TEST_CASE("block  header setter 2  roundtrip  success", "[block generate merkle root]") {
     chain::header const header {
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u
@@ -465,8 +465,8 @@ TEST_CASE("block  header setter 2  roundtrip  success", "[block generate merkle 
 TEST_CASE("block  transactions accessor  always  returns initialized value", "[block generate merkle root]") {
     chain::header const header {
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u
@@ -514,8 +514,8 @@ TEST_CASE("block  transactions setter 2  roundtrip  success", "[block generate m
 TEST_CASE("block  operator assign equals  always  matches equivalent", "[block generate merkle root]") {
     chain::header const header(
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u
@@ -543,8 +543,8 @@ TEST_CASE("block  operator boolean equals  duplicates  returns true", "[block ge
     chain::block const expected(
         chain::header {
             10u,
-            hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-            hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
             531234u,
             6523454u,
             68644u
@@ -564,8 +564,8 @@ TEST_CASE("block  operator boolean equals  differs  returns false", "[block gene
     chain::block const expected(
         chain::header {
             10u,
-            hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-            hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
             531234u,
             6523454u,
             68644u
@@ -585,8 +585,8 @@ TEST_CASE("block  operator boolean not equals  duplicates  returns false", "[blo
     chain::block const expected {
         chain::header {
             10u,
-            hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-            hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
             531234u,
             6523454u,
             68644u
@@ -606,8 +606,8 @@ TEST_CASE("block  operator boolean not equals  differs  returns true", "[block g
     chain::block const expected(
         chain::header {
             10u,
-            hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-            hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
             531234u,
             6523454u,
             68644u

--- a/src/domain/test/chain/compact.cpp
+++ b/src/domain/test/chain/compact.cpp
@@ -12,8 +12,7 @@ using namespace kth;
 using namespace kd;
 using namespace kth::domain::chain;
 
-constexpr char primes_hex[] = "020305070b0d1113171d1f25292b2f353b3d4347494f53596165676b6d717f83";
-static auto const primes = hash_literal(primes_hex);
+static auto const primes = "020305070b0d1113171d1f25292b2f353b3d4347494f53596165676b6d717f83"_hash;
 
 static uint32_t factory(int32_t logical_exponent, bool negative, uint32_t mantissa) {
     // The exponent of a non-zero mantissa is valid from -3 to +29.

--- a/src/domain/test/chain/header.cpp
+++ b/src/domain/test/chain/header.cpp
@@ -18,8 +18,8 @@ TEST_CASE("chain header constructor 1 always initialized invalid", "[chain heade
 
 TEST_CASE("chain header  constructor 2  always  equals params", "[chain header]") {
     uint32_t const version = 10u;
-    auto const previous = hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
-    auto const merkle = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    auto const previous = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
+    auto const merkle = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     uint32_t const timestamp = 531234u;
     uint32_t const bits = 6523454u;
     uint32_t const nonce = 68644u;
@@ -41,8 +41,8 @@ TEST_CASE("chain header  constructor 3  always  equals params", "[chain header]"
     uint32_t const nonce = 68644u;
 
     // These must be non-const.
-    auto previous = hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
-    auto merkle = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    auto previous = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
+    auto merkle = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     chain::header instance(version, std::move(previous), std::move(merkle), timestamp, bits, nonce);
     REQUIRE(instance.is_valid());
@@ -57,8 +57,8 @@ TEST_CASE("chain header  constructor 3  always  equals params", "[chain header]"
 TEST_CASE("chain header  constructor 4  always  equals params", "[chain header]") {
     chain::header const expected(
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u);
@@ -72,8 +72,8 @@ TEST_CASE("chain header  constructor 5  always  equals params", "[chain header]"
     // This must be non-const.
     chain::header expected(
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u);
@@ -93,8 +93,8 @@ TEST_CASE("chain header from data insufficient bytes  failure", "[chain header]"
 TEST_CASE("chain header from data valid input  success", "[chain header]") {
     chain::header expected{
         10,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234,
         6523454,
         68644};
@@ -113,8 +113,8 @@ TEST_CASE("chain header from data valid input  success", "[chain header]") {
 TEST_CASE("chain header  factory from data 2  valid input  success", "[chain header]") {
     chain::header expected{
         10,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234,
         6523454,
         68644};
@@ -132,8 +132,8 @@ TEST_CASE("chain header  factory from data 2  valid input  success", "[chain hea
 TEST_CASE("chain header  factory from data 3  valid input  success", "[chain header]") {
     chain::header const expected{
         10,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234,
         6523454,
         68644};
@@ -152,8 +152,8 @@ TEST_CASE("chain header  version accessor  always  returns initialized value", "
     uint32_t const value = 11234u;
     chain::header const instance(
         value,
-        hash_literal("abababababababababababababababababababababababababababababababab"),
-        hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
+        "abababababababababababababababababababababababababababababababab"_hash,
+        "fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"_hash,
         753234u,
         4356344u,
         34564u);
@@ -170,11 +170,11 @@ TEST_CASE("chain header  version setter  roundtrip  success", "[chain header]") 
 }
 
 TEST_CASE("chain header  previous block hash accessor 1  always  returns initialized value", "[chain header]") {
-    auto const value = hash_literal("abababababababababababababababababababababababababababababababab");
+    auto const value = "abababababababababababababababababababababababababababababababab"_hash;
     chain::header instance(
         11234u,
         value,
-        hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
+        "fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"_hash,
         753234u,
         4356344u,
         34564u);
@@ -183,11 +183,11 @@ TEST_CASE("chain header  previous block hash accessor 1  always  returns initial
 }
 
 TEST_CASE("chain header  previous block hash accessor 2  always  returns initialized value", "[chain header]") {
-    auto const value = hash_literal("abababababababababababababababababababababababababababababababab");
+    auto const value = "abababababababababababababababababababababababababababababababab"_hash;
     chain::header const instance(
         11234u,
         value,
-        hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
+        "fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"_hash,
         753234u,
         4356344u,
         34564u);
@@ -196,7 +196,7 @@ TEST_CASE("chain header  previous block hash accessor 2  always  returns initial
 }
 
 TEST_CASE("chain header  previous block hash setter 1  roundtrip  success", "[chain header]") {
-    auto const expected = hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe");
+    auto const expected = "fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"_hash;
     chain::header instance;
     REQUIRE(expected != instance.previous_block_hash());
     instance.set_previous_block_hash(expected);
@@ -204,7 +204,7 @@ TEST_CASE("chain header  previous block hash setter 1  roundtrip  success", "[ch
 }
 
 TEST_CASE("chain header  previous block hash setter 2  roundtrip  success", "[chain header]") {
-    auto const expected = hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe");
+    auto const expected = "fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"_hash;
 
     // This must be non-const.
     auto duplicate = expected;
@@ -216,10 +216,10 @@ TEST_CASE("chain header  previous block hash setter 2  roundtrip  success", "[ch
 }
 
 TEST_CASE("chain header  merkle accessor 1  always  returns initialized value", "[chain header]") {
-    auto const value = hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe");
+    auto const value = "fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"_hash;
     chain::header instance(
         11234u,
-        hash_literal("abababababababababababababababababababababababababababababababab"),
+        "abababababababababababababababababababababababababababababababab"_hash,
         value,
         753234u,
         4356344u,
@@ -229,10 +229,10 @@ TEST_CASE("chain header  merkle accessor 1  always  returns initialized value", 
 }
 
 TEST_CASE("chain header  merkle accessor 2  always  returns initialized value", "[chain header]") {
-    auto const value = hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe");
+    auto const value = "fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"_hash;
     chain::header const instance(
         11234u,
-        hash_literal("abababababababababababababababababababababababababababababababab"),
+        "abababababababababababababababababababababababababababababababab"_hash,
         value,
         753234u,
         4356344u,
@@ -242,7 +242,7 @@ TEST_CASE("chain header  merkle accessor 2  always  returns initialized value", 
 }
 
 TEST_CASE("chain header  merkle setter 1  roundtrip  success", "[chain header]") {
-    auto const expected = hash_literal("abababababababababababababababababababababababababababababababab");
+    auto const expected = "abababababababababababababababababababababababababababababababab"_hash;
     chain::header instance;
     REQUIRE(expected != instance.merkle());
     instance.set_merkle(expected);
@@ -250,7 +250,7 @@ TEST_CASE("chain header  merkle setter 1  roundtrip  success", "[chain header]")
 }
 
 TEST_CASE("chain header  merkle setter 2  roundtrip  success", "[chain header]") {
-    auto const expected = hash_literal("abababababababababababababababababababababababababababababababab");
+    auto const expected = "abababababababababababababababababababababababababababababababab"_hash;
 
     // This must be non-const.
     hash_digest duplicate = expected;
@@ -265,8 +265,8 @@ TEST_CASE("chain header  timestamp accessor  always  returns initialized value",
     uint32_t value = 753234u;
     chain::header instance(
         11234u,
-        hash_literal("abababababababababababababababababababababababababababababababab"),
-        hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
+        "abababababababababababababababababababababababababababababababab"_hash,
+        "fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"_hash,
         value,
         4356344u,
         34564u);
@@ -286,8 +286,8 @@ TEST_CASE("chain header  bits accessor  always  returns initialized value", "[ch
     uint32_t value = 4356344u;
     chain::header instance(
         11234u,
-        hash_literal("abababababababababababababababababababababababababababababababab"),
-        hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
+        "abababababababababababababababababababababababababababababababab"_hash,
+        "fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"_hash,
         753234u,
         value,
         34564u);
@@ -307,8 +307,8 @@ TEST_CASE("chain header  nonce accessor  always  returns initialized value", "[c
     uint32_t value = 34564u;
     chain::header instance(
         11234u,
-        hash_literal("abababababababababababababababababababababababababababababababab"),
-        hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
+        "abababababababababababababababababababababababababababababababab"_hash,
+        "fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"_hash,
         753234u,
         4356344u,
         value);
@@ -360,8 +360,8 @@ TEST_CASE("chain header  is valid proof of work  retarget bits exceeds maximum  
 TEST_CASE("chain header  is valid proof of work  hash greater bits  returns false", "[chain header]") {
     chain::header const instance(
         11234u,
-        hash_literal("abababababababababababababababababababababababababababababababab"),
-        hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
+        "abababababababababababababababababababababababababababababababab"_hash,
+        "fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"_hash,
         753234u,
         0u,
         34564u);
@@ -372,8 +372,8 @@ TEST_CASE("chain header  is valid proof of work  hash greater bits  returns fals
 TEST_CASE("chain header  is valid proof of work  hash less than bits  returns true", "[chain header]") {
     chain::header const instance(
         4u,
-        hash_literal("000000000000000003ddc1e929e2944b8b0039af9aa0d826c480a83d8b39c373"),
-        hash_literal("a6cb0b0d6531a71abe2daaa4a991e5498e1b6b0b51549568d0f9d55329b905df"),
+        "000000000000000003ddc1e929e2944b8b0039af9aa0d826c480a83d8b39c373"_hash,
+        "a6cb0b0d6531a71abe2daaa4a991e5498e1b6b0b51549568d0f9d55329b905df"_hash,
         1474388414u,
         402972254u,
         2842832236u);
@@ -385,8 +385,8 @@ TEST_CASE("chain header  operator assign equals  always  matches equivalent", "[
     // This must be non-const.
     chain::header value(
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u);
@@ -403,8 +403,8 @@ TEST_CASE("chain header  operator assign equals  always  matches equivalent", "[
 TEST_CASE("chain header  operator boolean equals  duplicates  returns true", "[chain header]") {
     chain::header const expected(
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u);
@@ -416,8 +416,8 @@ TEST_CASE("chain header  operator boolean equals  duplicates  returns true", "[c
 TEST_CASE("chain header  operator boolean equals  differs  returns false", "[chain header]") {
     chain::header const expected(
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u);
@@ -429,8 +429,8 @@ TEST_CASE("chain header  operator boolean equals  differs  returns false", "[cha
 TEST_CASE("chain header  operator boolean not equals  duplicates  returns false", "[chain header]") {
     chain::header const expected(
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u);
@@ -442,8 +442,8 @@ TEST_CASE("chain header  operator boolean not equals  duplicates  returns false"
 TEST_CASE("chain header  operator boolean not equals  differs  returns true", "[chain header]") {
     chain::header const expected(
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u);

--- a/src/domain/test/chain/input.cpp
+++ b/src/domain/test/chain/input.cpp
@@ -243,7 +243,7 @@ TEST_CASE("input  signature operations  bip16 active cache empty  returns script
 
 TEST_CASE("input  previous output setter 1  roundtrip  success", "[input]") {
     output_point const value{
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
         5434u};
 
     input instance;
@@ -256,7 +256,7 @@ TEST_CASE("input  previous output setter 1  roundtrip  success", "[input]") {
 
 TEST_CASE("input  previous output setter 2  roundtrip  success", "[input]") {
     output_point const value{
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
         5434u};
 
     auto dup_value = value;

--- a/src/domain/test/chain/output_point.cpp
+++ b/src/domain/test/chain/output_point.cpp
@@ -7,7 +7,7 @@
 using namespace kth;
 using namespace kd;
 
-auto const hash1 = hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+auto const hash1 = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
 auto const valid_raw_output_point = to_chunk("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f00000015"_base16);
 
 // Start Test Suite: output point tests

--- a/src/domain/test/chain/point.cpp
+++ b/src/domain/test/chain/point.cpp
@@ -17,7 +17,7 @@ TEST_CASE("point  constructor 1  always  returns default initialized", "[point]"
 }
 
 TEST_CASE("point  constructor 2  valid input  returns input initialized", "[point]") {
-    auto const hash = hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+    auto const hash = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
     uint32_t index = 1234u;
 
     chain::point instance(hash, index);
@@ -27,7 +27,7 @@ TEST_CASE("point  constructor 2  valid input  returns input initialized", "[poin
 }
 
 TEST_CASE("point  constructor 3  valid input  returns input initialized", "[point]") {
-    auto const hash = hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+    auto const hash = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
     uint32_t index = 1234u;
 
     // This must be non-const.
@@ -41,7 +41,7 @@ TEST_CASE("point  constructor 3  valid input  returns input initialized", "[poin
 
 TEST_CASE("point  constructor 4  valid input  returns input initialized", "[point]") {
     const chain::point expected{
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
         524342u};
 
     chain::point instance(expected);
@@ -52,7 +52,7 @@ TEST_CASE("point  constructor 4  valid input  returns input initialized", "[poin
 TEST_CASE("point  constructor 5  valid input  returns input initialized", "[point]") {
     // This must be non-const.
     chain::point expected{
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
         524342u};
 
     chain::point instance(std::move(expected));
@@ -123,7 +123,7 @@ TEST_CASE("point from data roundtrip  success 2", "[point]") {
 
 
 TEST_CASE("point  hash setter 1  roundtrip  success", "[point]") {
-    auto const value = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    auto const value = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     chain::point instance;
     REQUIRE(value != instance.hash());
@@ -132,7 +132,7 @@ TEST_CASE("point  hash setter 1  roundtrip  success", "[point]") {
 }
 
 TEST_CASE("point  hash setter 2  roundtrip  success", "[point]") {
-    auto const value = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    auto const value = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     // This must be non-const.
     auto dup_value = value;
@@ -228,25 +228,25 @@ TEST_CASE("point  operator boolean not equals  differs  returns true", "[point]"
 }
 
 TEST_CASE("point  checksum  all ones  returns all ones", "[point]") {
-    static auto const tx_hash = hash_literal("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    static auto const tx_hash = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"_hash;
     chain::point instance(tx_hash, 0xffffffff);
     REQUIRE(instance.checksum() == 0xffffffffffffffff);
 }
 
 TEST_CASE("point  checksum  all zeroes  returns all zeroes", "[point]") {
-    static auto const tx_hash = hash_literal("0000000000000000000000000000000000000000000000000000000000000000");
+    static auto const tx_hash = "0000000000000000000000000000000000000000000000000000000000000000"_hash;
     chain::point instance(tx_hash, 0x00000000);
     REQUIRE(instance.checksum() == 0x0000000000000000);
 }
 
 TEST_CASE("point  checksum  pattern one  returns expected", "[point]") {
-    static auto const tx_hash = hash_literal("000000000000000000000000aaaaaaaaaaaaaaaa000000000000000000000000");
+    static auto const tx_hash = "000000000000000000000000aaaaaaaaaaaaaaaa000000000000000000000000"_hash;
     chain::point instance(tx_hash, 0x00000001);
     REQUIRE(instance.checksum() == 0xaaaaaaaaaaaa8001);
 }
 
 TEST_CASE("point  checksum  pattern high  returns expected", "[point]") {
-    static auto const tx_hash = hash_literal("ffffffffffffffffffffffff01234567aaaaaaaaffffffffffffffffffffffff");
+    static auto const tx_hash = "ffffffffffffffffffffffff01234567aaaaaaaaffffffffffffffffffffffff"_hash;
     chain::point instance(tx_hash, 0x89abcdef);
     REQUIRE(instance.checksum() == 0x1234567aaaacdef);
 }

--- a/src/domain/test/chain/point_value.cpp
+++ b/src/domain/test/chain/point_value.cpp
@@ -10,8 +10,7 @@ using namespace kth::domain::chain;
 
 // Start Test Suite: point value tests
 
-static auto const hash1 = hash_literal(
-    "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+static auto const hash1 = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
 
 TEST_CASE("point value  default constructor  always  zero value", "[point value]") {
     static point_value const instance;

--- a/src/domain/test/chain/script.cpp
+++ b/src/domain/test/chain/script.cpp
@@ -182,7 +182,7 @@ std::string test_name_bchn(bchn_script_test const& test) {
 //------------------------------------------------------------------------------
 
 TEST_CASE("script one hash literal same", "[script]") {
-    static auto const hash_one = hash_literal("0000000000000000000000000000000000000000000000000000000000000001");
+    static auto const hash_one = "0000000000000000000000000000000000000000000000000000000000000001"_hash;
     static hash_digest const one_hash{{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}};
     REQUIRE(one_hash == hash_one);
 }
@@ -831,7 +831,7 @@ TEST_CASE("script construction failures", "[script]") {
 //     script prevout_script;
 //     REQUIRE(prevout_script.from_string("dup hash160 [88350574280395ad2c3e2ee20e322073d94e5e40] equalverify checksig"));
 
-//     ec_secret const secret = hash_literal("ce8f4b713ffdd2658900845251890f30371856be201cd1f5b3d970f793634333");
+//     ec_secret const secret = "ce8f4b713ffdd2658900845251890f30371856be201cd1f5b3d970f793634333"_hash;
 
 //     auto const index = 0u;
 //     auto const sighash_type = sighash_algorithm::all;
@@ -857,7 +857,7 @@ TEST_CASE("script create endorsement  single input no output  expected", "[scrip
     script prevout_script;
     REQUIRE(prevout_script.from_string("dup hash160 [88350574280395ad2c3e2ee20e322073d94e5e40] equalverify checksig"));
 
-    ec_secret const secret = hash_literal("ce8f4b713ffdd2658900845251890f30371856be201cd1f5b3d970f793634333");
+    ec_secret const secret = "ce8f4b713ffdd2658900845251890f30371856be201cd1f5b3d970f793634333"_hash;
 
     auto const index = 0u;
     auto const sighash_type = sighash_algorithm::all;

--- a/src/domain/test/chain/transaction.cpp
+++ b/src/domain/test/chain/transaction.cpp
@@ -34,7 +34,7 @@ constexpr auto tx1 =
     "0000001976a9141ee32412020a324b93b1a1acfdfff6ab9ca8fac288ac000000"
     "00"_base16;
 
-constexpr char tx1_hash_hex[] = "bf7c3f5a69a78edd81f3eff7e93a37fb2d7da394d48db4d85e7e5353b9b8e270";
+static auto const tx1_hash = "bf7c3f5a69a78edd81f3eff7e93a37fb2d7da394d48db4d85e7e5353b9b8e270"_hash;
 
 constexpr auto tx3_wire_serialized =
     "010000000209e300a61db28e4fd3562aec52647646fc55aa3e3f7d824f20f451"
@@ -82,7 +82,8 @@ constexpr auto tx4 =
     "ffff02c0e1e400000000001976a914884c09d7e1f6420976c40e040c30b2b622"
     "10c3d488ac20300500000000001976a914905f933de850988603aafeeb2fd7fc"
     "e61e66fe5d88ac00000000"_base16;
-constexpr char tx4_hash_hex[] = "8a6d9302fbe24f0ec756a94ecfc837eaffe16c43d1e68c62dfe980d99eea556f";
+
+static auto const tx4_hash = "8a6d9302fbe24f0ec756a94ecfc837eaffe16c43d1e68c62dfe980d99eea556f"_hash;
 
 constexpr char tx4_text[] = 
     "Transaction:\n"
@@ -134,7 +135,8 @@ constexpr auto tx7 =
     "a54e38193e381aee4b896e7958ce381afe4bb96e4babae381abe38288e381a3e3"
     "81a6e7ac91e9a194e38292e5a5aae3828fe3828ce3828be7bea9e58b99e38292e"
     "8a8ade38191e381a6e381afe38184e381aae3818400000000"_base16;
-constexpr char tx7_hash_hex[] = "cb1e303db604f066225eb14d59d3f8d2231200817bc9d4610d2802586bd93f8a";
+
+static auto const tx7_hash = "cb1e303db604f066225eb14d59d3f8d2231200817bc9d4610d2802586bd93f8a"_hash;
 
 TEST_CASE("chain transaction  constructor 2  valid input  returns input initialized", "[chain transaction]") {
     uint32_t version = 2345u;
@@ -228,7 +230,7 @@ TEST_CASE("chain transaction  constructor 6  valid input  returns input initiali
     auto result = chain::transaction::from_data(reader, true);
     REQUIRE(result);
     auto const expected = std::move(*result);
-    hash_digest const expected_hash = hash_literal(tx1_hash_hex);
+    hash_digest const expected_hash = tx1_hash;
 
     chain::transaction instance(expected, expected_hash);
     REQUIRE(instance.is_valid());
@@ -243,7 +245,7 @@ TEST_CASE("chain transaction  constructor 7  valid input  returns input initiali
     auto result = chain::transaction::from_data(reader, true);
     REQUIRE(result);
     auto const expected = std::move(*result);
-    hash_digest const expected_hash = hash_literal(tx1_hash_hex);
+    hash_digest const expected_hash = tx1_hash;
 
     chain::transaction instance(std::move(expected), expected_hash);
     REQUIRE(instance.is_valid());
@@ -467,7 +469,7 @@ TEST_CASE("chain transaction from data compare wire to store  success", "[None]"
 }
 
 TEST_CASE("chain transaction  factory data 1  case 1  success", "[chain transaction]") {
-    static auto const tx_hash = hash_literal(tx1_hash_hex);
+    static auto const tx_hash = tx1_hash;
     static auto const raw_tx = to_chunk(tx1);
     REQUIRE(raw_tx.size() == 225u);
 
@@ -487,7 +489,7 @@ TEST_CASE("chain transaction  factory data 1  case 1  success", "[chain transact
 }
 
 TEST_CASE("chain transaction  factory data 1  case 2  success", "[chain transaction]") {
-    static auto const tx_hash = hash_literal(tx4_hash_hex);
+    static auto const tx_hash = tx4_hash;
     static auto const raw_tx = to_chunk(tx4);
     REQUIRE(raw_tx.size() == 523u);
 
@@ -875,7 +877,7 @@ TEST_CASE("chain transaction  is dusty  two outputs limit between both  returns 
     REQUIRE(instance.is_dusty(258000001));
 }
 
-auto const hash1 = hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+auto const hash1 = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
 
 TEST_CASE("chain transaction  is mature  no inputs  returns true", "[chain transaction]") {
     chain::transaction instance;
@@ -1003,7 +1005,7 @@ TEST_CASE("chain transaction  operator boolean not equals  differs  returns true
 
 TEST_CASE("chain transaction  hash  block320670  success", "[chain transaction]") {
     // This is a garbage script that collides with the former opcode::raw_data sentinel.
-    static auto const expected = hash_literal(tx7_hash_hex);
+    static auto const expected = tx7_hash;
     static auto const data = to_chunk(tx7);
     chain::transaction instance;
     byte_reader reader(data);
@@ -1014,4 +1016,3 @@ TEST_CASE("chain transaction  hash  block320670  success", "[chain transaction]"
     REQUIRE(data == instance.to_data());
 }
 
-// End Test Suite

--- a/src/domain/test/message/block.cpp
+++ b/src/domain/test/message/block.cpp
@@ -19,8 +19,8 @@ TEST_CASE("block  constructor 1  always invalid", "[message block]") {
 
 TEST_CASE("block  constructor 2  always  equals params", "[message block]") {
     chain::header const header(10u,
-                               hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                               hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                                531234u,
                                6523454u,
                                68644u);
@@ -38,8 +38,8 @@ TEST_CASE("block  constructor 2  always  equals params", "[message block]") {
 
 TEST_CASE("block  constructor 3  always  equals params", "[message block]") {
     chain::header const header(10u,
-                               hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                               hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                                531234u,
                                6523454u,
                                68644u);
@@ -59,8 +59,8 @@ TEST_CASE("block  constructor 3  always  equals params", "[message block]") {
 
 TEST_CASE("block  constructor 4  always  equals params", "[message block]") {
     chain::header const header(10u,
-                               hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                               hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                                531234u,
                                6523454u,
                                68644u);
@@ -80,8 +80,8 @@ TEST_CASE("block  constructor 4  always  equals params", "[message block]") {
 
 TEST_CASE("block  constructor 5  always  equals params", "[message block]") {
     chain::header const header(10u,
-                               hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                               hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                                531234u,
                                6523454u,
                                68644u);
@@ -100,8 +100,8 @@ TEST_CASE("block  constructor 5  always  equals params", "[message block]") {
 
 TEST_CASE("block  constructor 6  always  equals params", "[message block]") {
     chain::header const header(10u,
-                               hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                               hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                                531234u,
                                6523454u,
                                68644u);
@@ -121,8 +121,8 @@ TEST_CASE("block  constructor 6  always  equals params", "[message block]") {
 
 TEST_CASE("block  constructor 7  always  equals params", "[message block]") {
     chain::header const header(10u,
-                               hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                               hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                                531234u,
                                6523454u,
                                68644u);
@@ -169,8 +169,8 @@ TEST_CASE("block  factory data 1  genesis mainnet  success", "[message block]") 
 
 TEST_CASE("block  operator assign equals 1  always  matches equivalent", "[message block]") {
     chain::header const header(10u,
-                               hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                               hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                                531234u,
                                6523454u,
                                68644u);
@@ -194,8 +194,8 @@ TEST_CASE("block  operator assign equals 1  always  matches equivalent", "[messa
 
 TEST_CASE("block  operator assign equals 2  always  matches equivalent", "[message block]") {
     chain::header const header(10u,
-                               hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                               hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                                531234u,
                                6523454u,
                                68644u);
@@ -221,8 +221,8 @@ TEST_CASE("block  operator assign equals 2  always  matches equivalent", "[messa
 TEST_CASE("block  operator boolean equals 1  duplicates  returns true", "[message block]") {
     const chain::block expected(
         chain::header(10u,
-                      hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                      hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                      "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                       531234u,
                       6523454u,
                       68644u),
@@ -237,8 +237,8 @@ TEST_CASE("block  operator boolean equals 1  duplicates  returns true", "[messag
 TEST_CASE("block  operator boolean equals 1  differs  returns false", "[message block]") {
     const chain::block expected(
         chain::header(10u,
-                      hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                      hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                      "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                       531234u,
                       6523454u,
                       68644u),
@@ -253,8 +253,8 @@ TEST_CASE("block  operator boolean equals 1  differs  returns false", "[message 
 TEST_CASE("block  operator boolean not equals 1  duplicates  returns false", "[message block]") {
     const chain::block expected(
         chain::header(10u,
-                      hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                      hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                      "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                       531234u,
                       6523454u,
                       68644u),
@@ -269,8 +269,8 @@ TEST_CASE("block  operator boolean not equals 1  duplicates  returns false", "[m
 TEST_CASE("block  operator boolean not equals 1  differs  returns true", "[message block]") {
     const chain::block expected(
         chain::header(10u,
-                      hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                      hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                      "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                       531234u,
                       6523454u,
                       68644u),
@@ -285,8 +285,8 @@ TEST_CASE("block  operator boolean not equals 1  differs  returns true", "[messa
 TEST_CASE("block  operator boolean equals 2  duplicates  returns true", "[message block]") {
     const message::block expected(
         chain::header(10u,
-                      hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                      hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                      "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                       531234u,
                       6523454u,
                       68644u),
@@ -301,8 +301,8 @@ TEST_CASE("block  operator boolean equals 2  duplicates  returns true", "[messag
 TEST_CASE("block  operator boolean equals 2  differs  returns false", "[message block]") {
     const message::block expected(
         chain::header(10u,
-                      hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                      hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                      "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                       531234u,
                       6523454u,
                       68644u),
@@ -317,8 +317,8 @@ TEST_CASE("block  operator boolean equals 2  differs  returns false", "[message 
 TEST_CASE("block  operator boolean not equals 2  duplicates  returns false", "[message block]") {
     const message::block expected(
         chain::header(10u,
-                      hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                      hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                      "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                       531234u,
                       6523454u,
                       68644u),
@@ -333,8 +333,8 @@ TEST_CASE("block  operator boolean not equals 2  duplicates  returns false", "[m
 TEST_CASE("block  operator boolean not equals 2  differs  returns true", "[message block]") {
     const message::block expected(
         chain::header(10u,
-                      hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                      hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                      "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                       531234u,
                       6523454u,
                       68644u),

--- a/src/domain/test/message/block_transactions.cpp
+++ b/src/domain/test/message/block_transactions.cpp
@@ -15,8 +15,7 @@ TEST_CASE("block transactions  constructor 1  always invalid", "[block transacti
 }
 
 TEST_CASE("block transactions  constructor 2  always  equals params", "[block transactions]") {
-    hash_digest const hash = hash_literal(
-        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+    hash_digest const hash = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
 
     chain::transaction::list const transactions = {
         chain::transaction(1, 48, {}, {}),
@@ -30,8 +29,7 @@ TEST_CASE("block transactions  constructor 2  always  equals params", "[block tr
 }
 
 TEST_CASE("block transactions  constructor 3  always  equals params", "[block transactions]") {
-    hash_digest const hash = hash_literal(
-        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+    hash_digest const hash = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
     hash_digest dup_hash = hash;
 
     chain::transaction::list const transactions = {
@@ -49,8 +47,7 @@ TEST_CASE("block transactions  constructor 3  always  equals params", "[block tr
 }
 
 TEST_CASE("block transactions  constructor 4  always  equals params", "[block transactions]") {
-    hash_digest const hash = hash_literal(
-        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+    hash_digest const hash = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
 
     chain::transaction::list const transactions = {
         chain::transaction(1, 48, {}, {}),
@@ -67,8 +64,7 @@ TEST_CASE("block transactions  constructor 4  always  equals params", "[block tr
 }
 
 TEST_CASE("block transactions  constructor 5  always  equals params", "[block transactions]") {
-    hash_digest const hash = hash_literal(
-        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+    hash_digest const hash = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
 
     chain::transaction::list const transactions = {
         chain::transaction(1, 48, {}, {}),
@@ -218,8 +214,7 @@ TEST_CASE("block transactions from data valid input  success", "[block transacti
 }
 
 TEST_CASE("block transactions  block hash accessor 1  always  returns initialized value", "[block transactions]") {
-    hash_digest const hash = hash_literal(
-        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+    hash_digest const hash = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
 
     chain::transaction::list const transactions = {
         chain::transaction(1, 48, {}, {}),
@@ -231,8 +226,7 @@ TEST_CASE("block transactions  block hash accessor 1  always  returns initialize
 }
 
 TEST_CASE("block transactions  block hash accessor 2  always  returns initialized value", "[block transactions]") {
-    hash_digest const hash = hash_literal(
-        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+    hash_digest const hash = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
 
     chain::transaction::list const transactions = {
         chain::transaction(1, 48, {}, {}),
@@ -244,8 +238,7 @@ TEST_CASE("block transactions  block hash accessor 2  always  returns initialize
 }
 
 TEST_CASE("block transactions  block hash setter 1  roundtrip  success", "[block transactions]") {
-    hash_digest const hash = hash_literal(
-        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+    hash_digest const hash = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
 
     message::block_transactions instance;
     REQUIRE(hash != instance.block_hash());
@@ -254,8 +247,7 @@ TEST_CASE("block transactions  block hash setter 1  roundtrip  success", "[block
 }
 
 TEST_CASE("block transactions  block hash setter 2  roundtrip  success", "[block transactions]") {
-    hash_digest const hash = hash_literal(
-        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+    hash_digest const hash = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
 
     hash_digest dup_hash = hash;
     message::block_transactions instance;
@@ -265,8 +257,7 @@ TEST_CASE("block transactions  block hash setter 2  roundtrip  success", "[block
 }
 
 TEST_CASE("block transactions  transactions accessor 1  always  returns initialized value", "[block transactions]") {
-    hash_digest const hash = hash_literal(
-        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+    hash_digest const hash = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
 
     chain::transaction::list const transactions = {
         chain::transaction(1, 48, {}, {}),
@@ -278,8 +269,7 @@ TEST_CASE("block transactions  transactions accessor 1  always  returns initiali
 }
 
 TEST_CASE("block transactions  transactions accessor 2  always  returns initialized value", "[block transactions]") {
-    hash_digest const hash = hash_literal(
-        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+    hash_digest const hash = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
 
     chain::transaction::list const transactions = {
         chain::transaction(1, 48, {}, {}),
@@ -316,8 +306,7 @@ TEST_CASE("block transactions  transactions setter 2  roundtrip  success", "[blo
 }
 
 TEST_CASE("block transactions  operator assign equals  always  matches equivalent", "[block transactions]") {
-    hash_digest const hash = hash_literal(
-        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+    hash_digest const hash = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
 
     chain::transaction::list const transactions = {
         chain::transaction(1, 48, {}, {}),
@@ -336,7 +325,7 @@ TEST_CASE("block transactions  operator assign equals  always  matches equivalen
 
 TEST_CASE("block transactions  operator boolean equals  duplicates  returns true", "[block transactions]") {
     const message::block_transactions expected(
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
         {chain::transaction(1, 48, {}, {}),
          chain::transaction(2, 32, {}, {}),
          chain::transaction(4, 16, {}, {})});
@@ -347,7 +336,7 @@ TEST_CASE("block transactions  operator boolean equals  duplicates  returns true
 
 TEST_CASE("block transactions  operator boolean equals  differs  returns false", "[block transactions]") {
     const message::block_transactions expected(
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
         {chain::transaction(1, 48, {}, {}),
          chain::transaction(2, 32, {}, {}),
          chain::transaction(4, 16, {}, {})});
@@ -358,7 +347,7 @@ TEST_CASE("block transactions  operator boolean equals  differs  returns false",
 
 TEST_CASE("block transactions  operator boolean not equals  duplicates  returns false", "[block transactions]") {
     const message::block_transactions expected(
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
         {chain::transaction(1, 48, {}, {}),
          chain::transaction(2, 32, {}, {}),
          chain::transaction(4, 16, {}, {})});
@@ -369,7 +358,7 @@ TEST_CASE("block transactions  operator boolean not equals  duplicates  returns 
 
 TEST_CASE("block transactions  operator boolean not equals  differs  returns true", "[block transactions]") {
     const message::block_transactions expected(
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
         {chain::transaction(1, 48, {}, {}),
          chain::transaction(2, 32, {}, {}),
          chain::transaction(4, 16, {}, {})});
@@ -378,4 +367,3 @@ TEST_CASE("block transactions  operator boolean not equals  differs  returns tru
     REQUIRE(instance != expected);
 }
 
-// End Test Suite

--- a/src/domain/test/message/compact_block.cpp
+++ b/src/domain/test/message/compact_block.cpp
@@ -23,8 +23,8 @@ uint64_t convert_to_uint64t(std::string const& rawdata) {
 
 TEST_CASE("compact block  constructor 2  always  equals params", "[compact block]") {
     chain::header const header(10u,
-                               hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                               hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                                531234u,
                                6523454u,
                                68644u);
@@ -52,8 +52,8 @@ TEST_CASE("compact block  constructor 2  always  equals params", "[compact block
 
 TEST_CASE("compact block  constructor 3  always  equals params", "[compact block]") {
     chain::header const header(10u,
-                               hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                               hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                                531234u,
                                6523454u,
                                68644u);
@@ -85,8 +85,8 @@ TEST_CASE("compact block  constructor 3  always  equals params", "[compact block
 
 TEST_CASE("compact block  constructor 4  always  equals params", "[compact block]") {
     chain::header const header(10u,
-                               hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                               hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                                531234u,
                                6523454u,
                                68644u);
@@ -116,8 +116,8 @@ TEST_CASE("compact block  constructor 4  always  equals params", "[compact block
 
 TEST_CASE("compact block  constructor 5  always  equals params", "[compact block]") {
     chain::header const header(10u,
-                               hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                               hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                                531234u,
                                6523454u,
                                68644u);
@@ -200,8 +200,8 @@ TEST_CASE("compact block from data valid input  success", "[compact block]") {
 
 TEST_CASE("compact block  header accessor 1  always  returns initialized value", "[compact block]") {
     chain::header const header(10u,
-                               hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                               hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                                531234u,
                                6523454u,
                                68644u);
@@ -224,8 +224,8 @@ TEST_CASE("compact block  header accessor 1  always  returns initialized value",
 
 TEST_CASE("compact block  header accessor 2  always  returns initialized value", "[compact block]") {
     chain::header const header(10u,
-                               hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                               hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                                531234u,
                                6523454u,
                                68644u);
@@ -248,8 +248,8 @@ TEST_CASE("compact block  header accessor 2  always  returns initialized value",
 
 TEST_CASE("compact block  header setter 1  roundtrip  success", "[compact block]") {
     chain::header const value(10u,
-                              hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                              hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                              "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                              "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                               531234u,
                               6523454u,
                               68644u);
@@ -262,8 +262,8 @@ TEST_CASE("compact block  header setter 1  roundtrip  success", "[compact block]
 
 TEST_CASE("compact block  header setter 2  roundtrip  success", "[compact block]") {
     chain::header const value(10u,
-                              hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                              hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                              "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                              "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                               531234u,
                               6523454u,
                               68644u);
@@ -277,8 +277,8 @@ TEST_CASE("compact block  header setter 2  roundtrip  success", "[compact block]
 
 TEST_CASE("compact block  nonce accessor  always  returns initialized value", "[compact block]") {
     chain::header const header(10u,
-                               hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                               hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                                531234u,
                                6523454u,
                                68644u);
@@ -310,8 +310,8 @@ TEST_CASE("compact block  nonce setter  roundtrip  success", "[compact block]") 
 
 TEST_CASE("compact block  short ids accessor 1  always  returns initialized value", "[compact block]") {
     chain::header const header(10u,
-                               hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                               hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                                531234u,
                                6523454u,
                                68644u);
@@ -334,8 +334,8 @@ TEST_CASE("compact block  short ids accessor 1  always  returns initialized valu
 
 TEST_CASE("compact block  short ids accessor 2  always  returns initialized value", "[compact block]") {
     chain::header const header(10u,
-                               hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                               hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                                531234u,
                                6523454u,
                                68644u);
@@ -385,8 +385,8 @@ TEST_CASE("compact block  short ids setter 2  roundtrip  success", "[compact blo
 
 TEST_CASE("compact block  transactions accessor 1  always  returns initialized value", "[compact block]") {
     chain::header const header(10u,
-                               hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                               hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                                531234u,
                                6523454u,
                                68644u);
@@ -409,8 +409,8 @@ TEST_CASE("compact block  transactions accessor 1  always  returns initialized v
 
 TEST_CASE("compact block  transactions accessor 2  always  returns initialized value", "[compact block]") {
     chain::header const header(10u,
-                               hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                               hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                                531234u,
                                6523454u,
                                68644u);
@@ -458,8 +458,8 @@ TEST_CASE("compact block  transactions setter 2  roundtrip  success", "[compact 
 
 TEST_CASE("compact block  operator assign equals  always  matches equivalent", "[compact block]") {
     chain::header const header(10u,
-                               hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                               hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                                531234u,
                                6523454u,
                                68644u);
@@ -491,8 +491,8 @@ TEST_CASE("compact block  operator assign equals  always  matches equivalent", "
 TEST_CASE("compact block  operator boolean equals  duplicates  returns true", "[compact block]") {
     const message::compact_block expected(
         chain::header(10u,
-                      hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                      hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                      "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                       531234u,
                       6523454u,
                       68644u),
@@ -512,8 +512,8 @@ TEST_CASE("compact block  operator boolean equals  duplicates  returns true", "[
 TEST_CASE("compact block  operator boolean equals  differs  returns false", "[compact block]") {
     const message::compact_block expected(
         chain::header(10u,
-                      hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                      hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                      "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                       531234u,
                       6523454u,
                       68644u),
@@ -533,8 +533,8 @@ TEST_CASE("compact block  operator boolean equals  differs  returns false", "[co
 TEST_CASE("compact block  operator boolean not equals  duplicates  returns false", "[compact block]") {
     const message::compact_block expected(
         chain::header(10u,
-                      hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                      hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                      "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                       531234u,
                       6523454u,
                       68644u),
@@ -554,8 +554,8 @@ TEST_CASE("compact block  operator boolean not equals  duplicates  returns false
 TEST_CASE("compact block  operator boolean not equals  differs  returns true", "[compact block]") {
     const message::compact_block expected(
         chain::header(10u,
-                      hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-                      hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+                      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+                      "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
                       531234u,
                       6523454u,
                       68644u),

--- a/src/domain/test/message/get_block_transactions.cpp
+++ b/src/domain/test/message/get_block_transactions.cpp
@@ -15,7 +15,7 @@ TEST_CASE("get block transactions  constructor 1  always invalid", "[get block t
 }
 
 TEST_CASE("get block transactions  constructor 2  always  equals params", "[get block transactions]") {
-    hash_digest const hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     const std::vector<uint64_t> indexes = {1u, 3454u, 4234u, 75123u, 455323u};
 
     message::get_block_transactions instance(hash, indexes);
@@ -25,7 +25,7 @@ TEST_CASE("get block transactions  constructor 2  always  equals params", "[get 
 }
 
 TEST_CASE("get block transactions  constructor 3  always  equals params", "[get block transactions]") {
-    hash_digest hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     auto hash_dup = hash;
     std::vector<uint64_t> indexes = {1u, 3454u, 4234u, 75123u, 455323u};
     auto indexes_dup = indexes;
@@ -38,7 +38,7 @@ TEST_CASE("get block transactions  constructor 3  always  equals params", "[get 
 
 TEST_CASE("get block transactions  constructor 4  always  equals params", "[get block transactions]") {
     message::get_block_transactions value(
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         {1u, 3454u, 4234u, 75123u, 455323u});
 
     message::get_block_transactions instance(value);
@@ -47,7 +47,7 @@ TEST_CASE("get block transactions  constructor 4  always  equals params", "[get 
 }
 
 TEST_CASE("get block transactions  constructor 5  always  equals params", "[get block transactions]") {
-    hash_digest hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     std::vector<uint64_t> indexes = {1u, 3454u, 4234u, 75123u, 455323u};
 
     message::get_block_transactions value(hash, indexes);
@@ -68,7 +68,7 @@ TEST_CASE("get block transactions from data insufficient bytes  failure", "[get 
 
 TEST_CASE("get block transactions from data valid input  success", "[get block transactions]") {
     const message::get_block_transactions expected{
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         {16,
          32,
          37,
@@ -89,21 +89,21 @@ TEST_CASE("get block transactions from data valid input  success", "[get block t
 
 
 TEST_CASE("get block transactions  block hash accessor 1  always  returns initialized value", "[get block transactions]") {
-    hash_digest const hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     const std::vector<uint64_t> indexes = {1u, 3454u, 4234u, 75123u, 455323u};
     message::get_block_transactions instance(hash, indexes);
     REQUIRE(hash == instance.block_hash());
 }
 
 TEST_CASE("get block transactions  block hash accessor 2  always  returns initialized value", "[get block transactions]") {
-    hash_digest const hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     const std::vector<uint64_t> indexes = {1u, 3454u, 4234u, 75123u, 455323u};
     const message::get_block_transactions instance(hash, indexes);
     REQUIRE(hash == instance.block_hash());
 }
 
 TEST_CASE("get block transactions  block hash setter 1  roundtrip  success", "[get block transactions]") {
-    hash_digest const hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     message::get_block_transactions instance;
     REQUIRE(hash != instance.block_hash());
     instance.set_block_hash(hash);
@@ -111,7 +111,7 @@ TEST_CASE("get block transactions  block hash setter 1  roundtrip  success", "[g
 }
 
 TEST_CASE("get block transactions  block hash setter 2  roundtrip  success", "[get block transactions]") {
-    hash_digest hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     auto dup = hash;
     message::get_block_transactions instance;
     REQUIRE(hash != instance.block_hash());
@@ -120,14 +120,14 @@ TEST_CASE("get block transactions  block hash setter 2  roundtrip  success", "[g
 }
 
 TEST_CASE("get block transactions  indexes accessor 1  always  returns initialized value", "[get block transactions]") {
-    hash_digest const hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     const std::vector<uint64_t> indexes = {1u, 3454u, 4234u, 75123u, 455323u};
     message::get_block_transactions instance(hash, indexes);
     REQUIRE(indexes == instance.indexes());
 }
 
 TEST_CASE("get block transactions  indexes accessor 2  always  returns initialized value", "[get block transactions]") {
-    hash_digest const hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     const std::vector<uint64_t> indexes = {1u, 3454u, 4234u, 75123u, 455323u};
     const message::get_block_transactions instance(hash, indexes);
     REQUIRE(indexes == instance.indexes());
@@ -151,7 +151,7 @@ TEST_CASE("get block transactions  indexes setter 2  roundtrip  success", "[get 
 }
 
 TEST_CASE("get block transactions  operator assign equals  always  matches equivalent", "[get block transactions]") {
-    hash_digest const hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     const std::vector<uint64_t> indexes = {1u, 3454u, 4234u, 75123u, 455323u};
     message::get_block_transactions value(hash, indexes);
 
@@ -168,7 +168,7 @@ TEST_CASE("get block transactions  operator assign equals  always  matches equiv
 
 TEST_CASE("get block transactions  operator boolean equals  duplicates  returns true", "[get block transactions]") {
     const message::get_block_transactions expected(
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         {1u, 3454u, 4234u, 75123u, 455323u});
 
     message::get_block_transactions instance(expected);
@@ -177,7 +177,7 @@ TEST_CASE("get block transactions  operator boolean equals  duplicates  returns 
 
 TEST_CASE("get block transactions  operator boolean equals  differs  returns false", "[get block transactions]") {
     const message::get_block_transactions expected(
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         {1u, 3454u, 4234u, 75123u, 455323u});
 
     message::get_block_transactions instance;
@@ -186,7 +186,7 @@ TEST_CASE("get block transactions  operator boolean equals  differs  returns fal
 
 TEST_CASE("get block transactions  operator boolean not equals  duplicates  returns false", "[get block transactions]") {
     const message::get_block_transactions expected(
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         {1u, 3454u, 4234u, 75123u, 455323u});
 
     message::get_block_transactions instance(expected);
@@ -195,7 +195,7 @@ TEST_CASE("get block transactions  operator boolean not equals  duplicates  retu
 
 TEST_CASE("get block transactions  operator boolean not equals  differs  returns true", "[get block transactions]") {
     const message::get_block_transactions expected(
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         {1u, 3454u, 4234u, 75123u, 455323u});
 
     message::get_block_transactions instance;

--- a/src/domain/test/message/get_blocks.cpp
+++ b/src/domain/test/message/get_blocks.cpp
@@ -16,11 +16,11 @@ TEST_CASE("get blocks  constructor 1  always invalid", "[get blocks]") {
 
 TEST_CASE("get blocks  constructor 2  always  equals params", "[get blocks]") {
     hash_list const starts = {
-        hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-        hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-        hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")};
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash};
 
-    hash_digest stop = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest stop = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     message::get_blocks instance(starts, stop);
     REQUIRE(instance.is_valid());
@@ -30,12 +30,12 @@ TEST_CASE("get blocks  constructor 2  always  equals params", "[get blocks]") {
 
 TEST_CASE("get blocks  constructor 3  always  equals params", "[get blocks]") {
     hash_list starts = {
-        hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-        hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-        hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")};
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash};
     hash_list starts_duplicate = starts;
 
-    hash_digest stop = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest stop = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     message::get_blocks instance(std::move(starts_duplicate), std::move(stop));
     REQUIRE(instance.is_valid());
@@ -45,11 +45,11 @@ TEST_CASE("get blocks  constructor 3  always  equals params", "[get blocks]") {
 
 TEST_CASE("get blocks  constructor 4  always  equals params", "[get blocks]") {
     hash_list starts = {
-        hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-        hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-        hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")};
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash};
 
-    hash_digest stop = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest stop = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     const message::get_blocks expected(starts, stop);
     message::get_blocks instance(expected);
@@ -61,11 +61,11 @@ TEST_CASE("get blocks  constructor 4  always  equals params", "[get blocks]") {
 
 TEST_CASE("get blocks  constructor 5  always  equals params", "[get blocks]") {
     hash_list starts = {
-        hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-        hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-        hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")};
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash};
 
-    hash_digest stop = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest stop = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     message::get_blocks expected(starts, stop);
     message::get_blocks instance(std::move(expected));
@@ -85,12 +85,12 @@ TEST_CASE("get blocks from data insufficient bytes  failure", "[get blocks]") {
 
 TEST_CASE("get blocks from data valid input  success", "[get blocks]") {
     const message::get_blocks expected{
-        {hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-         hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-         hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-         hash_literal("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
-         hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")},
-        hash_literal("7777777777777777777777777777777777777777777777777777777777777777")};
+        {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+         "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"_hash,
+         "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+         "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"_hash,
+         "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash},
+        "7777777777777777777777777777777777777777777777777777777777777777"_hash};
 
     auto const data = expected.to_data(message::version::level::minimum);
     byte_reader reader(data);
@@ -108,41 +108,41 @@ TEST_CASE("get blocks from data valid input  success", "[get blocks]") {
 
 TEST_CASE("get blocks  start hashes accessor 1  always  returns initialized value", "[get blocks]") {
     hash_list expected = {
-        hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-        hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-        hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-        hash_literal("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
-        hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")};
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"_hash,
+        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+        "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"_hash,
+        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash};
 
     message::get_blocks instance{
         expected,
-        hash_literal("7777777777777777777777777777777777777777777777777777777777777777")};
+        "7777777777777777777777777777777777777777777777777777777777777777"_hash};
 
     REQUIRE(expected == instance.start_hashes());
 }
 
 TEST_CASE("get blocks  start hashes accessor 2  always  returns initialized value", "[get blocks]") {
     hash_list expected = {
-        hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-        hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-        hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-        hash_literal("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
-        hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")};
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"_hash,
+        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+        "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"_hash,
+        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash};
 
     const message::get_blocks instance{
         expected,
-        hash_literal("7777777777777777777777777777777777777777777777777777777777777777")};
+        "7777777777777777777777777777777777777777777777777777777777777777"_hash};
 
     REQUIRE(expected == instance.start_hashes());
 }
 
 TEST_CASE("get blocks  start hashes setter 1  roundtrip  success", "[get blocks]") {
     hash_list const values = {
-        hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-        hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-        hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-        hash_literal("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
-        hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")};
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"_hash,
+        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+        "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"_hash,
+        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash};
 
     message::get_blocks instance;
     REQUIRE(values != instance.start_hashes());
@@ -152,11 +152,11 @@ TEST_CASE("get blocks  start hashes setter 1  roundtrip  success", "[get blocks]
 
 TEST_CASE("get blocks  start hashes setter 2  roundtrip  success", "[get blocks]") {
     hash_list values = {
-        hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-        hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-        hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-        hash_literal("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
-        hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")};
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"_hash,
+        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+        "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"_hash,
+        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash};
 
     hash_list values_duplicate = values;
 
@@ -167,37 +167,35 @@ TEST_CASE("get blocks  start hashes setter 2  roundtrip  success", "[get blocks]
 }
 
 TEST_CASE("get blocks  stop hash accessor 1  always  returns initialized value", "[get blocks]") {
-    hash_digest expected = hash_literal(
-        "7777777777777777777777777777777777777777777777777777777777777777");
+    hash_digest expected = "7777777777777777777777777777777777777777777777777777777777777777"_hash;
 
     message::get_blocks instance{
-        {hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-         hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-         hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-         hash_literal("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
-         hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")},
+        {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+         "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"_hash,
+         "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+         "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"_hash,
+         "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash},
         expected};
 
     REQUIRE(expected == instance.stop_hash());
 }
 
 TEST_CASE("get blocks  stop hash accessor 2  always  returns initialized value", "[get blocks]") {
-    hash_digest expected = hash_literal(
-        "7777777777777777777777777777777777777777777777777777777777777777");
+    hash_digest expected = "7777777777777777777777777777777777777777777777777777777777777777"_hash;
 
     const message::get_blocks instance{
-        {hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-         hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-         hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-         hash_literal("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
-         hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")},
+        {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+         "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"_hash,
+         "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+         "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"_hash,
+         "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash},
         expected};
 
     REQUIRE(expected == instance.stop_hash());
 }
 
 TEST_CASE("get blocks  stop hash setter 1  roundtrip  success", "[get blocks]") {
-    hash_digest value = hash_literal("7777777777777777777777777777777777777777777777777777777777777777");
+    hash_digest value = "7777777777777777777777777777777777777777777777777777777777777777"_hash;
     message::get_blocks instance;
     REQUIRE(value != instance.stop_hash());
     instance.set_stop_hash(value);
@@ -205,7 +203,7 @@ TEST_CASE("get blocks  stop hash setter 1  roundtrip  success", "[get blocks]") 
 }
 
 TEST_CASE("get blocks  stop hash setter 2  roundtrip  success", "[get blocks]") {
-    hash_digest value = hash_literal("7777777777777777777777777777777777777777777777777777777777777777");
+    hash_digest value = "7777777777777777777777777777777777777777777777777777777777777777"_hash;
     message::get_blocks instance;
     REQUIRE(value != instance.stop_hash());
     instance.set_stop_hash(std::move(value));
@@ -214,13 +212,13 @@ TEST_CASE("get blocks  stop hash setter 2  roundtrip  success", "[get blocks]") 
 
 TEST_CASE("get blocks  operator assign equals  always  matches equivalent", "[get blocks]") {
     hash_list start = {
-        hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-        hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-        hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-        hash_literal("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
-        hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")};
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"_hash,
+        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+        "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"_hash,
+        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash};
 
-    hash_digest stop = hash_literal("7777777777777777777777777777777777777777777777777777777777777777");
+    hash_digest stop = "7777777777777777777777777777777777777777777777777777777777777777"_hash;
 
     message::get_blocks value{start, stop};
 
@@ -237,12 +235,12 @@ TEST_CASE("get blocks  operator assign equals  always  matches equivalent", "[ge
 
 TEST_CASE("get blocks  operator boolean equals  duplicates  returns true", "[get blocks]") {
     const message::get_blocks expected{
-        {hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-         hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-         hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-         hash_literal("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
-         hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")},
-        hash_literal("7777777777777777777777777777777777777777777777777777777777777777")};
+        {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+         "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"_hash,
+         "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+         "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"_hash,
+         "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash},
+        "7777777777777777777777777777777777777777777777777777777777777777"_hash};
 
     message::get_blocks instance(expected);
     REQUIRE(instance == expected);
@@ -250,12 +248,12 @@ TEST_CASE("get blocks  operator boolean equals  duplicates  returns true", "[get
 
 TEST_CASE("get blocks  operator boolean equals  differs  returns false", "[get blocks]") {
     const message::get_blocks expected{
-        {hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-         hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-         hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-         hash_literal("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
-         hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")},
-        hash_literal("7777777777777777777777777777777777777777777777777777777777777777")};
+        {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+         "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"_hash,
+         "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+         "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"_hash,
+         "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash},
+        "7777777777777777777777777777777777777777777777777777777777777777"_hash};
 
     message::get_blocks instance;
     REQUIRE(instance != expected);
@@ -263,12 +261,12 @@ TEST_CASE("get blocks  operator boolean equals  differs  returns false", "[get b
 
 TEST_CASE("get blocks  operator boolean not equals  duplicates  returns false", "[get blocks]") {
     const message::get_blocks expected{
-        {hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-         hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-         hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-         hash_literal("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
-         hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")},
-        hash_literal("7777777777777777777777777777777777777777777777777777777777777777")};
+        {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+         "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"_hash,
+         "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+         "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"_hash,
+         "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash},
+        "7777777777777777777777777777777777777777777777777777777777777777"_hash};
 
     message::get_blocks instance(expected);
     REQUIRE(instance == expected);
@@ -276,15 +274,14 @@ TEST_CASE("get blocks  operator boolean not equals  duplicates  returns false", 
 
 TEST_CASE("get blocks  operator boolean not equals  differs  returns true", "[get blocks]") {
     const message::get_blocks expected{
-        {hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-         hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-         hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-         hash_literal("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
-         hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")},
-        hash_literal("7777777777777777777777777777777777777777777777777777777777777777")};
+        {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+         "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"_hash,
+         "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+         "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"_hash,
+         "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash},
+        "7777777777777777777777777777777777777777777777777777777777777777"_hash};
 
     message::get_blocks instance;
     REQUIRE(instance != expected);
 }
 
-// End Test Suite

--- a/src/domain/test/message/get_data.cpp
+++ b/src/domain/test/message/get_data.cpp
@@ -32,7 +32,7 @@ TEST_CASE("get data  constructor 2  always  equals params", "[get data]") {
 
 TEST_CASE("get data  constructor 3  always  equals params", "[get data]") {
     static auto const type = inventory_vector::type_id::error;
-    static auto const hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     inventory_vector::list const values{
         inventory_vector(type, hash)};
 
@@ -46,7 +46,7 @@ TEST_CASE("get data  constructor 3  always  equals params", "[get data]") {
 
 TEST_CASE("get data  constructor 4  always  equals params", "[get data]") {
     static auto const type = inventory_vector::type_id::error;
-    static auto const hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     static hash_list const hashes{hash};
 
     const get_data instance(hashes, type);
@@ -59,7 +59,7 @@ TEST_CASE("get data  constructor 4  always  equals params", "[get data]") {
 
 TEST_CASE("get data  constructor 5  always  equals params", "[get data]") {
     static auto const type = inventory_vector::type_id::error;
-    static auto const hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     const get_data instance{{type, hash}};
     REQUIRE(instance.is_valid());
@@ -71,7 +71,7 @@ TEST_CASE("get data  constructor 5  always  equals params", "[get data]") {
 
 TEST_CASE("get data  constructor 6  always  equals params", "[get data]") {
     static auto const type = inventory_vector::type_id::error;
-    static auto const hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     const get_data value{{type, hash}};
     REQUIRE(value.is_valid());
@@ -85,7 +85,7 @@ TEST_CASE("get data  constructor 6  always  equals params", "[get data]") {
 
 TEST_CASE("get data  constructor 7  always  equals params", "[get data]") {
     static auto const type = inventory_vector::type_id::error;
-    static auto const hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     const get_data value{{type, hash}};
     REQUIRE(value.is_valid());
@@ -108,7 +108,7 @@ TEST_CASE("get data from data insufficient bytes  failure", "[get data]") {
 TEST_CASE("get data from data insufficient version  failure", "[get data]") {
     static const get_data expected{
         {inventory_vector::type_id::error,
-         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b")}};
+         "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash}};
 
     auto const raw = expected.to_data(version::level::maximum);
     byte_reader reader(raw);
@@ -119,7 +119,7 @@ TEST_CASE("get data from data insufficient version  failure", "[get data]") {
 TEST_CASE("get data from data valid input  success", "[get data]") {
     static const get_data expected{
         {inventory_vector::type_id::error,
-         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b")}};
+         "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash}};
 
     static auto const version = version::level::maximum;
     auto const data = expected.to_data(version);
@@ -136,7 +136,7 @@ TEST_CASE("get data from data valid input  success", "[get data]") {
 
 
 TEST_CASE("get data  operator assign equals  always  matches equivalent", "[get data]") {
-    static auto const hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     static inventory_vector::list const elements{
         inventory_vector(inventory_vector::type_id::error, hash)};
 
@@ -152,7 +152,7 @@ TEST_CASE("get data  operator assign equals  always  matches equivalent", "[get 
 }
 
 TEST_CASE("get data  operator boolean equals  duplicates  returns true", "[get data]") {
-    static auto const hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     const get_data expected{
         inventory_vector(inventory_vector::type_id::error, hash)};
 
@@ -161,7 +161,7 @@ TEST_CASE("get data  operator boolean equals  duplicates  returns true", "[get d
 }
 
 TEST_CASE("get data  operator boolean equals  differs  returns false", "[get data]") {
-    static auto const hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     const get_data expected{
         inventory_vector(inventory_vector::type_id::error, hash)};
 
@@ -170,7 +170,7 @@ TEST_CASE("get data  operator boolean equals  differs  returns false", "[get dat
 }
 
 TEST_CASE("get data  operator boolean not equals  duplicates  returns false", "[get data]") {
-    static auto const hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     const get_data expected{
         inventory_vector(inventory_vector::type_id::error, hash)};
 
@@ -179,7 +179,7 @@ TEST_CASE("get data  operator boolean not equals  duplicates  returns false", "[
 }
 
 TEST_CASE("get data  operator boolean not equals  differs  returns true", "[get data]") {
-    static auto const hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     const get_data expected{
         inventory_vector(inventory_vector::type_id::error, hash)};
 

--- a/src/domain/test/message/get_headers.cpp
+++ b/src/domain/test/message/get_headers.cpp
@@ -16,11 +16,11 @@ TEST_CASE("get headers  constructor 1  always invalid", "[get headers]") {
 
 TEST_CASE("get headers  constructor 2  always  equals params", "[get headers]") {
     hash_list starts = {
-        hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-        hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-        hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")};
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash};
 
-    hash_digest stop = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest stop = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     message::get_headers instance(starts, stop);
     REQUIRE(instance.is_valid());
@@ -30,12 +30,12 @@ TEST_CASE("get headers  constructor 2  always  equals params", "[get headers]") 
 
 TEST_CASE("get headers  constructor 3  always  equals params", "[get headers]") {
     hash_list starts = {
-        hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-        hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-        hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")};
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash};
     hash_list starts_duplicate = starts;
 
-    hash_digest stop = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest stop = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     message::get_headers instance(std::move(starts_duplicate), std::move(stop));
     REQUIRE(instance.is_valid());
@@ -45,11 +45,11 @@ TEST_CASE("get headers  constructor 3  always  equals params", "[get headers]") 
 
 TEST_CASE("get headers  constructor 4  always  equals params", "[get headers]") {
     hash_list starts = {
-        hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-        hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-        hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")};
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash};
 
-    hash_digest stop = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest stop = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     const message::get_headers expected(starts, stop);
     message::get_headers instance(expected);
@@ -61,11 +61,11 @@ TEST_CASE("get headers  constructor 4  always  equals params", "[get headers]") 
 
 TEST_CASE("get headers  constructor 5  always  equals params", "[get headers]") {
     hash_list starts = {
-        hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-        hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-        hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")};
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash};
 
-    hash_digest stop = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest stop = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     message::get_headers expected(starts, stop);
     message::get_headers instance(std::move(expected));
@@ -86,12 +86,12 @@ TEST_CASE("get headers from data insufficient bytes failure", "[get headers]") {
 TEST_CASE("get headers from data insufficient version failure", "[get headers]") {
     message::get_headers const expected {
         {
-            hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-            hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-            hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-            hash_literal("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
-            hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
-        }, hash_literal("7777777777777777777777777777777777777777777777777777777777777777")
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"_hash,
+            "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+            "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"_hash,
+            "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash
+        }, "7777777777777777777777777777777777777777777777777777777777777777"_hash
     };
 
     auto const data = expected.to_data(message::get_headers::version_minimum);
@@ -105,12 +105,12 @@ TEST_CASE("get headers from data insufficient version failure", "[get headers]")
 TEST_CASE("get headers from data valid input  success", "[get headers]") {
     message::get_headers const expected {
         {
-            hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-            hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-            hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-            hash_literal("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
-            hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
-        }, hash_literal("7777777777777777777777777777777777777777777777777777777777777777")
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"_hash,
+            "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+            "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"_hash,
+            "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash
+        }, "7777777777777777777777777777777777777777777777777777777777777777"_hash
     };
 
     auto const data = expected.to_data(message::get_headers::version_minimum);
@@ -131,14 +131,14 @@ TEST_CASE("get headers from data valid input  success", "[get headers]") {
 
 TEST_CASE("get headers  operator assign equals  always  matches equivalent", "[get headers]") {
     hash_list const start = {
-        hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-        hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-        hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-        hash_literal("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
-        hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"_hash,
+        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+        "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"_hash,
+        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash
     };
 
-    hash_digest const stop = hash_literal("7777777777777777777777777777777777777777777777777777777777777777");
+    hash_digest const stop = "7777777777777777777777777777777777777777777777777777777777777777"_hash;
 
     message::get_headers value{start, stop};
 
@@ -156,12 +156,12 @@ TEST_CASE("get headers  operator assign equals  always  matches equivalent", "[g
 TEST_CASE("get headers  operator boolean equals  duplicates  returns true", "[get headers]") {
     message::get_headers const expected {
         {
-            hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-            hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-            hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-            hash_literal("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
-            hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
-        }, hash_literal("7777777777777777777777777777777777777777777777777777777777777777")
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"_hash,
+            "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+            "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"_hash,
+            "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash
+        }, "7777777777777777777777777777777777777777777777777777777777777777"_hash
     };
 
     message::get_headers instance(expected);
@@ -171,12 +171,12 @@ TEST_CASE("get headers  operator boolean equals  duplicates  returns true", "[ge
 TEST_CASE("get headers  operator boolean equals  differs  returns false", "[get headers]") {
     message::get_headers const expected {
         {
-            hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-            hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-            hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-            hash_literal("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
-            hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
-        }, hash_literal("7777777777777777777777777777777777777777777777777777777777777777")
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"_hash,
+            "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+            "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"_hash,
+            "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash
+        }, "7777777777777777777777777777777777777777777777777777777777777777"_hash
     };
 
     message::get_headers instance;
@@ -186,12 +186,12 @@ TEST_CASE("get headers  operator boolean equals  differs  returns false", "[get 
 TEST_CASE("get headers  operator boolean not equals  duplicates  returns false", "[get headers]") {
     message::get_headers const expected {
         {
-            hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-            hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-            hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-            hash_literal("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
-            hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
-        }, hash_literal("7777777777777777777777777777777777777777777777777777777777777777")
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"_hash,
+            "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+            "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"_hash,
+            "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash
+        }, "7777777777777777777777777777777777777777777777777777777777777777"_hash
     };
 
     message::get_headers instance(expected);
@@ -201,12 +201,12 @@ TEST_CASE("get headers  operator boolean not equals  duplicates  returns false",
 TEST_CASE("get headers  operator boolean not equals  differs  returns true", "[get headers]") {
     message::get_headers const expected {
         {
-            hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-            hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-            hash_literal("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-            hash_literal("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
-            hash_literal("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
-        }, hash_literal("7777777777777777777777777777777777777777777777777777777777777777")
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"_hash,
+            "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"_hash,
+            "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"_hash,
+            "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash
+        }, "7777777777777777777777777777777777777777777777777777777777777777"_hash
     };
 
     message::get_headers instance;

--- a/src/domain/test/message/header.cpp
+++ b/src/domain/test/message/header.cpp
@@ -16,8 +16,8 @@ TEST_CASE("message header constructor 1  always initialized invalid", "[message 
 
 TEST_CASE("message header  constructor 2  always  equals params", "[message header]") {
     uint32_t version = 10u;
-    hash_digest previous = hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
-    hash_digest merkle = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest previous = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
+    hash_digest merkle = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     uint32_t timestamp = 531234u;
     uint32_t bits = 6523454u;
     uint32_t nonce = 68644u;
@@ -34,8 +34,8 @@ TEST_CASE("message header  constructor 2  always  equals params", "[message head
 
 TEST_CASE("message header  constructor 3  always  equals params", "[message header]") {
     uint32_t version = 10u;
-    hash_digest previous = hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
-    hash_digest merkle = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest previous = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
+    hash_digest merkle = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     uint32_t timestamp = 531234u;
     uint32_t bits = 6523454u;
     uint32_t nonce = 68644u;
@@ -53,8 +53,8 @@ TEST_CASE("message header  constructor 3  always  equals params", "[message head
 TEST_CASE("message header  constructor 4  always  equals params", "[message header]") {
     chain::header const expected(
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         1234u);
@@ -67,8 +67,8 @@ TEST_CASE("message header  constructor 4  always  equals params", "[message head
 TEST_CASE("message header  constructor 5  always  equals params", "[message header]") {
     chain::header expected(
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         123u);
@@ -81,8 +81,8 @@ TEST_CASE("message header  constructor 5  always  equals params", "[message head
 TEST_CASE("message header  constructor 6  always  equals params", "[message header]") {
     const message::header expected(
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u);
@@ -95,8 +95,8 @@ TEST_CASE("message header  constructor 6  always  equals params", "[message head
 TEST_CASE("message header  constructor 7  always  equals params", "[message header]") {
     message::header expected(
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u);
@@ -119,8 +119,8 @@ TEST_CASE("message header from data valid input canonical version  no transactio
     auto const version = message::version::level::canonical;
     message::header expected{
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u};
@@ -142,8 +142,8 @@ TEST_CASE("message header from data valid input  success", "[message header]") {
     auto const version = message::header::version_minimum;
     message::header expected{
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u};
@@ -166,8 +166,8 @@ TEST_CASE("message header from data valid input  success", "[message header]") {
 TEST_CASE("message header  operator assign equals 1  always  matches equivalent", "[message header]") {
     chain::header value(
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u);
@@ -185,8 +185,8 @@ TEST_CASE("message header  operator assign equals 1  always  matches equivalent"
 TEST_CASE("message header  operator assign equals 2  always  matches equivalent", "[message header]") {
     message::header value(
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u);
@@ -204,8 +204,8 @@ TEST_CASE("message header  operator assign equals 2  always  matches equivalent"
 TEST_CASE("message header  operator boolean equals 1  duplicates  returns true", "[message header]") {
     chain::header const expected(
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         3565u);
@@ -217,8 +217,8 @@ TEST_CASE("message header  operator boolean equals 1  duplicates  returns true",
 TEST_CASE("message header  operator boolean equals 1  differs  returns false", "[message header]") {
     chain::header const expected(
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         6523454u,
         68644u,
         4453u);
@@ -230,8 +230,8 @@ TEST_CASE("message header  operator boolean equals 1  differs  returns false", "
 TEST_CASE("message header  operator boolean not equals 1  duplicates  returns false", "[message header]") {
     chain::header const expected(
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         6523454u,
         68644u,
         2345u);
@@ -243,8 +243,8 @@ TEST_CASE("message header  operator boolean not equals 1  duplicates  returns fa
 TEST_CASE("message header  operator boolean not equals 1  differs  returns true", "[message header]") {
     chain::header const expected(
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         68644u,
         47476u);
@@ -256,8 +256,8 @@ TEST_CASE("message header  operator boolean not equals 1  differs  returns true"
 TEST_CASE("message header  operator boolean equals 2  duplicates  returns true", "[message header]") {
     const message::header expected(
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u);
@@ -269,8 +269,8 @@ TEST_CASE("message header  operator boolean equals 2  duplicates  returns true",
 TEST_CASE("message header  operator boolean equals 2  differs  returns false", "[message header]") {
     const message::header expected(
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u);
@@ -282,8 +282,8 @@ TEST_CASE("message header  operator boolean equals 2  differs  returns false", "
 TEST_CASE("message header  operator boolean not equals 2  duplicates  returns false", "[message header]") {
     const message::header expected(
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u);
@@ -295,8 +295,8 @@ TEST_CASE("message header  operator boolean not equals 2  duplicates  returns fa
 TEST_CASE("message header  operator boolean not equals 2  differs  returns true", "[message header]") {
     const message::header expected(
         10u,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234u,
         6523454u,
         68644u);

--- a/src/domain/test/message/headers.cpp
+++ b/src/domain/test/message/headers.cpp
@@ -19,15 +19,15 @@ TEST_CASE("headers  constructor 2  always  equals params", "[headers]") {
     header::list const expected{
         header(
             10u,
-            hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-            hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
             531234u,
             6523454u,
             68644u),
         header(
             11234u,
-            hash_literal("abababababababababababababababababababababababababababababababab"),
-            hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
+            "abababababababababababababababababababababababababababababababab"_hash,
+            "fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"_hash,
             753234u,
             4356344u,
             34564u)};
@@ -41,15 +41,15 @@ TEST_CASE("headers  constructor 3  always  equals params", "[headers]") {
     header::list const expected{
         header(
             10u,
-            hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-            hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
             531234u,
             6523454u,
             68644u),
         header(
             11234u,
-            hash_literal("abababababababababababababababababababababababababababababababab"),
-            hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
+            "abababababababababababababababababababababababababababababababab"_hash,
+            "fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"_hash,
             753234u,
             4356344u,
             34564u)};
@@ -63,15 +63,15 @@ TEST_CASE("headers  constructor 4  always  equals params", "[headers]") {
     headers instance(
         {header(
              10u,
-             hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+             "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+             "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
              531234u,
              6523454u,
              68644u),
          header(
              11234u,
-             hash_literal("abababababababababababababababababababababababababababababababab"),
-             hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
+             "abababababababababababababababababababababababababababababababab"_hash,
+             "fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"_hash,
              753234u,
              4356344u,
              34564u)});
@@ -84,15 +84,15 @@ TEST_CASE("headers  constructor 5  always  equals params", "[headers]") {
     headers const expected(
         {header(
              10u,
-             hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+             "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+             "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
              531234u,
              6523454u,
              68644u),
          header(
              11234u,
-             hash_literal("abababababababababababababababababababababababababababababababab"),
-             hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
+             "abababababababababababababababababababababababababababababababab"_hash,
+             "fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"_hash,
              753234u,
              4356344u,
              34564u)});
@@ -105,15 +105,15 @@ TEST_CASE("headers  constructor 6  always  equals params", "[headers]") {
     headers expected(
         {header(
              10u,
-             hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+             "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+             "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
              531234u,
              6523454u,
              68644u),
          header(
              11234u,
-             hash_literal("abababababababababababababababababababababababababababababababab"),
-             hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
+             "abababababababababababababababababababababababababababababababab"_hash,
+             "fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"_hash,
              753234u,
              4356344u,
              34564u)});
@@ -133,8 +133,8 @@ TEST_CASE("headers from data insufficient bytes  failure", "[headers]") {
 TEST_CASE("headers from data insufficient version  failure", "[headers]") {
     static headers const expected{
         {10,
-         hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+         "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+         "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
          531234,
          6523454,
          68644}};
@@ -149,8 +149,8 @@ TEST_CASE("headers from data insufficient version  failure", "[headers]") {
 TEST_CASE("headers from data valid input  success", "[headers]") {
     static headers const expected{
         {10,
-         hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+         "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+         "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
          531234,
          6523454,
          68644}};
@@ -173,15 +173,15 @@ TEST_CASE("headers  elements accessor 1  always  returns initialized value", "[h
     header::list const expected{
         header(
             10u,
-            hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-            hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
             531234u,
             6523454u,
             68644u),
         header(
             11234u,
-            hash_literal("abababababababababababababababababababababababababababababababab"),
-            hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
+            "abababababababababababababababababababababababababababababababab"_hash,
+            "fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"_hash,
             753234u,
             4356344u,
             34564u)};
@@ -194,15 +194,15 @@ TEST_CASE("headers  elements accessor 2  always  returns initialized value", "[h
     header::list const expected{
         header(
             10u,
-            hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-            hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
             531234u,
             6523454u,
             68644u),
         header(
             11234u,
-            hash_literal("abababababababababababababababababababababababababababababababab"),
-            hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
+            "abababababababababababababababababababababababababababababababab"_hash,
+            "fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"_hash,
             753234u,
             4356344u,
             34564u)};
@@ -215,15 +215,15 @@ TEST_CASE("headers  command setter 1  roundtrip  success", "[headers]") {
     header::list const expected{
         header(
             10u,
-            hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-            hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
             531234u,
             6523454u,
             68644u),
         header(
             11234u,
-            hash_literal("abababababababababababababababababababababababababababababababab"),
-            hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
+            "abababababababababababababababababababababababababababababababab"_hash,
+            "fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"_hash,
             753234u,
             4356344u,
             34564u)};
@@ -238,15 +238,15 @@ TEST_CASE("headers  command setter 2  roundtrip  success", "[headers]") {
     header::list values{
         header(
             10u,
-            hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-            hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
             531234u,
             6523454u,
             68644u),
         header(
             11234u,
-            hash_literal("abababababababababababababababababababababababababababababababab"),
-            hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
+            "abababababababababababababababababababababababababababababababab"_hash,
+            "fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"_hash,
             753234u,
             4356344u,
             34564u)};
@@ -261,22 +261,22 @@ TEST_CASE("headers  operator assign equals  always  matches equivalent", "[heade
     message::headers value(
         {header{
              1u,
-             hash_literal("f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"),
-             hash_literal("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"),
+             "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"_hash,
+             "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"_hash,
              10u,
              100u,
              1000u},
          header{
              2u,
-             hash_literal("abababababababababababababababababababababababababababababababab"),
-             hash_literal("babababababababababababababababababababababababababababababababa"),
+             "abababababababababababababababababababababababababababababababab"_hash,
+             "babababababababababababababababababababababababababababababababa"_hash,
              20u,
              200u,
              2000u},
          header{
              3u,
-             hash_literal("e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2"),
-             hash_literal("7373737373737373737373737373737373737373737373737373737373737373"),
+             "e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2"_hash,
+             "7373737373737373737373737373737373737373737373737373737373737373"_hash,
              30u,
              300u,
              3000u}});
@@ -292,22 +292,22 @@ TEST_CASE("headers  operator boolean equals  duplicates  returns true", "[header
     const message::headers expected(
         {header{
              1u,
-             hash_literal("f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"),
-             hash_literal("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"),
+             "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"_hash,
+             "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"_hash,
              10u,
              100u,
              1000u},
          header{
              2u,
-             hash_literal("abababababababababababababababababababababababababababababababab"),
-             hash_literal("babababababababababababababababababababababababababababababababa"),
+             "abababababababababababababababababababababababababababababababab"_hash,
+             "babababababababababababababababababababababababababababababababa"_hash,
              20u,
              200u,
              2000u},
          header{
              3u,
-             hash_literal("e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2"),
-             hash_literal("7373737373737373737373737373737373737373737373737373737373737373"),
+             "e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2"_hash,
+             "7373737373737373737373737373737373737373737373737373737373737373"_hash,
              30u,
              300u,
              3000u}});
@@ -320,22 +320,22 @@ TEST_CASE("headers  operator boolean equals  differs  returns false", "[headers]
     const message::headers expected(
         {header{
              1u,
-             hash_literal("f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"),
-             hash_literal("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"),
+             "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"_hash,
+             "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"_hash,
              10u,
              100u,
              1000u},
          header{
              2u,
-             hash_literal("abababababababababababababababababababababababababababababababab"),
-             hash_literal("babababababababababababababababababababababababababababababababa"),
+             "abababababababababababababababababababababababababababababababab"_hash,
+             "babababababababababababababababababababababababababababababababa"_hash,
              20u,
              200u,
              2000u},
          header{
              3u,
-             hash_literal("e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2"),
-             hash_literal("7373737373737373737373737373737373737373737373737373737373737373"),
+             "e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2"_hash,
+             "7373737373737373737373737373737373737373737373737373737373737373"_hash,
              30u,
              300u,
              3000u}});
@@ -348,22 +348,22 @@ TEST_CASE("headers  operator boolean not equals  duplicates  returns false", "[h
     const message::headers expected(
         {header{
              1u,
-             hash_literal("f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"),
-             hash_literal("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"),
+             "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"_hash,
+             "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"_hash,
              10u,
              100u,
              1000u},
          header{
              2u,
-             hash_literal("abababababababababababababababababababababababababababababababab"),
-             hash_literal("babababababababababababababababababababababababababababababababa"),
+             "abababababababababababababababababababababababababababababababab"_hash,
+             "babababababababababababababababababababababababababababababababa"_hash,
              20u,
              200u,
              2000u},
          header{
              3u,
-             hash_literal("e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2"),
-             hash_literal("7373737373737373737373737373737373737373737373737373737373737373"),
+             "e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2"_hash,
+             "7373737373737373737373737373737373737373737373737373737373737373"_hash,
              30u,
              300u,
              3000u}});
@@ -376,22 +376,22 @@ TEST_CASE("headers  operator boolean not equals  differs  returns true", "[heade
     const message::headers expected(
         {header{
              1u,
-             hash_literal("f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"),
-             hash_literal("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"),
+             "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"_hash,
+             "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"_hash,
              10u,
              100u,
              1000u},
          header{
              2u,
-             hash_literal("abababababababababababababababababababababababababababababababab"),
-             hash_literal("babababababababababababababababababababababababababababababababa"),
+             "abababababababababababababababababababababababababababababababab"_hash,
+             "babababababababababababababababababababababababababababababababa"_hash,
              20u,
              200u,
              2000u},
          header{
              3u,
-             hash_literal("e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2"),
-             hash_literal("7373737373737373737373737373737373737373737373737373737373737373"),
+             "e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2"_hash,
+             "7373737373737373737373737373737373737373737373737373737373737373"_hash,
              30u,
              300u,
              3000u}});
@@ -409,29 +409,29 @@ TEST_CASE("headers  to hashes  empty  returns empty list", "[headers]") {
 
 TEST_CASE("headers  to hashes  non empty  returns header hash list", "[headers]") {
     hash_list const expected{
-        hash_literal("108127a4f5955a546b78807166d8cb9cd3eee1ed530c14d51095bc798685f4d6"),
-        hash_literal("37ec64a548b6419769b152d70efc4c356f74c7fda567711d98cac3c55c34a890"),
-        hash_literal("d9bbb4b47ca45ec8477cba125262b07b17daae944b54d1780e0a6373d2eed879")};
+        "108127a4f5955a546b78807166d8cb9cd3eee1ed530c14d51095bc798685f4d6"_hash,
+        "37ec64a548b6419769b152d70efc4c356f74c7fda567711d98cac3c55c34a890"_hash,
+        "d9bbb4b47ca45ec8477cba125262b07b17daae944b54d1780e0a6373d2eed879"_hash};
 
     const message::headers instance(
         {header{
              1u,
-             hash_literal("f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"),
-             hash_literal("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"),
+             "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"_hash,
+             "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"_hash,
              10u,
              100u,
              1000u},
          header{
              2u,
-             hash_literal("abababababababababababababababababababababababababababababababab"),
-             hash_literal("babababababababababababababababababababababababababababababababa"),
+             "abababababababababababababababababababababababababababababababab"_hash,
+             "babababababababababababababababababababababababababababababababa"_hash,
              20u,
              200u,
              2000u},
          header{
              3u,
-             hash_literal("e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2"),
-             hash_literal("7373737373737373737373737373737373737373737373737373737373737373"),
+             "e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2"_hash,
+             "7373737373737373737373737373737373737373737373737373737373737373"_hash,
              30u,
              300u,
              3000u}});
@@ -451,29 +451,29 @@ TEST_CASE("headers  to inventory  empty  returns empty list", "[headers]") {
 
 TEST_CASE("headers  to inventory  non empty  returns header hash inventory list", "[headers]") {
     inventory_vector::list const expected{
-        inventory_vector(inventory_vector::type_id::block, hash_literal("108127a4f5955a546b78807166d8cb9cd3eee1ed530c14d51095bc798685f4d6")),
-        inventory_vector(inventory_vector::type_id::block, hash_literal("37ec64a548b6419769b152d70efc4c356f74c7fda567711d98cac3c55c34a890")),
-        inventory_vector(inventory_vector::type_id::block, hash_literal("d9bbb4b47ca45ec8477cba125262b07b17daae944b54d1780e0a6373d2eed879"))};
+        inventory_vector(inventory_vector::type_id::block, "108127a4f5955a546b78807166d8cb9cd3eee1ed530c14d51095bc798685f4d6"_hash),
+        inventory_vector(inventory_vector::type_id::block, "37ec64a548b6419769b152d70efc4c356f74c7fda567711d98cac3c55c34a890"_hash),
+        inventory_vector(inventory_vector::type_id::block, "d9bbb4b47ca45ec8477cba125262b07b17daae944b54d1780e0a6373d2eed879"_hash)};
 
     headers const instance(
         {header{
              1u,
-             hash_literal("f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"),
-             hash_literal("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"),
+             "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"_hash,
+             "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"_hash,
              10u,
              100u,
              1000u},
          header{
              2u,
-             hash_literal("abababababababababababababababababababababababababababababababab"),
-             hash_literal("babababababababababababababababababababababababababababababababa"),
+             "abababababababababababababababababababababababababababababababab"_hash,
+             "babababababababababababababababababababababababababababababababa"_hash,
              20u,
              200u,
              2000u},
          header{
              3u,
-             hash_literal("e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2"),
-             hash_literal("7373737373737373737373737373737373737373737373737373737373737373"),
+             "e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2"_hash,
+             "7373737373737373737373737373737373737373737373737373737373737373"_hash,
              30u,
              300u,
              3000u}});
@@ -493,8 +493,8 @@ TEST_CASE("headers  is sequential  empty  true", "[headers]") {
 TEST_CASE("headers  is sequential  single  true", "[headers]") {
     static header const first{
         1u,
-        hash_literal("f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"),
-        hash_literal("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"),
+        "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"_hash,
+        "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"_hash,
         10u,
         100u,
         1000u};
@@ -506,8 +506,8 @@ TEST_CASE("headers  is sequential  single  true", "[headers]") {
 TEST_CASE("headers  is sequential  sequential  true", "[headers]") {
     static header const first{
         1u,
-        hash_literal("f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"),
-        hash_literal("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"),
+        "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"_hash,
+        "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"_hash,
         10u,
         100u,
         1000u};
@@ -515,7 +515,7 @@ TEST_CASE("headers  is sequential  sequential  true", "[headers]") {
     static header const second{
         2u,
         first.hash(),
-        hash_literal("babababababababababababababababababababababababababababababababa"),
+        "babababababababababababababababababababababababababababababababa"_hash,
         20u,
         200u,
         2000u};
@@ -523,7 +523,7 @@ TEST_CASE("headers  is sequential  sequential  true", "[headers]") {
     static header const third{
         3u,
         second.hash(),
-        hash_literal("7373737373737373737373737373737373737373737373737373737373737373"),
+        "7373737373737373737373737373737373737373737373737373737373737373"_hash,
         30u,
         300u,
         3000u};
@@ -535,24 +535,24 @@ TEST_CASE("headers  is sequential  sequential  true", "[headers]") {
 TEST_CASE("headers  is sequential  disordered  false", "[headers]") {
     static header const first{
         1u,
-        hash_literal("f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"),
-        hash_literal("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"),
+        "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"_hash,
+        "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"_hash,
         10u,
         100u,
         1000u};
 
     static header const second{
         2u,
-        hash_literal("abababababababababababababababababababababababababababababababab"),
-        hash_literal("babababababababababababababababababababababababababababababababa"),
+        "abababababababababababababababababababababababababababababababab"_hash,
+        "babababababababababababababababababababababababababababababababa"_hash,
         20u,
         200u,
         2000u};
 
     static header const third{
         3u,
-        hash_literal("e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2"),
-        hash_literal("7373737373737373737373737373737373737373737373737373737373737373"),
+        "e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2"_hash,
+        "7373737373737373737373737373737373737373737373737373737373737373"_hash,
         30u,
         300u,
         3000u};

--- a/src/domain/test/message/inventory.cpp
+++ b/src/domain/test/message/inventory.cpp
@@ -32,7 +32,7 @@ TEST_CASE("inventory  constructor 2  always  equals params", "[inventory]") {
 
 TEST_CASE("inventory  constructor 3  always  equals params", "[inventory]") {
     message::inventory_vector::type_id type = message::inventory_vector::type_id::error;
-    auto hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    auto hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     message::inventory_vector::list values =
         {
             message::inventory_vector(type, hash)};
@@ -47,7 +47,7 @@ TEST_CASE("inventory  constructor 3  always  equals params", "[inventory]") {
 
 TEST_CASE("inventory  constructor 4  always  equals params", "[inventory]") {
     message::inventory_vector::type_id type = message::inventory_vector::type_id::error;
-    auto hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    auto hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     hash_list const hashes = {hash};
 
     message::inventory instance(hashes, type);
@@ -60,7 +60,7 @@ TEST_CASE("inventory  constructor 4  always  equals params", "[inventory]") {
 
 TEST_CASE("inventory  constructor 5  always  equals params", "[inventory]") {
     message::inventory_vector::type_id type = message::inventory_vector::type_id::error;
-    auto hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    auto hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     message::inventory instance{{type, hash}};
     REQUIRE(instance.is_valid());
@@ -72,7 +72,7 @@ TEST_CASE("inventory  constructor 5  always  equals params", "[inventory]") {
 
 TEST_CASE("inventory  constructor 6  always  equals params", "[inventory]") {
     message::inventory_vector::type_id type = message::inventory_vector::type_id::error;
-    auto hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    auto hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     const message::inventory value{{type, hash}};
     REQUIRE(value.is_valid());
@@ -86,7 +86,7 @@ TEST_CASE("inventory  constructor 6  always  equals params", "[inventory]") {
 
 TEST_CASE("inventory  constructor 7  always  equals params", "[inventory]") {
     message::inventory_vector::type_id type = message::inventory_vector::type_id::error;
-    auto hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    auto hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     message::inventory value{{type, hash}};
     REQUIRE(value.is_valid());
@@ -132,7 +132,7 @@ TEST_CASE("inventory  inventories accessor 1  always  returns initialized value"
     const message::inventory_vector::list values =
         {
             message::inventory_vector(message::inventory_vector::type_id::error,
-                                      hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"))};
+                                      "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)};
 
     message::inventory instance(values);
     REQUIRE(values == instance.inventories());
@@ -142,7 +142,7 @@ TEST_CASE("inventory  inventories accessor 2  always  returns initialized value"
     const message::inventory_vector::list values =
         {
             message::inventory_vector(message::inventory_vector::type_id::error,
-                                      hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"))};
+                                      "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)};
 
     const message::inventory instance(values);
     REQUIRE(values == instance.inventories());
@@ -152,7 +152,7 @@ TEST_CASE("inventory  inventories setter 1  roundtrip  success", "[inventory]") 
     const message::inventory_vector::list values =
         {
             message::inventory_vector(message::inventory_vector::type_id::error,
-                                      hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"))};
+                                      "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)};
 
     message::inventory instance;
     REQUIRE(values != instance.inventories());
@@ -164,7 +164,7 @@ TEST_CASE("inventory  inventories setter 2  roundtrip  success", "[inventory]") 
     message::inventory_vector::list values =
         {
             message::inventory_vector(message::inventory_vector::type_id::error,
-                                      hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"))};
+                                      "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)};
 
     message::inventory instance;
     REQUIRE(0u == instance.inventories().size());
@@ -176,7 +176,7 @@ TEST_CASE("inventory  operator assign equals  always  matches equivalent", "[inv
     const message::inventory_vector::list elements =
         {
             message::inventory_vector(message::inventory_vector::type_id::error,
-                                      hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"))};
+                                      "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)};
 
     message::inventory instance;
     REQUIRE( ! instance.is_valid());
@@ -189,7 +189,7 @@ TEST_CASE("inventory  operator assign equals  always  matches equivalent", "[inv
 TEST_CASE("inventory  operator boolean equals  duplicates  returns true", "[inventory]") {
     const message::inventory expected(
         {message::inventory_vector(message::inventory_vector::type_id::error,
-                                   hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"))});
+                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)});
 
     message::inventory instance(expected);
     REQUIRE(instance == expected);
@@ -198,7 +198,7 @@ TEST_CASE("inventory  operator boolean equals  duplicates  returns true", "[inve
 TEST_CASE("inventory  operator boolean equals  differs  returns false", "[inventory]") {
     const message::inventory expected(
         {message::inventory_vector(message::inventory_vector::type_id::error,
-                                   hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"))});
+                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)});
 
     message::inventory instance;
     REQUIRE(instance != expected);
@@ -207,7 +207,7 @@ TEST_CASE("inventory  operator boolean equals  differs  returns false", "[invent
 TEST_CASE("inventory  operator boolean not equals  duplicates  returns false", "[inventory]") {
     const message::inventory expected(
         {message::inventory_vector(message::inventory_vector::type_id::error,
-                                   hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"))});
+                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)});
 
     message::inventory instance(expected);
     REQUIRE(instance == expected);
@@ -216,7 +216,7 @@ TEST_CASE("inventory  operator boolean not equals  duplicates  returns false", "
 TEST_CASE("inventory  operator boolean not equals  differs  returns true", "[inventory]") {
     const message::inventory expected(
         {message::inventory_vector(message::inventory_vector::type_id::error,
-                                   hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"))});
+                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)});
 
     message::inventory instance;
     REQUIRE(instance != expected);
@@ -225,7 +225,7 @@ TEST_CASE("inventory  operator boolean not equals  differs  returns true", "[inv
 TEST_CASE("inventory  count  no matching type  returns zero", "[inventory]") {
     message::inventory instance(
         {message::inventory_vector(message::inventory_vector::type_id::error,
-                                   hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"))});
+                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)});
 
     REQUIRE(0u == instance.count(message::inventory_vector::type_id::block));
 }
@@ -233,13 +233,13 @@ TEST_CASE("inventory  count  no matching type  returns zero", "[inventory]") {
 TEST_CASE("inventory  count  matching type  returns count", "[inventory]") {
     message::inventory instance(
         {message::inventory_vector(message::inventory_vector::type_id::error,
-                                   hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b")),
+                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash),
          message::inventory_vector(message::inventory_vector::type_id::error,
-                                   hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b")),
+                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash),
          message::inventory_vector(message::inventory_vector::type_id::block,
-                                   hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b")),
+                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash),
          message::inventory_vector(message::inventory_vector::type_id::error,
-                                   hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"))});
+                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)});
 
     REQUIRE(3u == instance.count(message::inventory_vector::type_id::error));
 }
@@ -249,13 +249,13 @@ TEST_CASE("inventory  to hashes  matching type  returns empty list", "[inventory
 
     message::inventory instance(
         {message::inventory_vector(message::inventory_vector::type_id::error,
-                                   hash_literal("1111111111111111111111111111111111111111111111111111111111111111")),
+                                   "1111111111111111111111111111111111111111111111111111111111111111"_hash),
          message::inventory_vector(message::inventory_vector::type_id::error,
-                                   hash_literal("2222222222222222222222222222222222222222222222222222222222222222")),
+                                   "2222222222222222222222222222222222222222222222222222222222222222"_hash),
          message::inventory_vector(message::inventory_vector::type_id::block,
-                                   hash_literal("3333333333333333333333333333333333333333333333333333333333333333")),
+                                   "3333333333333333333333333333333333333333333333333333333333333333"_hash),
          message::inventory_vector(message::inventory_vector::type_id::error,
-                                   hash_literal("4444444444444444444444444444444444444444444444444444444444444444"))});
+                                   "4444444444444444444444444444444444444444444444444444444444444444"_hash)});
 
     hash_list result;
     instance.to_hashes(result, message::inventory_vector::type_id::transaction);
@@ -264,19 +264,19 @@ TEST_CASE("inventory  to hashes  matching type  returns empty list", "[inventory
 
 TEST_CASE("inventory  to hashes  matching type  returns hashes", "[inventory]") {
     hash_list const hashes = {
-        hash_literal("1111111111111111111111111111111111111111111111111111111111111111"),
-        hash_literal("2222222222222222222222222222222222222222222222222222222222222222"),
-        hash_literal("4444444444444444444444444444444444444444444444444444444444444444")};
+        "1111111111111111111111111111111111111111111111111111111111111111"_hash,
+        "2222222222222222222222222222222222222222222222222222222222222222"_hash,
+        "4444444444444444444444444444444444444444444444444444444444444444"_hash};
 
     message::inventory instance(
         {message::inventory_vector(message::inventory_vector::type_id::error,
-                                   hash_literal("1111111111111111111111111111111111111111111111111111111111111111")),
+                                   "1111111111111111111111111111111111111111111111111111111111111111"_hash),
          message::inventory_vector(message::inventory_vector::type_id::error,
-                                   hash_literal("2222222222222222222222222222222222222222222222222222222222222222")),
+                                   "2222222222222222222222222222222222222222222222222222222222222222"_hash),
          message::inventory_vector(message::inventory_vector::type_id::block,
-                                   hash_literal("3333333333333333333333333333333333333333333333333333333333333333")),
+                                   "3333333333333333333333333333333333333333333333333333333333333333"_hash),
          message::inventory_vector(message::inventory_vector::type_id::error,
-                                   hash_literal("4444444444444444444444444444444444444444444444444444444444444444"))});
+                                   "4444444444444444444444444444444444444444444444444444444444444444"_hash)});
 
     hash_list result;
     instance.to_hashes(result, message::inventory_vector::type_id::error);
@@ -288,13 +288,13 @@ TEST_CASE("inventory  reduce  matching type  returns empty list", "[inventory]")
 
     message::inventory instance(
         {message::inventory_vector(message::inventory_vector::type_id::error,
-                                   hash_literal("1111111111111111111111111111111111111111111111111111111111111111")),
+                                   "1111111111111111111111111111111111111111111111111111111111111111"_hash),
          message::inventory_vector(message::inventory_vector::type_id::error,
-                                   hash_literal("2222222222222222222222222222222222222222222222222222222222222222")),
+                                   "2222222222222222222222222222222222222222222222222222222222222222"_hash),
          message::inventory_vector(message::inventory_vector::type_id::block,
-                                   hash_literal("3333333333333333333333333333333333333333333333333333333333333333")),
+                                   "3333333333333333333333333333333333333333333333333333333333333333"_hash),
          message::inventory_vector(message::inventory_vector::type_id::error,
-                                   hash_literal("4444444444444444444444444444444444444444444444444444444444444444"))});
+                                   "4444444444444444444444444444444444444444444444444444444444444444"_hash)});
 
     message::inventory_vector::list result;
     instance.reduce(result, message::inventory_vector::type_id::transaction);
@@ -304,21 +304,21 @@ TEST_CASE("inventory  reduce  matching type  returns empty list", "[inventory]")
 TEST_CASE("inventory  reduce  matching type  returns matches", "[inventory]") {
     const message::inventory_vector::list expected = {
         message::inventory_vector(message::inventory_vector::type_id::error,
-                                  hash_literal("1111111111111111111111111111111111111111111111111111111111111111")),
+                                  "1111111111111111111111111111111111111111111111111111111111111111"_hash),
         message::inventory_vector(message::inventory_vector::type_id::error,
-                                  hash_literal("2222222222222222222222222222222222222222222222222222222222222222")),
+                                  "2222222222222222222222222222222222222222222222222222222222222222"_hash),
         message::inventory_vector(message::inventory_vector::type_id::error,
-                                  hash_literal("4444444444444444444444444444444444444444444444444444444444444444"))};
+                                  "4444444444444444444444444444444444444444444444444444444444444444"_hash)};
 
     message::inventory instance(
         {message::inventory_vector(message::inventory_vector::type_id::error,
-                                   hash_literal("1111111111111111111111111111111111111111111111111111111111111111")),
+                                   "1111111111111111111111111111111111111111111111111111111111111111"_hash),
          message::inventory_vector(message::inventory_vector::type_id::error,
-                                   hash_literal("2222222222222222222222222222222222222222222222222222222222222222")),
+                                   "2222222222222222222222222222222222222222222222222222222222222222"_hash),
          message::inventory_vector(message::inventory_vector::type_id::block,
-                                   hash_literal("3333333333333333333333333333333333333333333333333333333333333333")),
+                                   "3333333333333333333333333333333333333333333333333333333333333333"_hash),
          message::inventory_vector(message::inventory_vector::type_id::error,
-                                   hash_literal("4444444444444444444444444444444444444444444444444444444444444444"))});
+                                   "4444444444444444444444444444444444444444444444444444444444444444"_hash)});
 
     message::inventory_vector::list result;
     instance.reduce(result, message::inventory_vector::type_id::error);

--- a/src/domain/test/message/inventory_vector.cpp
+++ b/src/domain/test/message/inventory_vector.cpp
@@ -65,7 +65,7 @@ TEST_CASE("inventory vector constructor 1 always invalid", "[inventory vector]")
 
 TEST_CASE("inventory vector constructor 2 always equals params", "[inventory vector]") {
     inventory_vector::type_id type = inventory_vector::type_id::block;
-    hash_digest hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     inventory_vector instance(type, hash);
     REQUIRE(instance.is_valid());
     REQUIRE(type == instance.type());
@@ -74,14 +74,14 @@ TEST_CASE("inventory vector constructor 2 always equals params", "[inventory vec
 
 TEST_CASE("inventory vector constructor 3 always equals params", "[inventory vector]") {
     inventory_vector::type_id type = inventory_vector::type_id::block;
-    hash_digest hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     inventory_vector instance(type, std::move(hash));
     REQUIRE(instance.is_valid());
 }
 
 TEST_CASE("inventory vector constructor 4 always equals params", "[inventory vector]") {
     inventory_vector::type_id type = inventory_vector::type_id::block;
-    hash_digest hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     inventory_vector const expected(type, hash);
     REQUIRE(expected.is_valid());
     inventory_vector instance(expected);
@@ -91,7 +91,7 @@ TEST_CASE("inventory vector constructor 4 always equals params", "[inventory vec
 
 TEST_CASE("inventory vector constructor 5 always equals params", "[inventory vector]") {
     inventory_vector::type_id type = inventory_vector::type_id::block;
-    hash_digest hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     inventory_vector expected(type, hash);
     REQUIRE(expected.is_valid());
     inventory_vector instance(std::move(expected));
@@ -174,7 +174,7 @@ TEST_CASE("inventory vector is transaction type non transaction type returns fal
 
 TEST_CASE("inventory vector type accessor always returns initialized value", "[inventory vector]") {
     inventory_vector::type_id type = inventory_vector::type_id::transaction;
-    hash_digest hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     inventory_vector instance(type, hash);
     REQUIRE(type == instance.type());
 }
@@ -189,13 +189,13 @@ TEST_CASE("inventory vector type setter  roundtrip  success", "[inventory vector
 
 TEST_CASE("inventory vector hash accessor always returns initialized value", "[inventory vector]") {
     inventory_vector::type_id type = inventory_vector::type_id::transaction;
-    hash_digest hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     inventory_vector instance(type, hash);
     REQUIRE(hash == instance.hash());
 }
 
 TEST_CASE("inventory vector hash setter 1  roundtrip  success", "[inventory vector]") {
-    hash_digest hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     inventory_vector instance;
     REQUIRE(hash != instance.hash());
     instance.set_hash(hash);
@@ -203,8 +203,8 @@ TEST_CASE("inventory vector hash setter 1  roundtrip  success", "[inventory vect
 }
 
 TEST_CASE("inventory vector hash setter 2  roundtrip  success", "[inventory vector]") {
-    hash_digest duplicate = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
-    hash_digest hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest duplicate = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
+    hash_digest hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     inventory_vector instance;
     REQUIRE(duplicate != instance.hash());
     instance.set_hash(std::move(hash));
@@ -214,7 +214,7 @@ TEST_CASE("inventory vector hash setter 2  roundtrip  success", "[inventory vect
 TEST_CASE("inventory vector operator assign equals 1 always matches equivalent", "[inventory vector]") {
     inventory_vector value(
         inventory_vector::type_id::compact_block,
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash);
 
     REQUIRE(value.is_valid());
 
@@ -228,7 +228,7 @@ TEST_CASE("inventory vector operator assign equals 1 always matches equivalent",
 TEST_CASE("inventory vector operator assign equals 2 always matches equivalent", "[inventory vector]") {
     inventory_vector value(
         inventory_vector::type_id::compact_block,
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash);
 
     REQUIRE(value.is_valid());
 
@@ -243,7 +243,7 @@ TEST_CASE("inventory vector operator assign equals 2 always matches equivalent",
 TEST_CASE("inventory vector operator boolean equals duplicates returns true", "[inventory vector]") {
     inventory_vector const expected(
         inventory_vector::type_id::filtered_block,
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash);
 
     inventory_vector instance(expected);
     REQUIRE(instance == expected);
@@ -252,7 +252,7 @@ TEST_CASE("inventory vector operator boolean equals duplicates returns true", "[
 TEST_CASE("inventory vector operator boolean equals differs returns false", "[inventory vector]") {
     inventory_vector const expected(
         inventory_vector::type_id::filtered_block,
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash);
 
     inventory_vector instance;
     REQUIRE(instance != expected);
@@ -261,7 +261,7 @@ TEST_CASE("inventory vector operator boolean equals differs returns false", "[in
 TEST_CASE("inventory vector - reject  operator boolean not equals duplicates returns false", "[inventory vector]") {
     inventory_vector const expected(
         inventory_vector::type_id::filtered_block,
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash);
 
     inventory_vector instance(expected);
     REQUIRE(instance == expected);
@@ -270,7 +270,7 @@ TEST_CASE("inventory vector - reject  operator boolean not equals duplicates ret
 TEST_CASE("inventory vector - reject  operator boolean not equals differs returns true", "[inventory vector]") {
     inventory_vector const expected(
         inventory_vector::type_id::filtered_block,
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash);
 
     inventory_vector instance;
     REQUIRE(instance != expected);

--- a/src/domain/test/message/merkle_block.cpp
+++ b/src/domain/test/message/merkle_block.cpp
@@ -17,8 +17,8 @@ TEST_CASE("merkle block  constructor 1  always invalid", "[merkle block]") {
 TEST_CASE("merkle block  constructor 2  always  equals params", "[merkle block]") {
     chain::header const header(
         10,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234,
         6523454,
         68644);
@@ -26,9 +26,9 @@ TEST_CASE("merkle block  constructor 2  always  equals params", "[merkle block]"
     size_t const count = 1234u;
 
     hash_list const hashes{
-        hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"),
-        hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
-        hash_literal("ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"),
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
+        "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
     };
     data_chunk const flags{0xae, 0x56, 0x0f};
 
@@ -44,16 +44,16 @@ TEST_CASE("merkle block  constructor 3  always  equals params", "[merkle block]"
     const message::merkle_block instance(
         chain::header{
             10,
-            hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-            hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
             531234,
             6523454,
             68644},
         1234u,
         {
-            hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"),
-            hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
-            hash_literal("ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"),
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
+            "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
         },
         {0xae, 0x56, 0x0f});
 
@@ -64,16 +64,16 @@ TEST_CASE("merkle block  constructor 4  always  equals params", "[merkle block]"
     const message::merkle_block expected(
         chain::header{
             10,
-            hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-            hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
             531234,
             6523454,
             68644},
         4321234u,
         {
-            hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"),
-            hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
-            hash_literal("ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"),
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
+            "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
         },
         {0xae, 0x56, 0x0f});
 
@@ -85,8 +85,8 @@ TEST_CASE("merkle block  constructor 4  always  equals params", "[merkle block]"
 TEST_CASE("merkle block  constructor 5  always  equals params", "[merkle block]") {
     chain::header const header(
         10,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234,
         6523454,
         68644);
@@ -94,9 +94,9 @@ TEST_CASE("merkle block  constructor 5  always  equals params", "[merkle block]"
     size_t const count = 654576u;
 
     hash_list const hashes{
-        hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"),
-        hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
-        hash_literal("ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"),
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
+        "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
     };
     data_chunk const flags{0xae, 0x56, 0x0f};
 
@@ -122,13 +122,13 @@ TEST_CASE("from data insufficient data fails", "[merkle block]") {
 TEST_CASE("from data insufficient version fails", "[merkle block]") {
     const message::merkle_block expected{
         {10,
-         hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+         "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+         "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
          531234,
          6523454,
          68644},
         34523u,
-        {hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b")},
+        {"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash},
         {0x00}};
 
     auto const data = expected.to_data(message::version::level::maximum);
@@ -143,13 +143,13 @@ TEST_CASE("from data insufficient version fails", "[merkle block]") {
 TEST_CASE("merkle block - roundtrip to data factory from data chunk", "[merkle block]") {
     const message::merkle_block expected{
         {10,
-         hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+         "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+         "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
          531234,
          6523454,
          68644},
         45633u,
-        {hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b")},
+        {"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash},
         {0x00}};
 
     auto const data = expected.to_data(message::version::level::maximum);
@@ -167,8 +167,8 @@ TEST_CASE("merkle block - roundtrip to data factory from data chunk", "[merkle b
 TEST_CASE("merkle block  header accessor 1  always  returns initialized value", "[merkle block]") {
     chain::header const expected{
         10,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234,
         6523454,
         68644};
@@ -177,9 +177,9 @@ TEST_CASE("merkle block  header accessor 1  always  returns initialized value", 
         expected,
         753u,
         {
-            hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"),
-            hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
-            hash_literal("ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"),
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
+            "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
         },
         {0xae, 0x56, 0x0f});
 
@@ -189,8 +189,8 @@ TEST_CASE("merkle block  header accessor 1  always  returns initialized value", 
 TEST_CASE("merkle block  header accessor 2  always  returns initialized value", "[merkle block]") {
     chain::header const expected{
         10,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234,
         6523454,
         68644};
@@ -199,9 +199,9 @@ TEST_CASE("merkle block  header accessor 2  always  returns initialized value", 
         expected,
         9542u,
         {
-            hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"),
-            hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
-            hash_literal("ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"),
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
+            "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
         },
         {0xae, 0x56, 0x0f});
 
@@ -211,8 +211,8 @@ TEST_CASE("merkle block  header accessor 2  always  returns initialized value", 
 TEST_CASE("merkle block  header setter 1  roundtrip  success", "[merkle block]") {
     chain::header const expected{
         10,
-        hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         531234,
         6523454,
         68644};
@@ -229,8 +229,8 @@ TEST_CASE("merkle block  header setter 2  roundtrip  success", "[merkle block]")
     instance.set_header(
         chain::header{
             10,
-            hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-            hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
             531234,
             6523454,
             68644});
@@ -240,16 +240,16 @@ TEST_CASE("merkle block  header setter 2  roundtrip  success", "[merkle block]")
 
 TEST_CASE("merkle block  hashes accessor 1  always  returns initialized value", "[merkle block]") {
     hash_list const expected{
-        hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"),
-        hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
-        hash_literal("ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"),
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
+        "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
     };
 
     const message::merkle_block instance(
         chain::header{
             10,
-            hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-            hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
             531234,
             6523454,
             68644},
@@ -262,16 +262,16 @@ TEST_CASE("merkle block  hashes accessor 1  always  returns initialized value", 
 
 TEST_CASE("merkle block  hashes accessor 2  always  returns initialized value", "[merkle block]") {
     hash_list const expected{
-        hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"),
-        hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
-        hash_literal("ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"),
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
+        "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
     };
 
     const message::merkle_block instance(
         chain::header{
             10,
-            hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-            hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
             531234,
             6523454,
             68644},
@@ -284,9 +284,9 @@ TEST_CASE("merkle block  hashes accessor 2  always  returns initialized value", 
 
 TEST_CASE("merkle block  hashes setter 1  roundtrip  success", "[merkle block]") {
     hash_list const expected{
-        hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"),
-        hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
-        hash_literal("ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"),
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
+        "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
     };
 
     message::merkle_block instance;
@@ -299,9 +299,9 @@ TEST_CASE("merkle block  hashes setter 2  roundtrip  success", "[merkle block]")
     message::merkle_block instance;
     REQUIRE(instance.hashes().empty());
     instance.set_hashes(hash_list{
-        hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"),
-        hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
-        hash_literal("ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"),
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
+        "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
     });
 
     REQUIRE( ! instance.hashes().empty());
@@ -313,16 +313,16 @@ TEST_CASE("merkle block  flags accessor 1  always  returns initialized value", "
     const message::merkle_block instance(
         chain::header{
             10,
-            hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-            hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
             531234,
             6523454,
             68644},
         8264u,
         {
-            hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"),
-            hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
-            hash_literal("ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"),
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
+            "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
         },
         expected);
 
@@ -335,16 +335,16 @@ TEST_CASE("merkle block  flags accessor 2  always  returns initialized value", "
     const message::merkle_block instance(
         chain::header{
             10,
-            hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-            hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
             531234,
             6523454,
             68644},
         6428u,
         {
-            hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"),
-            hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
-            hash_literal("ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"),
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
+            "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
         },
         expected);
 
@@ -370,16 +370,16 @@ TEST_CASE("merkle block  operator assign equals  always  matches equivalent", "[
     message::merkle_block value(
         chain::header{
             10,
-            hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-            hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
             531234,
             6523454,
             68644},
         3197u,
         {
-            hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"),
-            hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
-            hash_literal("ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"),
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
+            "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
         },
         {0xae, 0x56, 0x0f});
 
@@ -396,16 +396,16 @@ TEST_CASE("merkle block  operator boolean equals  duplicates  returns true", "[m
     const message::merkle_block expected(
         chain::header{
             10,
-            hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-            hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
             531234,
             6523454,
             68644},
         9821u,
         {
-            hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"),
-            hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
-            hash_literal("ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"),
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
+            "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
         },
         {0xae, 0x56, 0x0f});
 
@@ -417,16 +417,16 @@ TEST_CASE("merkle block  operator boolean equals  differs  returns false", "[mer
     const message::merkle_block expected(
         chain::header{
             10,
-            hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-            hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
             531234,
             6523454,
             68644},
         1469u,
         {
-            hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"),
-            hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
-            hash_literal("ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"),
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
+            "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
         },
         {0xae, 0x56, 0x0f});
 
@@ -438,16 +438,16 @@ TEST_CASE("merkle block  operator boolean not equals  duplicates  returns false"
     const message::merkle_block expected(
         chain::header{
             10,
-            hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-            hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
             531234,
             6523454,
             68644},
         3524u,
         {
-            hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"),
-            hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
-            hash_literal("ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"),
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
+            "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
         },
         {0xae, 0x56, 0x0f});
 
@@ -459,16 +459,16 @@ TEST_CASE("merkle block  operator boolean not equals  differs  returns true", "[
     const message::merkle_block expected(
         chain::header{
             10,
-            hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-            hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
             531234,
             6523454,
             68644},
         8642u,
         {
-            hash_literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"),
-            hash_literal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
-            hash_literal("ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"),
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
+            "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
         },
         {0xae, 0x56, 0x0f});
 

--- a/src/domain/test/message/not_found.cpp
+++ b/src/domain/test/message/not_found.cpp
@@ -32,7 +32,7 @@ TEST_CASE("not found  constructor 2  always  equals params", "[not found]") {
 
 TEST_CASE("not found  constructor 3  always  equals params", "[not found]") {
     message::inventory_vector::type_id type = message::inventory_vector::type_id::error;
-    auto hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    auto hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     message::inventory_vector::list values =
         {
             message::inventory_vector(type, hash)};
@@ -47,7 +47,7 @@ TEST_CASE("not found  constructor 3  always  equals params", "[not found]") {
 
 TEST_CASE("not found  constructor 4  always  equals params", "[not found]") {
     message::inventory_vector::type_id type = message::inventory_vector::type_id::error;
-    auto hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    auto hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     hash_list const hashes = {hash};
 
     message::not_found instance(hashes, type);
@@ -60,7 +60,7 @@ TEST_CASE("not found  constructor 4  always  equals params", "[not found]") {
 
 TEST_CASE("not found  constructor 5  always  equals params", "[not found]") {
     message::inventory_vector::type_id type = message::inventory_vector::type_id::error;
-    auto hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    auto hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     message::not_found instance{{type, hash}};
     REQUIRE(instance.is_valid());
@@ -72,7 +72,7 @@ TEST_CASE("not found  constructor 5  always  equals params", "[not found]") {
 
 TEST_CASE("not found  constructor 6  always  equals params", "[not found]") {
     message::inventory_vector::type_id type = message::inventory_vector::type_id::error;
-    auto hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    auto hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     const message::not_found value{{type, hash}};
     REQUIRE(value.is_valid());
@@ -86,7 +86,7 @@ TEST_CASE("not found  constructor 6  always  equals params", "[not found]") {
 
 TEST_CASE("not found  constructor 7  always  equals params", "[not found]") {
     message::inventory_vector::type_id type = message::inventory_vector::type_id::error;
-    auto hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    auto hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     message::not_found value{{type, hash}};
     REQUIRE(value.is_valid());
@@ -148,7 +148,7 @@ TEST_CASE("not found  operator assign equals  always  matches equivalent", "[not
     const message::inventory_vector::list elements =
         {
             message::inventory_vector(message::inventory_vector::type_id::error,
-                                      hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"))};
+                                      "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)};
 
     message::not_found value(elements);
     REQUIRE(value.is_valid());
@@ -164,7 +164,7 @@ TEST_CASE("not found  operator assign equals  always  matches equivalent", "[not
 TEST_CASE("not found  operator boolean equals  duplicates  returns true", "[not found]") {
     const message::not_found expected(
         {message::inventory_vector(message::inventory_vector::type_id::error,
-                                   hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"))});
+                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)});
 
     message::not_found instance(expected);
     REQUIRE(instance == expected);
@@ -173,7 +173,7 @@ TEST_CASE("not found  operator boolean equals  duplicates  returns true", "[not 
 TEST_CASE("not found  operator boolean equals  differs  returns false", "[not found]") {
     const message::not_found expected(
         {message::inventory_vector(message::inventory_vector::type_id::error,
-                                   hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"))});
+                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)});
 
     message::not_found instance;
     REQUIRE(instance != expected);
@@ -182,7 +182,7 @@ TEST_CASE("not found  operator boolean equals  differs  returns false", "[not fo
 TEST_CASE("not found  operator boolean not equals  duplicates  returns false", "[not found]") {
     const message::not_found expected(
         {message::inventory_vector(message::inventory_vector::type_id::error,
-                                   hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"))});
+                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)});
 
     message::not_found instance(expected);
     REQUIRE(instance == expected);
@@ -191,7 +191,7 @@ TEST_CASE("not found  operator boolean not equals  duplicates  returns false", "
 TEST_CASE("not found  operator boolean not equals  differs  returns true", "[not found]") {
     const message::not_found expected(
         {message::inventory_vector(message::inventory_vector::type_id::error,
-                                   hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"))});
+                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)});
 
     message::not_found instance;
     REQUIRE(instance != expected);

--- a/src/domain/test/message/reject.cpp
+++ b/src/domain/test/message/reject.cpp
@@ -45,7 +45,7 @@ TEST_CASE("reject  constructor 2  always  equals params", "[reject]") {
     auto code = message::reject::reason_code::nonstandard;
     std::string message = "Alpha Beta";
     std::string reason = "Gamma Delta";
-    hash_digest data = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest data = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     message::reject instance(code, message, reason, data);
     REQUIRE(instance.is_valid());
     REQUIRE(code == instance.code());
@@ -58,7 +58,7 @@ TEST_CASE("reject  constructor 3  always  equals params", "[reject]") {
     auto code = message::reject::reason_code::nonstandard;
     std::string message = "sadfasdgd";
     std::string reason = "jgfghkggfsr";
-    hash_digest data = hash_literal("ce8f4b713ffdd2658900845251890f30371856be201cd1f5b3d970f793634333");
+    hash_digest data = "ce8f4b713ffdd2658900845251890f30371856be201cd1f5b3d970f793634333"_hash;
     message::reject instance(code, std::move(message), std::move(reason), std::move(data));
     REQUIRE(instance.is_valid());
 }
@@ -67,7 +67,7 @@ TEST_CASE("reject  constructor 4  always  equals params", "[reject]") {
     auto code = message::reject::reason_code::nonstandard;
     std::string message = "Alpha Beta";
     std::string reason = "Gamma Delta";
-    hash_digest data = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest data = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     message::reject expected(code, message, reason, data);
     message::reject instance(expected);
     REQUIRE(instance.is_valid());
@@ -82,7 +82,7 @@ TEST_CASE("reject  constructor 5  always  equals params", "[reject]") {
     auto code = message::reject::reason_code::nonstandard;
     std::string message = "Alpha Beta";
     std::string reason = "Gamma Delta";
-    hash_digest data = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest data = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     message::reject expected(code, message, reason, data);
     message::reject instance(std::move(expected));
     REQUIRE(instance.is_valid());
@@ -285,7 +285,7 @@ TEST_CASE("reject  code accessor  always  returns initialized value", "[reject]"
     auto code = message::reject::reason_code::nonstandard;
     std::string message = "Alpha Beta";
     std::string reason = "Gamma Delta";
-    hash_digest data = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest data = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     message::reject instance(code, message, reason, data);
     REQUIRE(code == instance.code());
 }
@@ -294,7 +294,7 @@ TEST_CASE("reject  code setter  roundtrip  success", "[reject]") {
     auto code = message::reject::reason_code::nonstandard;
     std::string message = "Alpha Beta";
     std::string reason = "Gamma Delta";
-    hash_digest data = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest data = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     message::reject instance;
     REQUIRE(code != instance.code());
     instance.set_code(code);
@@ -305,7 +305,7 @@ TEST_CASE("reject  message accessor 1  always  returns initialized value", "[rej
     auto code = message::reject::reason_code::nonstandard;
     std::string message = "Alpha Beta";
     std::string reason = "Gamma Delta";
-    hash_digest data = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest data = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     message::reject instance(code, message, reason, data);
     REQUIRE(message == instance.message());
 }
@@ -314,7 +314,7 @@ TEST_CASE("reject  message accessor 2  always  returns initialized value", "[rej
     auto code = message::reject::reason_code::nonstandard;
     std::string message = "Alpha Beta";
     std::string reason = "Gamma Delta";
-    hash_digest data = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest data = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     const message::reject instance(code, message, reason, data);
     REQUIRE(message == instance.message());
 }
@@ -340,7 +340,7 @@ TEST_CASE("reject  reason accessor 1  always  returns initialized value", "[reje
     auto code = message::reject::reason_code::nonstandard;
     std::string message = "Alpha Beta";
     std::string reason = "Gamma Delta";
-    hash_digest data = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest data = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     message::reject instance(code, message, reason, data);
     REQUIRE(reason == instance.reason());
 }
@@ -349,7 +349,7 @@ TEST_CASE("reject  reason accessor 2  always  returns initialized value", "[reje
     auto code = message::reject::reason_code::nonstandard;
     std::string message = "Alpha Beta";
     std::string reason = "Gamma Delta";
-    hash_digest data = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest data = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     const message::reject instance(code, message, reason, data);
     REQUIRE(reason == instance.reason());
 }
@@ -375,7 +375,7 @@ TEST_CASE("reject  data accessor 1  always  returns initialized value", "[reject
     auto code = message::reject::reason_code::nonstandard;
     std::string message = "Alpha Beta";
     std::string reason = "Gamma Delta";
-    hash_digest data = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest data = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     message::reject instance(code, message, reason, data);
     REQUIRE(data == instance.data());
 }
@@ -384,13 +384,13 @@ TEST_CASE("reject  data accessor 2  always  returns initialized value", "[reject
     auto code = message::reject::reason_code::nonstandard;
     std::string message = "Alpha Beta";
     std::string reason = "Gamma Delta";
-    hash_digest data = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest data = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     const message::reject instance(code, message, reason, data);
     REQUIRE(data == instance.data());
 }
 
 TEST_CASE("reject  data setter 1  roundtrip  success", "[reject]") {
-    hash_digest data = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest data = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     message::reject instance;
     REQUIRE(data != instance.data());
     instance.set_data(data);
@@ -398,8 +398,8 @@ TEST_CASE("reject  data setter 1  roundtrip  success", "[reject]") {
 }
 
 TEST_CASE("reject  data setter 2  roundtrip  success", "[reject]") {
-    hash_digest duplicate = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
-    hash_digest data = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    hash_digest duplicate = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
+    hash_digest data = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     message::reject instance;
     REQUIRE(duplicate != instance.data());
     instance.set_data(std::move(data));
@@ -411,7 +411,7 @@ TEST_CASE("reject  operator assign equals  always  matches equivalent", "[reject
         message::reject::reason_code::dust,
         "My Message",
         "My Reason",
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash);
 
     REQUIRE(value.is_valid());
 
@@ -427,7 +427,7 @@ TEST_CASE("reject  operator boolean equals  duplicates  returns true", "[reject]
         message::reject::reason_code::dust,
         "My Message",
         "My Reason",
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash);
 
     message::reject instance(expected);
     REQUIRE(instance == expected);
@@ -438,7 +438,7 @@ TEST_CASE("reject  operator boolean equals  differs  returns false", "[reject]")
         message::reject::reason_code::dust,
         "My Message",
         "My Reason",
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash);
 
     message::reject instance;
     REQUIRE(instance != expected);
@@ -449,7 +449,7 @@ TEST_CASE("reject - reject  operator boolean not equals  duplicates  returns fal
         message::reject::reason_code::dust,
         "My Message",
         "My Reason",
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash);
 
     message::reject instance(expected);
     REQUIRE(instance == expected);
@@ -460,7 +460,7 @@ TEST_CASE("reject - reject  operator boolean not equals  differs  returns true",
         message::reject::reason_code::dust,
         "My Message",
         "My Reason",
-        hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash);
 
     message::reject instance;
     REQUIRE(instance != expected);

--- a/src/domain/test/message/transaction.cpp
+++ b/src/domain/test/message/transaction.cpp
@@ -20,7 +20,7 @@ constexpr auto raw_tx1 =
     "001976a914d9d78e26df4e4601cf9b26d09c7b280ee764469f88ac80c4600f00"
     "0000001976a9141ee32412020a324b93b1a1acfdfff6ab9ca8fac288ac000000"
     "00"_base16;
-constexpr char raw_tx1_hash_hex[] = "bf7c3f5a69a78edd81f3eff7e93a37fb2d7da394d48db4d85e7e5353b9b8e270";
+static auto const raw_tx1_hash = "bf7c3f5a69a78edd81f3eff7e93a37fb2d7da394d48db4d85e7e5353b9b8e270"_hash;
 
 // Junk data for testing
 constexpr auto junk_data =
@@ -46,7 +46,7 @@ constexpr auto raw_tx2 =
     "ffff02c0e1e400000000001976a914884c09d7e1f6420976c40e040c30b2b622"
     "10c3d488ac20300500000000001976a914905f933de850988603aafeeb2fd7fc"
     "e61e66fe5d88ac00000000"_base16;
-constexpr char raw_tx2_hash_hex[] = "8a6d9302fbe24f0ec756a94ecfc837eaffe16c43d1e68c62dfe980d99eea556f";
+static auto const raw_tx2_hash = "8a6d9302fbe24f0ec756a94ecfc837eaffe16c43d1e68c62dfe980d99eea556f"_hash;
 
 // Start Test Suite: message transaction tests
 
@@ -163,7 +163,7 @@ TEST_CASE("message transaction from data valid junk  success", "[message transac
 }
 
 TEST_CASE("message transaction from data case 1 valid data  success", "[message transaction]") {
-    hash_digest tx_hash = hash_literal(raw_tx1_hash_hex);
+    hash_digest tx_hash = raw_tx1_hash;
     data_chunk raw_tx = to_chunk(raw_tx1);
     REQUIRE(raw_tx.size() == 225u);
 
@@ -182,7 +182,7 @@ TEST_CASE("message transaction from data case 1 valid data  success", "[message 
 }
 
 TEST_CASE("message transaction from data case 2 valid data  success", "[message transaction]") {
-    hash_digest tx_hash = hash_literal(raw_tx2_hash_hex);
+    hash_digest tx_hash = raw_tx2_hash;
     data_chunk raw_tx = to_chunk(raw_tx2);
     REQUIRE(raw_tx.size() == 523u);
 
@@ -337,4 +337,3 @@ TEST_CASE("message transaction  operator boolean not equals 2  differs  returns 
     REQUIRE(alpha != beta);
 }
 
-// End Test Suite

--- a/src/infrastructure/include/kth/infrastructure/formats/base_16.hpp
+++ b/src/infrastructure/include/kth/infrastructure/formats/base_16.hpp
@@ -55,12 +55,6 @@ KI_API std::string encode_hash(hash_digest hash);
  */
 KI_API bool decode_hash(hash_digest& out, std::string_view in);
 
-/**
- * Convert a hex string literal into a bitcoin_hash.
- * The bitcoin_hash format is like base16, but with the bytes reversed.
- */
-KI_API hash_digest hash_literal(char const (&string)[2*hash_size + 1]);
-
 } // namespace kth
 
 #include <kth/infrastructure/impl/formats/base_16.ipp>

--- a/src/infrastructure/include/kth/infrastructure/impl/formats/base_16.ipp
+++ b/src/infrastructure/include/kth/infrastructure/impl/formats/base_16.ipp
@@ -107,6 +107,21 @@ constexpr auto operator""_base16() {
     return result;
 }
 
+template <fixed_string Str>
+concept hash_literal = base16_literal<Str> && (Str.size() == 2 * hash_size);
+
+// User-defined literal for bitcoin hash: "000...abc"_hash
+// Bitcoin hashes are displayed reversed (little-endian)
+// TODO(fernando): investigate if this can be consteval instead of constexpr
+template <fixed_string Str>
+    requires hash_literal<Str>
+constexpr hash_digest operator""_hash() {
+    hash_digest result{};
+    detail::decode_base16(result.data(), result.size(), Str.content);
+    std::reverse(result.begin(), result.end());
+    return result;
+}
+
 } // namespace kth
 
 #endif

--- a/src/infrastructure/src/formats/base_16.cpp
+++ b/src/infrastructure/src/formats/base_16.cpp
@@ -52,12 +52,4 @@ bool decode_hash(hash_digest& out, std::string_view in) {
     return true;
 }
 
-hash_digest hash_literal(char const (&string)[2 * hash_size + 1]) {
-    hash_digest out;
-    [[maybe_unused]] auto const success = detail::decode_base16(out.data(), out.size(), string);
-    KTH_ASSERT(success);
-    std::reverse(out.begin(), out.end());
-    return out;
-}
-
 } // namespace kth

--- a/src/infrastructure/test/math/elliptic_curve.cpp
+++ b/src/infrastructure/test/math/elliptic_curve.cpp
@@ -16,12 +16,12 @@ constexpr auto uncompressed1 = "0409ba8621aefd3b6ba4ca6d11a4746e8df8d35d9b51b383
 
 // Scenario 2
 constexpr auto compressed2 = "03bc88a1bd6ebac38e9a9ed58eda735352ad10650e235499b7318315cc26c9b55b"_base16;
-constexpr char sighash2_hex[] = "ed8f9b40c2d349c8a7e58cebe79faa25c21b6bb85b874901f72a1b3f1ad0a67f";
+static auto const sighash2 = "ed8f9b40c2d349c8a7e58cebe79faa25c21b6bb85b874901f72a1b3f1ad0a67f"_hash;
 constexpr auto der_signature2 = "3045022100bc494fbd09a8e77d8266e2abdea9aef08b9e71b451c7d8de9f63cda33a62437802206b93edd6af7c659db42c579eb34a3a4cb60c28b5a6bc86fd5266d42f6b8bb67d";
 
-// Scenario 3 - these use hash_literal() which reverses bytes
-constexpr char secret3_hex[] = "ce8f4b713ffdd2658900845251890f30371856be201cd1f5b3d970f793634333";
-constexpr char sighash3_hex[] = "f89572635651b2e4f89778350616989183c98d1a721c911324bf9f17a0cf5bf0";
+// Scenario 3
+static auto const secret3 = "ce8f4b713ffdd2658900845251890f30371856be201cd1f5b3d970f793634333"_hash;
+static auto const sighash3 = "f89572635651b2e4f89778350616989183c98d1a721c911324bf9f17a0cf5bf0"_hash;
 constexpr auto ec_signature3 = "17b7b25c48e4ed2bd43369fa282f608b4329d96409860ce832fd5497b65fe663b901e34dff5291868c4401c8c1c6ed23b1887139cc4cd6884f38b9d936356131"_base16;
 constexpr auto der_signature3 = "3044022063e65fb69754fd32e80c860964d929438b602f28fa6933d42bede4485cb2b717022031613536d9b9384f88d64ccc397188b123edc6c1c801448c869152ff4de301b9";
 
@@ -41,8 +41,6 @@ TEST_CASE("elliptic curve decompress positive test", "[elliptic curve tests]") {
 
 TEST_CASE("elliptic curve sign positive test", "[elliptic curve tests]") {
     ec_signature signature;
-    ec_secret const secret3 = hash_literal(secret3_hex);
-    hash_digest const sighash3 = hash_literal(sighash3_hex);
     REQUIRE(sign_ecdsa(signature, secret3, sighash3));
     REQUIRE(signature == ec_signature3);
 }
@@ -81,7 +79,7 @@ TEST_CASE("elliptic curve sign round trip negative test", "[elliptic curve tests
 TEST_CASE("elliptic curve verify signature positive test", "[elliptic curve tests]") {
     ec_signature signature;
     static auto const strict = false;
-    hash_digest const sighash = hash_literal(sighash2_hex);
+    hash_digest const sighash = sighash2;
     auto const distinguished = decode_base16(der_signature2);
     REQUIRE(distinguished);
     REQUIRE(parse_signature(signature, *distinguished, strict));
@@ -91,7 +89,7 @@ TEST_CASE("elliptic curve verify signature positive test", "[elliptic curve test
 TEST_CASE("elliptic curve verify signature negative test", "[elliptic curve tests]") {
     ec_signature signature;
     static auto const strict = false;
-    hash_digest const sighash = hash_literal(sighash2_hex);
+    hash_digest const sighash = sighash2;
     auto const distinguished = decode_base16(der_signature2);
     REQUIRE(distinguished);
     REQUIRE(parse_signature(signature, *distinguished, strict));
@@ -142,4 +140,3 @@ TEST_CASE("elliptic curve  ec multiply test", "[elliptic curve tests]") {
     REQUIRE(std::equal(public1.begin(), public1.end(), public2.begin()));
 }
 
-// End Test Suite

--- a/src/infrastructure/test/math/uint256.cpp
+++ b/src/infrastructure/test/math/uint256.cpp
@@ -923,4 +923,3 @@
 //     REQUIRE(quotient[3] == 0x00ffffffffffffff);
 // }
 
-// // End Test Suite

--- a/src/network/test/p2p.cpp
+++ b/src/network/test/p2p.cpp
@@ -178,7 +178,7 @@ TEST_CASE("p2p set top block1 values expected", "[p2p tests]") {
     network::settings const configuration;
     p2p network(configuration);
     size_t const expected_height = 42;
-    auto const expected_hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    auto const expected_hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     network.set_top_block({ expected_hash, expected_height });
     REQUIRE(network.top_block().hash() == expected_hash);
     REQUIRE(network.top_block().height() == expected_height);
@@ -189,7 +189,7 @@ TEST_CASE("p2p set top block2 values expected", "[p2p tests]") {
     network::settings const configuration;
     p2p network(configuration);
     size_t const expected_height = 42;
-    auto const hash = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     infrastructure::config::checkpoint const expected{ hash, expected_height };
     network.set_top_block(expected);
     REQUIRE(network.top_block().hash() == expected.hash());


### PR DESCRIPTION
## Summary

- Add `hash_literal` concept that reuses `base16_literal` with size constraint for 64-char hex strings
- Add `operator""_hash` UDL for bitcoin hash literals (reversed bytes, little-endian format)
- Remove `hash_literal()` function from `base_16.hpp/cpp`
- Migrate all `hash_literal()` calls to use `_hash` UDL
- Add migration script for reference

## Changes

### New UDL
```cpp
// Before
auto const hash = hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");

// After  
auto const hash = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
```

### Concept reuse
```cpp
template <fixed_string Str>
concept hash_literal = base16_literal<Str> && (Str.size() == 2 * hash_size);
```

## Test plan
- [x] Build passes
- [ ] All tests pass