### PR TITLE
cleanup: remove dead container_source.hpp includes

### DIFF
--- a/src/domain/include/kth/domain/chain/block.hpp
+++ b/src/domain/include/kth/domain/chain/block.hpp
@@ -27,7 +27,6 @@
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/asio.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/thread.hpp>

--- a/src/domain/include/kth/domain/chain/block_basis.hpp
+++ b/src/domain/include/kth/domain/chain/block_basis.hpp
@@ -24,7 +24,6 @@
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/asio.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/thread.hpp>

--- a/src/domain/include/kth/domain/chain/header.hpp
+++ b/src/domain/include/kth/domain/chain/header.hpp
@@ -19,7 +19,6 @@
 #include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/thread.hpp>

--- a/src/domain/include/kth/domain/chain/header_basis.hpp
+++ b/src/domain/include/kth/domain/chain/header_basis.hpp
@@ -17,7 +17,6 @@
 #include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/thread.hpp>

--- a/src/domain/include/kth/domain/chain/input.hpp
+++ b/src/domain/include/kth/domain/chain/input.hpp
@@ -23,7 +23,6 @@
 
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/thread.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/chain/input_basis.hpp
+++ b/src/domain/include/kth/domain/chain/input_basis.hpp
@@ -17,7 +17,6 @@
 
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/thread.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/chain/output.hpp
+++ b/src/domain/include/kth/domain/chain/output.hpp
@@ -17,7 +17,6 @@
 #include <kth/domain/define.hpp>
 #include <kth/domain/wallet/payment_address.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/thread.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/chain/output_basis.hpp
+++ b/src/domain/include/kth/domain/chain/output_basis.hpp
@@ -18,7 +18,6 @@
 #include <kth/domain/chain/token_data.hpp>
 
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/thread.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/chain/output_point.hpp
+++ b/src/domain/include/kth/domain/chain/output_point.hpp
@@ -14,7 +14,6 @@
 #include <kth/domain/chain/script.hpp>
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 
 namespace kth::domain::chain {
 

--- a/src/domain/include/kth/domain/chain/point.hpp
+++ b/src/domain/include/kth/domain/chain/point.hpp
@@ -18,7 +18,6 @@
 #include <kth/domain/deserialization.hpp>
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/chain/script.hpp
+++ b/src/domain/include/kth/domain/chain/script.hpp
@@ -26,7 +26,6 @@
 #include <kth/infrastructure/machine/script_version.hpp>
 #include <kth/infrastructure/math/elliptic_curve.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/thread.hpp>

--- a/src/domain/include/kth/domain/chain/script_basis.hpp
+++ b/src/domain/include/kth/domain/chain/script_basis.hpp
@@ -25,7 +25,6 @@
 #include <kth/infrastructure/machine/script_version.hpp>
 #include <kth/infrastructure/math/elliptic_curve.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/thread.hpp>

--- a/src/domain/include/kth/domain/chain/token_data.hpp
+++ b/src/domain/include/kth/domain/chain/token_data.hpp
@@ -21,7 +21,6 @@
 #include <kth/domain/machine/opcode.hpp>
 
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/serializer.hpp>
 #include <kth/infrastructure/utility/thread.hpp>

--- a/src/domain/include/kth/domain/chain/transaction.hpp
+++ b/src/domain/include/kth/domain/chain/transaction.hpp
@@ -29,7 +29,6 @@
 #include <kth/infrastructure/math/elliptic_curve.hpp>
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>
 

--- a/src/domain/include/kth/domain/chain/transaction_basis.hpp
+++ b/src/domain/include/kth/domain/chain/transaction_basis.hpp
@@ -26,7 +26,6 @@
 #include <kth/infrastructure/math/elliptic_curve.hpp>
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/thread.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/chain/witness.hpp
+++ b/src/domain/include/kth/domain/chain/witness.hpp
@@ -16,7 +16,6 @@
 #include <kth/domain/machine/operation.hpp>
 
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/thread.hpp>

--- a/src/domain/include/kth/domain/machine/operation.hpp
+++ b/src/domain/include/kth/domain/machine/operation.hpp
@@ -19,7 +19,6 @@
 #include <kth/infrastructure/machine/script_pattern.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/address.hpp
+++ b/src/domain/include/kth/domain/message/address.hpp
@@ -17,7 +17,6 @@
 #include <kth/infrastructure/message/network_address.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>
 

--- a/src/domain/include/kth/domain/message/alert.hpp
+++ b/src/domain/include/kth/domain/message/alert.hpp
@@ -12,7 +12,6 @@
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/alert_payload.hpp
+++ b/src/domain/include/kth/domain/message/alert_payload.hpp
@@ -12,7 +12,6 @@
 #include <kth/infrastructure/math/elliptic_curve.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/block.hpp
+++ b/src/domain/include/kth/domain/message/block.hpp
@@ -17,7 +17,6 @@
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 

--- a/src/domain/include/kth/domain/message/block_transactions.hpp
+++ b/src/domain/include/kth/domain/message/block_transactions.hpp
@@ -12,7 +12,6 @@
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/compact_block.hpp
+++ b/src/domain/include/kth/domain/message/compact_block.hpp
@@ -14,7 +14,6 @@
 #include <kth/domain/message/prefilled_transaction.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/double_spend_proof.hpp
+++ b/src/domain/include/kth/domain/message/double_spend_proof.hpp
@@ -14,7 +14,6 @@
 // #include <kth/domain/message/prefilled_transaction.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/fee_filter.hpp
+++ b/src/domain/include/kth/domain/message/fee_filter.hpp
@@ -13,7 +13,6 @@
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>
 

--- a/src/domain/include/kth/domain/message/filter_add.hpp
+++ b/src/domain/include/kth/domain/message/filter_add.hpp
@@ -13,7 +13,6 @@
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/filter_clear.hpp
+++ b/src/domain/include/kth/domain/message/filter_clear.hpp
@@ -12,7 +12,6 @@
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/filter_load.hpp
+++ b/src/domain/include/kth/domain/message/filter_load.hpp
@@ -13,7 +13,6 @@
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/get_address.hpp
+++ b/src/domain/include/kth/domain/message/get_address.hpp
@@ -12,7 +12,6 @@
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/get_block_transactions.hpp
+++ b/src/domain/include/kth/domain/message/get_block_transactions.hpp
@@ -14,7 +14,6 @@
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/get_blocks.hpp
+++ b/src/domain/include/kth/domain/message/get_blocks.hpp
@@ -17,7 +17,6 @@
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/get_data.hpp
+++ b/src/domain/include/kth/domain/message/get_data.hpp
@@ -16,7 +16,6 @@
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 
 

--- a/src/domain/include/kth/domain/message/get_headers.hpp
+++ b/src/domain/include/kth/domain/message/get_headers.hpp
@@ -13,7 +13,6 @@
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 
 
 #include <kth/domain/concepts.hpp>

--- a/src/domain/include/kth/domain/message/header.hpp
+++ b/src/domain/include/kth/domain/message/header.hpp
@@ -15,7 +15,6 @@
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 

--- a/src/domain/include/kth/domain/message/headers.hpp
+++ b/src/domain/include/kth/domain/message/headers.hpp
@@ -18,7 +18,6 @@
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/heading.hpp
+++ b/src/domain/include/kth/domain/message/heading.hpp
@@ -17,7 +17,6 @@
 #include <kth/infrastructure/math/checksum.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/inventory.hpp
+++ b/src/domain/include/kth/domain/message/inventory.hpp
@@ -18,7 +18,6 @@
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/inventory_vector.hpp
+++ b/src/domain/include/kth/domain/message/inventory_vector.hpp
@@ -13,7 +13,6 @@
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/memory_pool.hpp
+++ b/src/domain/include/kth/domain/message/memory_pool.hpp
@@ -12,7 +12,6 @@
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/merkle_block.hpp
+++ b/src/domain/include/kth/domain/message/merkle_block.hpp
@@ -15,7 +15,6 @@
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/not_found.hpp
+++ b/src/domain/include/kth/domain/message/not_found.hpp
@@ -17,7 +17,6 @@
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 
 

--- a/src/domain/include/kth/domain/message/ping.hpp
+++ b/src/domain/include/kth/domain/message/ping.hpp
@@ -14,7 +14,6 @@
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/pong.hpp
+++ b/src/domain/include/kth/domain/message/pong.hpp
@@ -13,7 +13,6 @@
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/prefilled_transaction.hpp
+++ b/src/domain/include/kth/domain/message/prefilled_transaction.hpp
@@ -12,7 +12,6 @@
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/reject.hpp
+++ b/src/domain/include/kth/domain/message/reject.hpp
@@ -15,7 +15,6 @@
 #include <kth/domain/message/transaction.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>
 

--- a/src/domain/include/kth/domain/message/send_compact.hpp
+++ b/src/domain/include/kth/domain/message/send_compact.hpp
@@ -12,7 +12,6 @@
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/send_headers.hpp
+++ b/src/domain/include/kth/domain/message/send_headers.hpp
@@ -12,7 +12,6 @@
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/transaction.hpp
+++ b/src/domain/include/kth/domain/message/transaction.hpp
@@ -17,7 +17,6 @@
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 

--- a/src/domain/include/kth/domain/message/verack.hpp
+++ b/src/domain/include/kth/domain/message/verack.hpp
@@ -12,7 +12,6 @@
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/version.hpp
+++ b/src/domain/include/kth/domain/message/version.hpp
@@ -15,7 +15,6 @@
 #include <kth/infrastructure/message/network_address.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>
 

--- a/src/domain/include/kth/domain/message/xverack.hpp
+++ b/src/domain/include/kth/domain/message/xverack.hpp
@@ -12,7 +12,6 @@
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>

--- a/src/domain/include/kth/domain/message/xversion.hpp
+++ b/src/domain/include/kth/domain/message/xversion.hpp
@@ -15,7 +15,6 @@
 #include <kth/infrastructure/message/network_address.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>
 

--- a/src/domain/src/chain/block.cpp
+++ b/src/domain/src/chain/block.cpp
@@ -35,7 +35,6 @@
 #include <kth/infrastructure/utility/asio.hpp>
 #include <kth/infrastructure/utility/assert.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 

--- a/src/domain/src/chain/block_basis.cpp
+++ b/src/domain/src/chain/block_basis.cpp
@@ -36,7 +36,6 @@
 #include <kth/infrastructure/utility/asio.hpp>
 #include <kth/infrastructure/utility/assert.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 

--- a/src/domain/src/chain/input.cpp
+++ b/src/domain/src/chain/input.cpp
@@ -11,7 +11,6 @@
 #include <kth/domain/constants.hpp>
 #include <kth/domain/wallet/payment_address.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::chain {

--- a/src/domain/src/chain/input_basis.cpp
+++ b/src/domain/src/chain/input_basis.cpp
@@ -10,7 +10,6 @@
 #include <kth/domain/chain/script.hpp>
 #include <kth/domain/constants.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::chain {

--- a/src/domain/src/chain/output.cpp
+++ b/src/domain/src/chain/output.cpp
@@ -11,7 +11,6 @@
 #include <kth/domain/constants.hpp>
 #include <kth/domain/wallet/payment_address.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::chain {

--- a/src/domain/src/chain/output_basis.cpp
+++ b/src/domain/src/chain/output_basis.cpp
@@ -10,7 +10,6 @@
 
 #include <kth/domain/constants.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::chain {

--- a/src/domain/src/chain/point.cpp
+++ b/src/domain/src/chain/point.cpp
@@ -13,7 +13,6 @@
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/assert.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 #include <kth/infrastructure/utility/serializer.hpp>
 

--- a/src/domain/src/chain/script.cpp
+++ b/src/domain/src/chain/script.cpp
@@ -34,7 +34,6 @@
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/assert.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 #include <kth/infrastructure/utility/string.hpp>

--- a/src/domain/src/chain/script_basis.cpp
+++ b/src/domain/src/chain/script_basis.cpp
@@ -33,7 +33,6 @@
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/assert.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 #include <kth/infrastructure/utility/string.hpp>

--- a/src/domain/src/chain/transaction.cpp
+++ b/src/domain/src/chain/transaction.cpp
@@ -34,7 +34,6 @@
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/collection.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/endian.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>

--- a/src/domain/src/chain/transaction_basis.cpp
+++ b/src/domain/src/chain/transaction_basis.cpp
@@ -29,7 +29,6 @@
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/collection.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/endian.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>

--- a/src/domain/src/chain/witness.cpp
+++ b/src/domain/src/chain/witness.cpp
@@ -25,7 +25,6 @@
 #include <kth/infrastructure/utility/assert.hpp>
 #include <kth/infrastructure/utility/collection.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 

--- a/src/domain/src/machine/operation.cpp
+++ b/src/domain/src/machine/operation.cpp
@@ -14,7 +14,6 @@
 #include <kth/infrastructure/formats/base_16.hpp>
 #include <kth/infrastructure/utility/assert.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 #include <kth/infrastructure/utility/string.hpp>

--- a/src/domain/src/message/address.cpp
+++ b/src/domain/src/message/address.cpp
@@ -8,7 +8,6 @@
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 

--- a/src/domain/src/message/alert.cpp
+++ b/src/domain/src/message/alert.cpp
@@ -9,7 +9,6 @@
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/assert.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 

--- a/src/domain/src/message/alert_payload.cpp
+++ b/src/domain/src/message/alert_payload.cpp
@@ -8,7 +8,6 @@
 // #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::message {

--- a/src/domain/src/message/block_transactions.cpp
+++ b/src/domain/src/message/block_transactions.cpp
@@ -9,7 +9,6 @@
 #include <kth/domain/multi_crypto_support.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 

--- a/src/domain/src/message/compact_block.cpp
+++ b/src/domain/src/message/compact_block.cpp
@@ -12,7 +12,6 @@
 #include <kth/infrastructure/math/sip_hash.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 #include <kth/infrastructure/utility/pseudo_random_broken_do_not_use.hpp>

--- a/src/domain/src/message/double_spend_proof.cpp
+++ b/src/domain/src/message/double_spend_proof.cpp
@@ -12,7 +12,6 @@
 #include <kth/infrastructure/math/sip_hash.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 

--- a/src/domain/src/message/fee_filter.cpp
+++ b/src/domain/src/message/fee_filter.cpp
@@ -7,7 +7,6 @@
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::message {

--- a/src/domain/src/message/filter_add.cpp
+++ b/src/domain/src/message/filter_add.cpp
@@ -9,7 +9,6 @@
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/assert.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 

--- a/src/domain/src/message/filter_clear.cpp
+++ b/src/domain/src/message/filter_clear.cpp
@@ -6,7 +6,6 @@
 
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::message {

--- a/src/domain/src/message/filter_load.cpp
+++ b/src/domain/src/message/filter_load.cpp
@@ -8,7 +8,6 @@
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/assert.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 

--- a/src/domain/src/message/get_address.cpp
+++ b/src/domain/src/message/get_address.cpp
@@ -6,7 +6,6 @@
 
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::message {

--- a/src/domain/src/message/get_block_transactions.cpp
+++ b/src/domain/src/message/get_block_transactions.cpp
@@ -10,7 +10,6 @@
 #include <kth/domain/multi_crypto_support.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 

--- a/src/domain/src/message/get_blocks.cpp
+++ b/src/domain/src/message/get_blocks.cpp
@@ -7,7 +7,6 @@
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 

--- a/src/domain/src/message/header.cpp
+++ b/src/domain/src/message/header.cpp
@@ -14,7 +14,6 @@
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::message {

--- a/src/domain/src/message/headers.cpp
+++ b/src/domain/src/message/headers.cpp
@@ -15,7 +15,6 @@
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 

--- a/src/domain/src/message/heading.cpp
+++ b/src/domain/src/message/heading.cpp
@@ -11,7 +11,6 @@
 
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::message {

--- a/src/domain/src/message/inventory.cpp
+++ b/src/domain/src/message/inventory.cpp
@@ -13,7 +13,6 @@
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 

--- a/src/domain/src/message/inventory_vector.cpp
+++ b/src/domain/src/message/inventory_vector.cpp
@@ -9,7 +9,6 @@
 
 #include <kth/domain/message/inventory.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::message {

--- a/src/domain/src/message/memory_pool.cpp
+++ b/src/domain/src/message/memory_pool.cpp
@@ -6,7 +6,6 @@
 
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::message {

--- a/src/domain/src/message/merkle_block.cpp
+++ b/src/domain/src/message/merkle_block.cpp
@@ -11,7 +11,6 @@
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/assert.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 

--- a/src/domain/src/message/ping.cpp
+++ b/src/domain/src/message/ping.cpp
@@ -6,7 +6,6 @@
 
 // #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::message {

--- a/src/domain/src/message/pong.cpp
+++ b/src/domain/src/message/pong.cpp
@@ -6,7 +6,6 @@
 
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::message {

--- a/src/domain/src/message/prefilled_transaction.cpp
+++ b/src/domain/src/message/prefilled_transaction.cpp
@@ -8,7 +8,6 @@
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::message {

--- a/src/domain/src/message/reject.cpp
+++ b/src/domain/src/message/reject.cpp
@@ -9,7 +9,6 @@
 // #include <kth/domain/message/transaction.hpp>
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::message {

--- a/src/domain/src/message/send_compact.cpp
+++ b/src/domain/src/message/send_compact.cpp
@@ -8,7 +8,6 @@
 
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::message {

--- a/src/domain/src/message/send_headers.cpp
+++ b/src/domain/src/message/send_headers.cpp
@@ -6,7 +6,6 @@
 
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::message {

--- a/src/domain/src/message/verack.cpp
+++ b/src/domain/src/message/verack.cpp
@@ -6,7 +6,6 @@
 
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::message {

--- a/src/domain/src/message/version.cpp
+++ b/src/domain/src/message/version.cpp
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::message {

--- a/src/domain/src/message/xverack.cpp
+++ b/src/domain/src/message/xverack.cpp
@@ -6,7 +6,6 @@
 
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::message {

--- a/src/domain/src/message/xversion.cpp
+++ b/src/domain/src/message/xversion.cpp
@@ -7,7 +7,6 @@
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::message {

--- a/src/infrastructure/include/kth/infrastructure/impl/utility/serializer.ipp
+++ b/src/infrastructure/include/kth/infrastructure/impl/utility/serializer.ipp
@@ -12,6 +12,7 @@
 #include <kth/infrastructure/constants.hpp>
 #include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/utility/endian.hpp>
+#include <kth/infrastructure/utility/limits.hpp>
 
 namespace kth {
 

--- a/src/infrastructure/include/kth/infrastructure/message/network_address.hpp
+++ b/src/infrastructure/include/kth/infrastructure/message/network_address.hpp
@@ -15,7 +15,6 @@
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 
 namespace kth::infrastructure::message {
 

--- a/src/infrastructure/src/message/network_address.cpp
+++ b/src/infrastructure/src/message/network_address.cpp
@@ -8,7 +8,6 @@
 #include <cstdint>
 
 #include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/container_source.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::infrastructure::message {


### PR DESCRIPTION
## Summary
- Remove unused `#include <kth/infrastructure/utility/container_source.hpp>` from 97 files
- These includes became dead code after removing `istream_reader` in PR #132
- Add missing `limits.hpp` include to `serializer.ipp` (was transitively included via `container_source.hpp`)

Note: `container_source.hpp` itself is NOT removed - it's still needed by `network/proxy.hpp` which uses `byte_source`.

## Test plan
- [x] All tests pass
- [x] Build completes successfully