### PR TITLE
feature: enable network tests

### DIFF
--- a/src/infrastructure/CMakeLists.txt
+++ b/src/infrastructure/CMakeLists.txt
@@ -501,7 +501,6 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     test/config/endpoint.cpp
     test/config/hash256.cpp
 
-
     test/formats/base_10.cpp
     test/formats/base_16.cpp
     test/formats/base_58.cpp

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -175,36 +175,33 @@ _group_sources(${PROJECT_NAME} "${CMAKE_CURRENT_LIST_DIR}")
 
 # Tests
 # ------------------------------------------------------------------------------
-# if (ENABLE_TEST)
-#     enable_testing()
-#     find_package(Catch2 3 REQUIRED)
+# Skip tests for WebAssembly (Catch2 incompatible with shared-memory/threads)
+if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  enable_testing()
+  find_package(Catch2 3 REQUIRED)
 
+  add_executable(kth_network_test
+        test/p2p.cpp
+  )
 
-#     add_executable(kth_network_test
-#           test/main.cpp
-#           # test/p2p.cpp
-#         #   test/user_agent_dummy.cpp
-#     )
+  target_include_directories(kth_network_test PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>)
 
-#     target_include_directories(kth_network_test PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>)
+  target_link_libraries(kth_network_test PUBLIC ${PROJECT_NAME})
+  target_link_libraries(kth_network_test PRIVATE Catch2::Catch2WithMain)
 
-#     target_link_libraries(kth_network_test PUBLIC ${PROJECT_NAME})
-#     target_link_libraries(kth_network_test PRIVATE Catch2::Catch2WithMain)
+  _group_sources(kth_network_test "${CMAKE_CURRENT_LIST_DIR}/test")
 
-#     _group_sources(kth_network_test "${CMAKE_CURRENT_LIST_DIR}/test")
-
-#     include(CTest)
-#   # Try to use Catch2 automatic test discovery
-#   find_package(Catch2 QUIET)
-#   if(Catch2_FOUND)
-#     include(Catch)
-#     catch_discover_tests(kth_network_test)
-#   else()
-#     # Fallback to manual test registration
-#     add_test(NAME kth_network_test COMMAND kth_network_test)
-#   endif()
-
-# endif()
+  include(CTest)
+  # Try to use Catch2 automatic test discovery
+  find_package(Catch2 QUIET)
+  if(Catch2_FOUND)
+    include(Catch)
+    catch_discover_tests(kth_network_test)
+  else()
+    # Fallback to manual test registration
+    add_test(NAME kth_network_test COMMAND kth_network_test)
+  endif()
+endif()
 
 
 # Install

--- a/src/network/test/main.cpp
+++ b/src/network/test/main.cpp
@@ -1,6 +1,0 @@
-// // Copyright (c) 2016-2025 Knuth Project developers.
-// // Distributed under the MIT software license, see the accompanying
-// // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-// #define CATCH_CONFIG_MAIN
-// #include <catch2/catch_all.hpp>

--- a/src/network/test/p2p.cpp
+++ b/src/network/test/p2p.cpp
@@ -15,28 +15,14 @@ using namespace kth;
 using namespace kd::message;
 using namespace kth::network;
 
-#define TEST_SET_NAME \
-    "p2p_tests"
+constexpr auto test_set_name = "p2p_tests";
 
 #define TEST_NAME \
     Catch::getResultCapture().getCurrentTestName()
 
-// TODO: build mock and/or use dedicated test service.
-#define SEED1 "testnet-seed.bitcoin.petertodd.org:18333"
-#define SEED2 "testnet-seed.bitcoin.schildbach.de:18333"
-
-// NOTE: this is insufficient as the address varies.
-#define SEED1_AUTHORITIES \
-    { \
-      { "52.8.185.53:18333" }, \
-      { "178.21.118.174:18333" }, \
-      { "[2604:880:d:2f::c7b2]:18333" }, \
-      { "[2604:a880:1:20::269:b001]:18333" }, \
-      { "[2602:ffea:1001:6ff::f922]:18333" }, \
-      { "[2401:2500:203:9:153:120:11:18]:18333" }, \
-      { "[2600:3c00::f03c:91ff:fe89:305f]:18333" }, \
-      { "[2600:3c01::f03c:91ff:fe98:68bb]:18333" } \
-    }
+// BCH testnet seeds
+constexpr auto seed1 = "testnet-seed.bchd.cash:18333";
+constexpr auto seed2 = "seed.tbch.loping.net:18333";
 
 #define SETTINGS_TESTNET_ONE_THREAD_NO_CONNECTIONS(name) \
     auto name = network::settings(domain::config::network::testnet); \
@@ -47,7 +33,7 @@ using namespace kth::network;
 #define SETTINGS_TESTNET_ONE_THREAD_ONE_SEED(name) \
     SETTINGS_TESTNET_ONE_THREAD_NO_CONNECTIONS(name); \
     name.host_pool_capacity = 42; \
-    name.seeds = { { SEED1 } }; \
+    name.seeds = { { seed1 } }; \
     name.hosts_file = get_log_path(TEST_NAME, "hosts")
 
 #define SETTINGS_TESTNET_THREE_THREADS_ONE_SEED_FIVE_OUTBOUND(name) \
@@ -55,7 +41,7 @@ using namespace kth::network;
     name.threads = 3; \
     name.host_pool_capacity = 42; \
     name.outbound_connections = 5; \
-    name.seeds = { { SEED1 } }; \
+    name.seeds = { { seed1 } }; \
     name.hosts_file = get_log_path(TEST_NAME, "hosts")
 
 std::string get_log_path(std::string const& test, std::string const& file) {
@@ -229,7 +215,7 @@ TEST_CASE("p2p start no sessions start success start operation fail", "[p2p test
 ////    REQUIRE(start_result(network) == error::success);
 ////}
 
-TEST_CASE("p2p start seed session handshake timeout start peer throttling stop success", "[p2p tests]") {
+TEST_CASE("p2p start seed session handshake timeout start peer throttling stop success", "[p2p tests][integration]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_ONE_SEED(configuration);
     configuration.channel_handshake_seconds = 0;
@@ -244,7 +230,7 @@ TEST_CASE("p2p start seed session handshake timeout start peer throttling stop s
     REQUIRE(network.stop());
 }
 
-TEST_CASE("p2p start seed session connect timeout start peer throttling stop success", "[p2p tests]") {
+TEST_CASE("p2p start seed session connect timeout start peer throttling stop success", "[p2p tests][integration]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_ONE_SEED(configuration);
     configuration.connect_timeout_seconds = 0;
@@ -253,7 +239,7 @@ TEST_CASE("p2p start seed session connect timeout start peer throttling stop suc
     REQUIRE(network.stop());
 }
 
-TEST_CASE("p2p start seed session germination timeout start peer throttling stop success", "[p2p tests]") {
+TEST_CASE("p2p start seed session germination timeout start peer throttling stop success", "[p2p tests][integration]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_ONE_SEED(configuration);
     configuration.channel_germination_seconds = 0;
@@ -262,7 +248,7 @@ TEST_CASE("p2p start seed session germination timeout start peer throttling stop
     REQUIRE(network.stop());
 }
 
-TEST_CASE("p2p start seed session inactivity timeout start peer throttling stop success", "[p2p tests]") {
+TEST_CASE("p2p start seed session inactivity timeout start peer throttling stop success", "[p2p tests][integration]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_ONE_SEED(configuration);
     configuration.channel_inactivity_minutes = 0;
@@ -271,7 +257,7 @@ TEST_CASE("p2p start seed session inactivity timeout start peer throttling stop 
     REQUIRE(network.stop());
 }
 
-TEST_CASE("p2p start seed session expiration timeout start peer throttling stop success", "[p2p tests]") {
+TEST_CASE("p2p start seed session expiration timeout start peer throttling stop success", "[p2p tests][integration]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_ONE_SEED(configuration);
     configuration.channel_expiration_minutes = 0;
@@ -280,16 +266,17 @@ TEST_CASE("p2p start seed session expiration timeout start peer throttling stop 
     REQUIRE(network.stop());
 }
 
+// TODO: implement seed1_authorities with current BCH testnet addresses
 // Disabled for live test reliability.
 // This may fail due to missing blacklist entries for the specified host.
-////TEST_CASE("p2p  start  seed session blacklisted  start operation fail stop success", "[p2p tests]")
+////TEST_CASE("p2p start seed session blacklisted start operation fail stop success", "[p2p tests]")
 ////{
 ////    print_headers(TEST_NAME);
 ////    SETTINGS_TESTNET_ONE_THREAD_NO_CONNECTIONS(configuration);
 ////    configuration.host_pool_capacity = 42;
 ////    configuration.hosts_file = get_log_path(TEST_NAME, "hosts");
-////    configuration.seeds = { { SEED1 } };
-////    configuration.blacklist = SEED1_AUTHORITIES;
+////    configuration.seeds = { { seed1 } };
+////    configuration.blacklist = seed1_authorities;
 ////    p2p network(configuration);
 ////    REQUIRE(start_result(network) == error::operation_failed);
 ////    REQUIRE(network.stop());
@@ -307,15 +294,15 @@ TEST_CASE("p2p connect not started service stopped", "[p2p tests]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_NO_CONNECTIONS(configuration);
     p2p network(configuration);
-    infrastructure::config::endpoint const host(SEED1);
+    infrastructure::config::endpoint const host(seed1);
     REQUIRE(connect_result(network, host) == error::service_stopped);
 }
 
-TEST_CASE("p2p connect started success", "[p2p tests]") {
+TEST_CASE("p2p connect started success", "[p2p tests][integration]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_NO_CONNECTIONS(configuration);
     p2p network(configuration);
-    infrastructure::config::endpoint const host(SEED1);
+    infrastructure::config::endpoint const host(seed1);
     REQUIRE(start_result(network) == error::success);
     REQUIRE(run_result(network) == error::success);
     REQUIRE(connect_result(network, host) == error::success);
@@ -328,7 +315,7 @@ TEST_CASE("p2p connect started success", "[p2p tests]") {
 ////    print_headers(TEST_NAME);
 ////    SETTINGS_TESTNET_ONE_THREAD_NO_CONNECTIONS(configuration);
 ////    p2p network(configuration);
-////    infrastructure::config::endpoint const host(SEED1);
+////    infrastructure::config::endpoint const host(seed1);
 ////    REQUIRE(start_result(network) == error::success);
 ////    REQUIRE(run_result(network) == error::success);
 ////    REQUIRE(connect_result(network, host) == error::success);
@@ -361,30 +348,30 @@ TEST_CASE("p2p subscribe started stop service stopped", "[p2p tests]") {
     network.subscribe_connection(handler);
 }
 
-TEST_CASE("p2p subscribe started connect1 success", "[p2p tests]") {
+TEST_CASE("p2p subscribe started connect1 success", "[p2p tests][integration]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_NO_CONNECTIONS(configuration);
     p2p network(configuration);
-    infrastructure::config::endpoint const host(SEED1);
+    infrastructure::config::endpoint const host(seed1);
     REQUIRE(start_result(network) == error::success);
     REQUIRE(subscribe_connect1_result(network, host) == error::success);
 }
 
-TEST_CASE("p2p subscribe started connect2 success", "[p2p tests]") {
+TEST_CASE("p2p subscribe started connect2 success", "[p2p tests][integration]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_NO_CONNECTIONS(configuration);
     p2p network(configuration);
-    infrastructure::config::endpoint const host(SEED1);
+    infrastructure::config::endpoint const host(seed1);
     REQUIRE(start_result(network) == error::success);
     REQUIRE(subscribe_connect2_result(network, host) == error::success);
 }
 
-TEST_CASE("p2p broadcast ping two distinct hosts two sends and successful completion", "[p2p tests]") {
+TEST_CASE("p2p broadcast ping two distinct hosts two sends and successful completion", "[p2p tests][integration]") {
     print_headers(TEST_NAME);
     SETTINGS_TESTNET_ONE_THREAD_NO_CONNECTIONS(configuration);
     p2p network(configuration);
-    infrastructure::config::endpoint const host1(SEED1);
-    infrastructure::config::endpoint const host2(SEED2);
+    infrastructure::config::endpoint const host1(seed1);
+    infrastructure::config::endpoint const host2(seed2);
     REQUIRE(start_result(network) == error::success);
     REQUIRE(run_result(network) == error::success);
     REQUIRE(connect_result(network, host1) == error::success);

--- a/src/network/test/test_helpers.hpp
+++ b/src/network/test/test_helpers.hpp
@@ -5,7 +5,9 @@
 #ifndef KTH_NETWORK_TEST_HELPERS_HPP
 #define KTH_NETWORK_TEST_HELPERS_HPP
 
-// Include the central test helpers from domain
+// Include the central test helpers from domain (which includes infrastructure)
 #include "../../domain/test/test_helpers.hpp"
+
+#include <kth/network.hpp>
 
 #endif // KTH_NETWORK_TEST_HELPERS_HPP


### PR DESCRIPTION
## Summary
- Enable network tests in CMakeLists.txt following infrastructure/domain pattern
- Remove `main.cpp` (using `Catch2WithMain`)
- Update `test_helpers.hpp` to include domain test helpers
- Update BCH testnet seeds (`testnet-seed.bchd.cash`, `seed.tbch.loping.net`)
- Replace `#define` with `constexpr` for seed constants
- Mark 9 tests as `[integration]` for tests that require network access
- Clean up test naming (remove double spaces)

## Test execution
```bash
# All tests
./kth_network_test

# Unit tests only (exclude integration)
./kth_network_test ~[integration]

# Integration tests only
./kth_network_test [integration]
```

## Test plan
- [x] Build completes successfully
- [x] Unit tests pass
- [ ] Integration tests pass (require network access to BCH testnet seeds)