### PR TITLE
test: improve transaction tests and add point::null() factory

### DIFF
--- a/src/domain/include/kth/domain/chain/point.hpp
+++ b/src/domain/include/kth/domain/chain/point.hpp
@@ -80,6 +80,12 @@ struct KD_API point {
     static
     expect<point> from_data(byte_reader& reader, bool wire = true);
 
+    /// Returns a null point (coinbase input reference).
+    [[nodiscard]]
+    static constexpr point null() noexcept {
+        return point{null_hash, null_index};
+    }
+
     // constexpr
     [[nodiscard]]
     bool is_valid() const;
@@ -161,8 +167,13 @@ struct KD_API point {
     void reset();
 
 private:
+    // Design note: A default-constructed point is "uninitialized" (not valid).
+    // A "null" point (null_hash + null_index) represents a coinbase input and IS valid.
+    // These are distinct concepts:
+    //   - is_valid(): has been properly initialized (explicitly or via deserialization)
+    //   - is_null(): references no previous output (coinbase input)
     hash_digest hash_{null_hash};
-    uint32_t index_{0};
+    uint32_t index_{0};  // Intentionally 0, not null_index. See comment above.
     bool valid_{false};
 };
 

--- a/src/domain/include/kth/domain/chain/transaction.hpp
+++ b/src/domain/include/kth/domain/chain/transaction.hpp
@@ -149,7 +149,6 @@ public:
 
     uint64_t fees() const;
     // point::list previous_outputs() const;
-    point::list missing_previous_outputs() const;
     // hash_list missing_previous_transactions() const;
     uint64_t total_input_value() const;
     uint64_t total_output_value() const;

--- a/src/domain/src/chain/script.cpp
+++ b/src/domain/src/chain/script.cpp
@@ -236,55 +236,6 @@ operation::iterator script::end() const {
 // Properties (size, accessors, cache).
 //-----------------------------------------------------------------------------
 
-// // protected
-// operation::list const& script::operations() const {
-//     ///////////////////////////////////////////////////////////////////////////
-//     // Critical Section
-//     mutex_.lock_upgrade();
-
-//     if (cached_) {
-//         mutex_.unlock_upgrade();
-//         //---------------------------------------------------------------------
-//         return operations_;
-//     }
-
-//     // operation op;
-//     data_source istream(bytes_);
-//     istream_reader stream_r(istream);
-//     auto const size = bytes_.size();
-
-//     //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-//     mutex_.unlock_upgrade_and_lock();
-
-//     // One operation per byte is the upper limit of operations.
-//     operations_.reserve(size);
-
-//     // ************************************************************************
-//     // CONSENSUS: In the case of a coinbase script we must parse the entire
-//     // script, beyond just the BIP34 requirements, so that sigops can be
-//     // calculated from the script. These are counted despite being irrelevant.
-//     // In this case an invalid script is parsed to the extent possible.
-//     // ************************************************************************
-
-//     // If an op fails it is pushed to operations and the loop terminates.
-//     // To validate the ops the caller must test the last op.is_valid(), or may
-//     // text script.is_valid_operations(), which is done in script validation.
-//     while ( ! stream_r.is_exhausted()) {
-//         // op.from_data(stream_r);
-//         // operations_.push_back(std::move(op));
-//         operations_.push_back(create<operation>(stream_r));
-//     }
-
-//     operations_.shrink_to_fit();
-//     cached_ = true;
-
-//     mutex_.unlock();
-//     ///////////////////////////////////////////////////////////////////////////
-
-//     return operations_;
-// }
-
-
 // protected
 operation::list const& script::operations() const {
 #if ! defined(__EMSCRIPTEN__)

--- a/src/domain/src/chain/script_basis.cpp
+++ b/src/domain/src/chain/script_basis.cpp
@@ -654,33 +654,6 @@ inline size_t multisig_sigops(bool accurate, opcode code) {
 
 // ------------------------------------------------------------------
 
-// operation::list operations(script_basis const& script) {
-//     data_source istream(script.bytes());
-//     istream_reader stream_r(istream);
-//     auto const size = script.bytes().size();
-
-//     operation::list res;
-//     // One operation per byte is the upper limit of operations.
-//     res.reserve(size);
-
-//     // ************************************************************************
-//     // CONSENSUS: In the case of a coinbase script we must parse the entire
-//     // script, beyond just the BIP34 requirements, so that sigops can be
-//     // calculated from the script. These are counted despite being irrelevant.
-//     // In this case an invalid script is parsed to the extent possible.
-//     // ************************************************************************
-
-//     // If an op fails it is pushed to operations and the loop terminates.
-//     // To validate the ops the caller must test the last op.is_valid(), or may
-//     // text script.is_valid_operations(), which is done in script validation.
-//     while ( ! stream_r.is_exhausted()) {
-//         res.push_back(create<operation>(stream_r));
-//     }
-
-//     res.shrink_to_fit();
-//     return res;
-// }
-
 operation::list operations(script_basis const& script) {
     byte_reader reader(script.bytes());
     auto const size = script.bytes().size();


### PR DESCRIPTION
## Summary
- Remove unused `instance` variable in failure tests (was checking default-constructed validity, not parse failure)
- Fix declare-then-assign pattern - use direct initialization where not testing assignment
- Add tests for `missing_previous_outputs()` function with proper coverage
- Add tests for `signature_operations()` with real P2PKH transaction data
- Add `point::null()` static factory method for creating coinbase input references
- Document point validity vs null semantics in point.hpp
- Remove redundant `missing_previous_outputs` declaration in transaction.hpp (inherited from transaction_basis)
- Clean up commented code in script.cpp and script_basis.cpp

## Design clarification (point.hpp)
- **Default-constructed point**: `index=0`, `is_valid()=false`, `is_null()=false` → "uninitialized"
- **Null point**: `index=null_index`, `is_valid()=true`, `is_null()=true` → coinbase input reference
- These are distinct concepts that were previously unclear

## Test plan
- [x] All transaction tests pass
- [x] `point::null()` works correctly for coinbase inputs