### PR TITLE
refactor: rename data_slice to byte_span

### DIFF
--- a/src/c-api/src/binary.cpp
+++ b/src/c-api/src/binary.cpp
@@ -23,7 +23,7 @@ kth_binary_t kth_core_binary_construct_string(char const* string) {
 }
 
 kth_binary_t kth_core_binary_construct_blocks(kth_size_t bits_size, uint8_t* blocks, kth_size_t n) {
-    kth::data_slice blocks_cpp(blocks, blocks + n);
+    kth::byte_span blocks_cpp(blocks, blocks + n);
     return new kth::binary(bits_size, blocks_cpp);
 }
 

--- a/src/c-api/src/chain/script.cpp
+++ b/src/c-api/src/chain/script.cpp
@@ -174,13 +174,13 @@ kth_bool_t  kth_chain_script_is_sign_script_hash_pattern(kth_operation_list_t op
 
 kth_operation_list_const_t kth_chain_script_to_null_data_pattern(uint8_t const* data, kth_size_t n) {
     // printf("kth_chain_script_to_null_data_pattern: data: %p, n: %u\n", data, n);
-    kth::data_slice data_cpp(data, data + n);
+    kth::byte_span data_cpp(data, data + n);
     auto res = kth::domain::chain::script::to_null_data_pattern(data_cpp);
     return kth::move_or_copy_and_leak(std::move(res));
 }
 
 kth_operation_list_const_t kth_chain_script_to_pay_public_key_pattern(uint8_t const* point, kth_size_t n) {
-    kth::data_slice point_cpp(point, point + n);
+    kth::byte_span point_cpp(point, point + n);
     auto res = kth::domain::chain::script::to_pay_public_key_pattern(point_cpp);
     return kth::move_or_copy_and_leak(std::move(res));
 }

--- a/src/c-api/src/hash.cpp
+++ b/src/c-api/src/hash.cpp
@@ -44,14 +44,14 @@ void hex2bin(char const* src, uint8_t* target) {
 extern "C" {
 
 kth_hash_t kth_sha256_hash(uint8_t const* data, kth_size_t size) {
-    kth::data_slice slice(data, data + size);
-    auto hash = kth::sha256_hash(slice);
+    kth::byte_span span(data, data + size);
+    auto hash = kth::sha256_hash(span);
     return kth::to_hash_t(hash);
 }
 
 kth_hash_t kth_sha256_hash_reversed(uint8_t const* data, kth_size_t size) {
-    kth::data_slice slice(data, data + size);
-    auto hash = kth::sha256_hash(slice);
+    kth::byte_span span(data, data + size);
+    auto hash = kth::sha256_hash(span);
     std::reverse(hash.begin(), hash.end());
     return kth::to_hash_t(hash);
 }

--- a/src/domain/include/kth/domain/chain/script.hpp
+++ b/src/domain/include/kth/domain/chain/script.hpp
@@ -235,10 +235,10 @@ public:
 
     /// Stack factories.
     static
-    operation::list to_null_data_pattern(data_slice data);
+    operation::list to_null_data_pattern(byte_span data);
 
     static
-    operation::list to_pay_public_key_pattern(data_slice point);
+    operation::list to_pay_public_key_pattern(byte_span point);
 
     static
     operation::list to_pay_public_key_hash_pattern(short_hash const& hash);

--- a/src/domain/include/kth/domain/chain/script_basis.hpp
+++ b/src/domain/include/kth/domain/chain/script_basis.hpp
@@ -158,10 +158,10 @@ struct KD_API script_basis {
 
     /// Stack factories.
     static
-    operation::list to_null_data_pattern(data_slice data);
+    operation::list to_null_data_pattern(byte_span data);
 
     static
-    operation::list to_pay_public_key_pattern(data_slice point);
+    operation::list to_pay_public_key_pattern(byte_span point);
 
     static
     operation::list to_pay_public_key_hash_pattern(short_hash const& hash);

--- a/src/domain/include/kth/domain/config/endorsement.hpp
+++ b/src/domain/include/kth/domain/config/endorsement.hpp
@@ -58,7 +58,7 @@ struct KD_API endorsement {
      * Overload cast to generic data reference.
      * @return  This object's value cast to a generic data reference.
      */
-    operator data_slice() const;
+    operator byte_span() const;
 
     /**
      * Overload stream in. If input is invalid sets no bytes in argument.

--- a/src/domain/include/kth/domain/message/messages.hpp
+++ b/src/domain/include/kth/domain/message/messages.hpp
@@ -165,8 +165,8 @@ data_chunk serialize(uint32_t version, const Message& packet, uint32_t magic) {
     KTH_ASSERT(data.size() == message_size);
 
     // Create the payload checksum without copying the buffer.
-    data_slice slice(data.data() + heading_size, data.data() + message_size);
-    auto const check = bitcoin_checksum(slice);
+    byte_span span(data.data() + heading_size, data.data() + message_size);
+    auto const check = bitcoin_checksum(span);
     auto const payload_size32 = *safe_unsigned<uint32_t>(payload_size);
 
     // Create and serialize the heading to a temporary variable (12 bytes).

--- a/src/domain/include/kth/domain/wallet/ec_private.hpp
+++ b/src/domain/include/kth/domain/wallet/ec_private.hpp
@@ -136,7 +136,7 @@ struct KD_API ec_private {
 private:
     /// Validators.
     static
-    bool is_wif(data_slice decoded);
+    bool is_wif(byte_span decoded);
 
     /// Factories.
     static

--- a/src/domain/include/kth/domain/wallet/ec_public.hpp
+++ b/src/domain/include/kth/domain/wallet/ec_public.hpp
@@ -97,7 +97,7 @@ struct KD_API ec_public {
 private:
     /// Validators.
     static
-    bool is_point(data_slice decoded);
+    bool is_point(byte_span decoded);
 
     /// Factories.
     static

--- a/src/domain/include/kth/domain/wallet/message.hpp
+++ b/src/domain/include/kth/domain/wallet/message.hpp
@@ -26,7 +26,7 @@ using message_signature = byte_array<message_signature_size>;
 /**
  * Hashes a messages in preparation for signing.
  */
-KD_API hash_digest hash_message(data_slice message);
+KD_API hash_digest hash_message(byte_span message);
 
 /**
  * Signs a message using deterministic signature.
@@ -34,7 +34,7 @@ KD_API hash_digest hash_message(data_slice message);
  * This should be base64 encoded for presentation to the user.
  * @return true if wif is valid and signature encoding is successful.
  */
-KD_API bool sign_message(message_signature& out_signature, data_slice message, ec_private const& secret);
+KD_API bool sign_message(message_signature& out_signature, byte_span message, ec_private const& secret);
 
 /**
  * Signs a message using deterministic signature.
@@ -42,7 +42,7 @@ KD_API bool sign_message(message_signature& out_signature, data_slice message, e
  * This should be base64 encoded for presentation to the user.
  * @return true if wif is valid and signature encoding is successful.
  */
-KD_API bool sign_message(message_signature& out_signature, data_slice message, std::string const& wif);
+KD_API bool sign_message(message_signature& out_signature, byte_span message, std::string const& wif);
 
 /**
  * Signs a message using deterministic signature.
@@ -52,7 +52,7 @@ KD_API bool sign_message(message_signature& out_signature, data_slice message, s
  * private key is in compressed format.
  * @return true if signature encoding is successful.
  */
-KD_API bool sign_message(message_signature& out_signature, data_slice message, ec_secret const& secret, bool compressed = true);
+KD_API bool sign_message(message_signature& out_signature, byte_span message, ec_secret const& secret, bool compressed = true);
 
 /**
  * Verifies a message.
@@ -62,7 +62,7 @@ KD_API bool sign_message(message_signature& out_signature, data_slice message, e
  * @return false if the signature does not match the address or if there are
  * any errors in the signature encoding.
  */
-KD_API bool verify_message(data_slice message, payment_address const& address, const message_signature& signature);
+KD_API bool verify_message(byte_span message, payment_address const& address, const message_signature& signature);
 
 /// Exposed primarily for independent testability.
 KD_API bool recovery_id_to_magic(uint8_t& out_magic, uint8_t recovery_id, bool compressed);

--- a/src/domain/include/kth/domain/wallet/payment_address.hpp
+++ b/src/domain/include/kth/domain/wallet/payment_address.hpp
@@ -134,7 +134,7 @@ struct KD_API payment_address {
 private:
     /// Validators.
     static
-    bool is_address(data_slice decoded);
+    bool is_address(byte_span decoded);
 
     /// Factories.
     static

--- a/src/domain/src/chain/script.cpp
+++ b/src/domain/src/chain/script.cpp
@@ -807,7 +807,7 @@ bool script::is_sign_script_hash_pattern(operation::list const& ops) {
     return !ops.empty() && is_push_only(ops) && !ops.back().data().empty();
 }
 
-operation::list script::to_null_data_pattern(data_slice data) {
+operation::list script::to_null_data_pattern(byte_span data) {
     if (data.size() > max_null_data_size) {
         return {};
     }
@@ -816,7 +816,7 @@ operation::list script::to_null_data_pattern(data_slice data) {
                            {to_chunk(data)}};
 }
 
-operation::list script::to_pay_public_key_pattern(data_slice point) {
+operation::list script::to_pay_public_key_pattern(byte_span point) {
     if ( ! is_public_key(point)) {
         return {};
     }

--- a/src/domain/src/chain/script_basis.cpp
+++ b/src/domain/src/chain/script_basis.cpp
@@ -523,7 +523,7 @@ bool script_basis::is_sign_script_hash_pattern(operation::list const& ops) {
     return !ops.empty() && is_push_only(ops) && !ops.back().data().empty();
 }
 
-operation::list script_basis::to_null_data_pattern(data_slice data) {
+operation::list script_basis::to_null_data_pattern(byte_span data) {
     if (data.size() > max_null_data_size) {
         return {};
     }
@@ -534,7 +534,7 @@ operation::list script_basis::to_null_data_pattern(data_slice data) {
     };
 }
 
-operation::list script_basis::to_pay_public_key_pattern(data_slice point) {
+operation::list script_basis::to_pay_public_key_pattern(byte_span point) {
     if ( ! is_public_key(point)) {
         return {};
     }

--- a/src/domain/src/config/endorsement.cpp
+++ b/src/domain/src/config/endorsement.cpp
@@ -31,7 +31,7 @@ bool decode_endorsement(kth::endorsement& endorsement,
 }
 
 static
-std::string encode_endorsement(data_slice signature) {
+std::string encode_endorsement(byte_span signature) {
     return encode_base16(signature);
 }
 
@@ -51,7 +51,7 @@ endorsement::operator data_chunk const&() const {
     return value_;
 }
 
-endorsement::operator data_slice() const {
+endorsement::operator byte_span() const {
     return value_;
 }
 

--- a/src/domain/src/math/hash.cpp
+++ b/src/domain/src/math/hash.cpp
@@ -26,7 +26,7 @@
 namespace kth {
 
 #if defined(KTH_CURRENCY_LTC)
-hash_digest litecoin_hash(data_slice data) {
+hash_digest litecoin_hash(byte_span data) {
     hash_digest hash;
     scrypt_1024_1_1_256(reinterpret_cast<char const*>(data.data()),
                         reinterpret_cast<char*>(hash.data()));

--- a/src/domain/src/wallet/ec_private.cpp
+++ b/src/domain/src/wallet/ec_private.cpp
@@ -54,7 +54,7 @@ ec_private::ec_private(ec_secret const& secret, uint16_t version, bool compress)
 // Validators.
 // ----------------------------------------------------------------------------
 
-bool ec_private::is_wif(data_slice decoded) {
+bool ec_private::is_wif(byte_span decoded) {
     auto const size = decoded.size();
     if (size != wif_compressed_size && size != wif_uncompressed_size) {
         return false;

--- a/src/domain/src/wallet/ec_public.cpp
+++ b/src/domain/src/wallet/ec_public.cpp
@@ -50,7 +50,7 @@ ec_public::ec_public(ec_compressed const& point, bool compress)
 // Validators.
 // ----------------------------------------------------------------------------
 
-bool ec_public::is_point(data_slice decoded) {
+bool ec_public::is_point(byte_span decoded) {
     return kth::is_public_key(decoded);
 }
 

--- a/src/domain/src/wallet/encrypted_keys.cpp
+++ b/src/domain/src/wallet/encrypted_keys.cpp
@@ -109,19 +109,19 @@ one_byte point_sign(const one_byte& single, hash_digest const& hash) {
 // ----------------------------------------------------------------------------
 
 static
-hash_digest scrypt_token(data_slice data, data_slice salt) {
+hash_digest scrypt_token(byte_span data, byte_span salt) {
     // Arbitrary scrypt parameters from BIP38.
     return scrypt<hash_size>(data, salt, 16384u, 8u, 8u);
 }
 
 static
-long_hash scrypt_pair(data_slice data, data_slice salt) {
+long_hash scrypt_pair(byte_span data, byte_span salt) {
     // Arbitrary scrypt parameters from BIP38.
     return scrypt<long_hash_size>(data, salt, 1024u, 1u, 1u);
 }
 
 static
-long_hash scrypt_private(data_slice data, data_slice salt) {
+long_hash scrypt_private(byte_span data, byte_span salt) {
     // Arbitrary scrypt parameters from BIP38.
     return scrypt<long_hash_size>(data, salt, 16384u, 8u, 8u);
 }
@@ -285,7 +285,7 @@ data_chunk normal(std::string const& passphrase) {
 static
 bool create_token(encrypted_token& out_token,
                          std::string const& passphrase,
-                         data_slice owner_salt,
+                         byte_span owner_salt,
                          const ek_entropy& owner_entropy,
                          const byte_array<parse_encrypted_token::prefix_size>& prefix) {
     KTH_ASSERT(owner_salt.size() == ek_salt_size ||

--- a/src/domain/src/wallet/message.cpp
+++ b/src/domain/src/wallet/message.cpp
@@ -20,7 +20,7 @@ static constexpr uint8_t magic_differential = magic_compressed - magic_uncompres
 static_assert(magic_differential > max_recovery_id, "oops!");
 static_assert(max_uint8 - max_recovery_id >= magic_uncompressed, "oops!");
 
-hash_digest hash_message(data_slice message) {
+hash_digest hash_message(byte_span message) {
     // This is a specified magic prefix.
     static std::string const prefix("Bitcoin Signed Message:\n");
 
@@ -92,16 +92,16 @@ bool magic_to_recovery_id(uint8_t& out_recovery_id, bool& out_compressed, uint8_
     return true;
 }
 
-bool sign_message(message_signature& out_signature, data_slice message, ec_private const& secret) {
+bool sign_message(message_signature& out_signature, byte_span message, ec_private const& secret) {
     return sign_message(out_signature, message, secret, secret.compressed());
 }
 
-bool sign_message(message_signature& out_signature, data_slice message, std::string const& wif) {
+bool sign_message(message_signature& out_signature, byte_span message, std::string const& wif) {
     ec_private secret(wif);
     return (secret && sign_message(out_signature, message, secret, secret.compressed()));
 }
 
-bool sign_message(message_signature& out_signature, data_slice message, ec_secret const& secret, bool compressed) {
+bool sign_message(message_signature& out_signature, byte_span message, ec_secret const& secret, bool compressed) {
     recoverable_signature recoverable;
     if ( ! sign_recoverable(recoverable, secret, hash_message(message))) {
         return false;
@@ -116,7 +116,7 @@ bool sign_message(message_signature& out_signature, data_slice message, ec_secre
     return true;
 }
 
-bool verify_message(data_slice message, payment_address const& address, message_signature const& signature) {
+bool verify_message(byte_span message, payment_address const& address, message_signature const& signature) {
     auto const magic = signature.front();
     auto const compact = slice<1, message_signature_size>(signature);
 

--- a/src/domain/src/wallet/payment_address.cpp
+++ b/src/domain/src/wallet/payment_address.cpp
@@ -84,7 +84,7 @@ payment_address payment_address::from_pay_public_key_hash_script(chain::script c
 // Validators.
 // ----------------------------------------------------------------------------
 
-bool payment_address::is_address(data_slice decoded) {
+bool payment_address::is_address(byte_span decoded) {
     return (decoded.size() == payment_size) && verify_checksum(decoded);
 }
 

--- a/src/infrastructure/include/kth/infrastructure/config/base16.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/base16.hpp
@@ -52,7 +52,7 @@ struct KI_API base16 {
      * @return  This object's value cast to a generic data.
      */
     [[nodiscard]] explicit
-    operator data_slice() const noexcept;
+    operator byte_span() const noexcept;
 
     /**
      * Get the underlying data.
@@ -62,11 +62,11 @@ struct KI_API base16 {
     data_chunk const& data() const noexcept;
 
     /**
-     * Get the underlying data as a slice.
-     * @return  The internal data as a slice.
+     * Get the underlying data as a span.
+     * @return  The internal data as a span.
      */
     [[nodiscard]]
-    data_slice as_slice() const noexcept;
+    byte_span as_span() const noexcept;
 
     /**
      * Parse a base16 string into a base16 object.

--- a/src/infrastructure/include/kth/infrastructure/config/base58.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/base58.hpp
@@ -39,7 +39,7 @@ struct KI_API base58 {
      * @return  This object's value cast to a generic data.
      */
     [[nodiscard]] explicit
-    operator data_slice() const noexcept;
+    operator byte_span() const noexcept;
 
     /**
      * Get the underlying data.
@@ -49,11 +49,11 @@ struct KI_API base58 {
     data_chunk const& data() const noexcept;
 
     /**
-     * Get the underlying data as a slice.
-     * @return  The internal data as a slice.
+     * Get the underlying data as a span.
+     * @return  The internal data as a span.
      */
     [[nodiscard]]
-    data_slice as_slice() const noexcept;
+    byte_span as_span() const noexcept;
 
     /**
      * Parse a base58 string into a base58 object.

--- a/src/infrastructure/include/kth/infrastructure/config/base64.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/base64.hpp
@@ -39,7 +39,7 @@ struct KI_API base64 {
      * @return  This object's value cast to a generic data.
      */
     [[nodiscard]] explicit
-    operator data_slice() const noexcept;
+    operator byte_span() const noexcept;
 
     /**
      * Get the underlying data.
@@ -49,11 +49,11 @@ struct KI_API base64 {
     data_chunk const& data() const noexcept;
 
     /**
-     * Get the underlying data as a slice.
-     * @return  The internal data as a slice.
+     * Get the underlying data as a span.
+     * @return  The internal data as a span.
      */
     [[nodiscard]]
-    data_slice as_slice() const noexcept;
+    byte_span as_span() const noexcept;
 
     /**
      * Parse a base64 string into a base64 object.

--- a/src/infrastructure/include/kth/infrastructure/config/sodium.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/sodium.hpp
@@ -66,7 +66,7 @@ public:
      * @return  This object's value cast to generic data.
      */
     explicit
-    operator data_slice() const;
+    operator byte_span() const;
 
     /**
      * Get the key as a base85 encoded (z85) string.

--- a/src/infrastructure/include/kth/infrastructure/formats/base_16.hpp
+++ b/src/infrastructure/include/kth/infrastructure/formats/base_16.hpp
@@ -29,7 +29,7 @@ bool is_base16(char c);
 /**
  * Convert data into a user-readable hex string.
  */
-KI_API std::string encode_base16(data_slice data);
+KI_API std::string encode_base16(byte_span data);
 
 /**
  * Convert a hex string into bytes.

--- a/src/infrastructure/include/kth/infrastructure/formats/base_58.hpp
+++ b/src/infrastructure/include/kth/infrastructure/formats/base_58.hpp
@@ -36,7 +36,7 @@ byte_array<Size * 733 / 1000> base58_literal(char const(&string)[Size]);
  * Encode data as base58.
  * @return the base58 encoded string.
  */
-KI_API std::string encode_base58(data_slice unencoded);
+KI_API std::string encode_base58(byte_span unencoded);
 
 /**
  * Attempt to decode base58 data.

--- a/src/infrastructure/include/kth/infrastructure/formats/base_64.hpp
+++ b/src/infrastructure/include/kth/infrastructure/formats/base_64.hpp
@@ -17,7 +17,7 @@ namespace kth {
  * Encode data as base64.
  * @return the base64 encoded string.
  */
-KI_API std::string encode_base64(data_slice unencoded);
+KI_API std::string encode_base64(byte_span unencoded);
 
 /**
  * Attempt to decode base64 data.

--- a/src/infrastructure/include/kth/infrastructure/formats/base_85.hpp
+++ b/src/infrastructure/include/kth/infrastructure/formats/base_85.hpp
@@ -17,7 +17,7 @@ namespace kth {
  * Encode data as base85 (Z85).
  * @return false if the input is not of base85 size (% 4).
  */
-KI_API bool encode_base85(std::string& out, data_slice in);
+KI_API bool encode_base85(std::string& out, byte_span in);
 
 /**
  * Attempt to decode base85 (Z85) data.

--- a/src/infrastructure/include/kth/infrastructure/impl/math/checksum.ipp
+++ b/src/infrastructure/include/kth/infrastructure/impl/math/checksum.ipp
@@ -16,8 +16,8 @@
 namespace kth {
 
 template <size_t Size>
-bool build_checked_array(byte_array<Size>& out, std::initializer_list<data_slice> const& slices) {
-    return build_array(out, slices) && insert_checksum(out);
+bool build_checked_array(byte_array<Size>& out, std::initializer_list<byte_span> const& spans) {
+    return build_array(out, spans) && insert_checksum(out);
 }
 
 template <size_t Size>

--- a/src/infrastructure/include/kth/infrastructure/impl/math/hash.ipp
+++ b/src/infrastructure/include/kth/infrastructure/impl/math/hash.ipp
@@ -13,7 +13,7 @@
 namespace kth {
 
 template <size_t Size>
-byte_array<Size> scrypt(data_slice data, data_slice salt, uint64_t N,
+byte_array<Size> scrypt(byte_span data, byte_span salt, uint64_t N,
     uint32_t p, uint32_t r)
 {
     auto const out = scrypt(data, salt, N, r, p, Size);

--- a/src/infrastructure/include/kth/infrastructure/impl/utility/data.ipp
+++ b/src/infrastructure/include/kth/infrastructure/impl/utility/data.ipp
@@ -25,26 +25,26 @@ data_chunk to_chunk(uint8_t byte) {
 }
 
 inline
-data_chunk build_chunk(loaf slices, size_t extra_reserve) {
+data_chunk build_chunk(loaf spans, size_t extra_reserve) {
     size_t size = 0;
-    for (auto const slice: slices) {
-        size += slice.size();
+    for (auto const span : spans) {
+        size += span.size();
     }
 
     data_chunk out;
     out.reserve(size + extra_reserve);
-    for (auto const slice: slices) {
-        out.insert(out.end(), slice.begin(), slice.end());
+    for (auto const span : spans) {
+        out.insert(out.end(), span.begin(), span.end());
     }
 
     return out;
 }
 
 template <size_t Size>
-bool build_array(byte_array<Size>& out, loaf slices) {
+bool build_array(byte_array<Size>& out, loaf spans) {
     size_t size = 0;
-    for (auto const slice: slices) {
-        size += slice.size();
+    for (auto const span : spans) {
+        size += span.size();
     }
 
     if (size > Size) {
@@ -52,9 +52,9 @@ bool build_array(byte_array<Size>& out, loaf slices) {
     }
 
     auto position = out.begin();
-    for (auto const slice: slices) {
-        std::copy(slice.begin(), slice.end(), position);
-        position += slice.size();
+    for (auto const span : spans) {
+        std::copy(span.begin(), span.end(), position);
+        position += span.size();
     }
 
     return true;
@@ -103,7 +103,7 @@ byte_array_parts<Size / 2> split(const byte_array<Size>& bytes) {
 
 // unsafe
 template <size_t Size>
-byte_array<Size> to_array(data_slice bytes) {
+byte_array<Size> to_array(byte_span bytes) {
     byte_array<Size> out;
     DEBUG_ONLY(auto const result =) build_array(out, { bytes });
     KTH_ASSERT(result);
@@ -125,19 +125,19 @@ bool starts_with(const typename Source::const_iterator& begin,
 
 // unsafe
 template <size_t Size>
-byte_array<Size> xor_data(data_slice bytes1, data_slice bytes2) {
+byte_array<Size> xor_data(byte_span bytes1, byte_span bytes2) {
     return xor_data<Size>(bytes1, bytes2, 0);
 }
 
 // unsafe
 template <size_t Size>
-byte_array<Size> xor_data(data_slice bytes1, data_slice bytes2, size_t offset) {
+byte_array<Size> xor_data(byte_span bytes1, byte_span bytes2, size_t offset) {
     return xor_data<Size>(bytes1, bytes2, offset, offset);
 }
 
 // unsafe
 template <size_t Size>
-byte_array<Size> xor_data(data_slice bytes1, data_slice bytes2, size_t offset1, size_t offset2) {
+byte_array<Size> xor_data(byte_span bytes1, byte_span bytes2, size_t offset1, size_t offset2) {
     KTH_ASSERT(offset1 + Size <= bytes1.size());
     KTH_ASSERT(offset2 + Size <= bytes2.size());
     auto const& data1 = bytes1.data();

--- a/src/infrastructure/include/kth/infrastructure/math/checksum.hpp
+++ b/src/infrastructure/include/kth/infrastructure/math/checksum.hpp
@@ -22,11 +22,11 @@ static constexpr size_t checksum_size = sizeof(uint32_t);
 #define UNWRAP_SIZE(payload_size) (payload_size - checksum_size - 1)
 
 /**
- * Concatenate several data slices into a single fixed size array and append a
+ * Concatenate several data spans into a single fixed size array and append a
  * checksum.
  */
 template <size_t Size>
-bool build_checked_array(byte_array<Size>& out, const std::initializer_list<data_slice>& slices);
+bool build_checked_array(byte_array<Size>& out, const std::initializer_list<byte_span>& spans);
 
 /**
  * Appends a four-byte checksum into the end of an array.
@@ -79,13 +79,13 @@ KI_API void append_checksum(data_chunk& data);
  *
  * int(sha256(sha256(data))[-4:])
  */
-KI_API uint32_t bitcoin_checksum(data_slice data);
+KI_API uint32_t bitcoin_checksum(byte_span data);
 
 /**
  * Verifies the last four bytes of a data chunk are a valid checksum of the
  * earlier bytes. This is typically used to verify base58 data.
  */
-KI_API bool verify_checksum(data_slice data);
+KI_API bool verify_checksum(byte_span data);
 
 } // namespace kth
 

--- a/src/infrastructure/include/kth/infrastructure/math/elliptic_curve.hpp
+++ b/src/infrastructure/include/kth/infrastructure/math/elliptic_curve.hpp
@@ -134,13 +134,13 @@ KI_API bool verify(ec_uncompressed const& point);
 bool is_even_key(ec_compressed const& point);
 
 /// Fast detection of compressed public key structure.
-bool is_compressed_key(data_slice point);
+bool is_compressed_key(byte_span point);
 
 /// Fast detection of uncompressed public key structure.
-bool is_uncompressed_key(data_slice point);
+bool is_uncompressed_key(byte_span point);
 
 /// Fast detection of compressed or uncompressed public key structure.
-bool is_public_key(data_slice point);
+bool is_public_key(byte_span point);
 
 /// Fast detection of endorsement structure (DER with signature hash type).
 bool is_endorsement(endorsement const& endorsement);
@@ -177,7 +177,7 @@ KI_API bool verify_signature(ec_compressed const& point, hash_digest const& hash
 KI_API bool verify_signature(ec_uncompressed const& point, hash_digest const& hash, ec_signature const& signature);
 
 /// Verify an EC signature using a potential point.
-KI_API bool verify_signature(data_slice point, hash_digest const& hash, ec_signature const& signature);
+KI_API bool verify_signature(byte_span point, hash_digest const& hash, ec_signature const& signature);
 
 // Recoverable sign/recover
 // ----------------------------------------------------------------------------

--- a/src/infrastructure/include/kth/infrastructure/math/hash.hpp
+++ b/src/infrastructure/include/kth/infrastructure/math/hash.hpp
@@ -51,50 +51,50 @@ uint256_t to_uint256(hash_digest const& hash) {
 
 /// Generate a scrypt hash to fill a byte array.
 template <size_t Size>
-byte_array<Size> scrypt(data_slice data, data_slice salt, uint64_t N, uint32_t p, uint32_t r);
+byte_array<Size> scrypt(byte_span data, byte_span salt, uint64_t N, uint32_t p, uint32_t r);
 
 /// Generate a scrypt hash of specified length.
-KI_API data_chunk scrypt(data_slice data, data_slice salt, uint64_t N, uint32_t p, uint32_t r, size_t length);
+KI_API data_chunk scrypt(byte_span data, byte_span salt, uint64_t N, uint32_t p, uint32_t r, size_t length);
 
 /// Generate a bitcoin hash.
-KI_API hash_digest bitcoin_hash(data_slice data);
+KI_API hash_digest bitcoin_hash(byte_span data);
 
 //TODO(fernando): see what to do with Currency
 #if defined(KTH_CURRENCY_LTC)
 /// Generate a litecoin hash.
-KI_API hash_digest litecoin_hash(data_slice data);
+KI_API hash_digest litecoin_hash(byte_span data);
 #endif
 
 /// Generate a bitcoin short hash.
-KI_API short_hash bitcoin_short_hash(data_slice data);
+KI_API short_hash bitcoin_short_hash(byte_span data);
 
 /// Generate a ripemd160 hash
-KI_API short_hash ripemd160_hash(data_slice data);
-KI_API data_chunk ripemd160_hash_chunk(data_slice data);
+KI_API short_hash ripemd160_hash(byte_span data);
+KI_API data_chunk ripemd160_hash_chunk(byte_span data);
 
 /// Generate a sha1 hash.
-KI_API short_hash sha1_hash(data_slice data);
-KI_API data_chunk sha1_hash_chunk(data_slice data);
+KI_API short_hash sha1_hash(byte_span data);
+KI_API data_chunk sha1_hash_chunk(byte_span data);
 
 /// Generate a sha256 hash.
-KI_API hash_digest sha256_hash(data_slice data);
-KI_API data_chunk sha256_hash_chunk(data_slice data);
+KI_API hash_digest sha256_hash(byte_span data);
+KI_API data_chunk sha256_hash_chunk(byte_span data);
 
 /// Generate a sha256 hash.
 /// This hash function was used in electrum seed stretching (obsoleted).
-KI_API hash_digest sha256_hash(data_slice first, data_slice second);
+KI_API hash_digest sha256_hash(byte_span first, byte_span second);
 
 // Generate a hmac sha256 hash.
-KI_API hash_digest hmac_sha256_hash(data_slice data, data_slice key);
+KI_API hash_digest hmac_sha256_hash(byte_span data, byte_span key);
 
 /// Generate a sha512 hash.
-KI_API long_hash sha512_hash(data_slice data);
+KI_API long_hash sha512_hash(byte_span data);
 
 /// Generate a hmac sha512 hash.
-KI_API long_hash hmac_sha512_hash(data_slice data, data_slice key);
+KI_API long_hash hmac_sha512_hash(byte_span data, byte_span key);
 
 /// Generate a pkcs5 pbkdf2 hmac sha512 hash.
-KI_API long_hash pkcs5_pbkdf2_hmac_sha512(data_slice passphrase, data_slice salt, size_t iterations);
+KI_API long_hash pkcs5_pbkdf2_hmac_sha512(byte_span passphrase, byte_span salt, size_t iterations);
 
 } // namespace kth
 

--- a/src/infrastructure/include/kth/infrastructure/utility/binary.hpp
+++ b/src/infrastructure/include/kth/infrastructure/utility/binary.hpp
@@ -35,7 +35,7 @@ struct KI_API binary {
     binary(std::string_view bit_string);
 
     binary(size_type size, uint32_t number);
-    binary(size_type size, data_slice blocks);
+    binary(size_type size, byte_span blocks);
 
     void resize(size_type size);
     [[nodiscard]] bool operator[](size_type index) const;
@@ -50,7 +50,7 @@ struct KI_API binary {
     void shift_right(size_type distance);
     [[nodiscard]] binary substring(size_type start, size_type length=max_size_t) const;
 
-    [[nodiscard]] bool is_prefix_of(data_slice field) const;
+    [[nodiscard]] bool is_prefix_of(byte_span field) const;
     [[nodiscard]] bool is_prefix_of(uint32_t field) const;
     [[nodiscard]] bool is_prefix_of(binary const& field) const;
 

--- a/src/infrastructure/include/kth/infrastructure/utility/data.hpp
+++ b/src/infrastructure/include/kth/infrastructure/utility/data.hpp
@@ -24,7 +24,6 @@ using byte_array = std::array<uint8_t, Size>;
 
 using byte_span = std::span<uint8_t const>;
 using byte_span_mut = std::span<uint8_t>;
-using data_slice = byte_span;  // Alias for backwards compatibility
 
 template <size_t Size>
 struct byte_array_parts {
@@ -37,7 +36,7 @@ using one_byte = byte_array<1>;
 using data_chunk = std::vector<uint8_t>;
 using data_queue = std::queue<data_chunk>;
 using data_stack = std::vector<data_chunk>;
-using loaf = std::initializer_list<data_slice>;
+using loaf = std::initializer_list<byte_span>;
 
 /**
  * Create a single byte arrray with an initial value.
@@ -50,18 +49,18 @@ inline one_byte to_array(uint8_t byte);
 inline data_chunk to_chunk(uint8_t byte);
 
 /**
- * Concatenate several data slices into a single data_chunk.
+ * Concatenate several data spans into a single data_chunk.
  * @param  extra_reserve  Include this many additional bytes when calling
  * `reserve` on the data_chunk (as an optimization).
  */
-inline data_chunk build_chunk(loaf slices, size_t extra_reserve=0);
+inline data_chunk build_chunk(loaf spans, size_t extra_reserve=0);
 
 /**
- * Concatenate several data slices into a single fixed size array.
- * Returns false if the slices don't fit in the array. Underfill is ok.
+ * Concatenate several data spans into a single fixed size array.
+ * Returns false if the spans don't fit in the array. Underfill is ok.
  */
 template <size_t Size>
-bool build_array(byte_array<Size>& out, loaf slices);
+bool build_array(byte_array<Size>& out, loaf spans);
 
 /**
  * Extend iterable object by appending x.
@@ -94,10 +93,10 @@ template <size_t Left, size_t Middle, size_t Right>
 byte_array<Left + Middle + Right> splice(const std::array<uint8_t, Left>& left, const std::array<uint8_t, Middle>& middle, const std::array<uint8_t, Right>& right);
 
 /**
- * Convert the data slice to an array. Underfill is ok.
+ * Convert a byte span to an array. Underfill is ok.
  */
 template <size_t Size>
-byte_array<Size> to_array(data_slice bytes);
+byte_array<Size> to_array(byte_span bytes);
 
 /**
  * Create a data chunk from an iterable object.
@@ -117,7 +116,7 @@ bool starts_with(const typename Source::const_iterator& begin, const typename So
  * either buffer.
  */
 template <size_t Size>
-byte_array<Size> xor_data(data_slice bytes1, data_slice bytes2);
+byte_array<Size> xor_data(byte_span bytes1, byte_span bytes2);
 
 /**
  * Perform an exclusive or (xor) across two buffers to the length specified.
@@ -125,7 +124,7 @@ byte_array<Size> xor_data(data_slice bytes1, data_slice bytes2);
  * exceed either buffer.
  */
 template <size_t Size>
-byte_array<Size> xor_data(data_slice bytes1, data_slice bytes2, size_t offset);
+byte_array<Size> xor_data(byte_span bytes1, byte_span bytes2, size_t offset);
 
 /**
  * Perform an exclusive or (xor) across two buffers to the length specified.
@@ -133,7 +132,7 @@ byte_array<Size> xor_data(data_slice bytes1, data_slice bytes2, size_t offset);
  * exceed the respective buffers.
  */
 template <size_t Size>
-byte_array<Size> xor_data(data_slice bytes1, data_slice bytes2, size_t offset1, size_t offset2);
+byte_array<Size> xor_data(byte_span bytes1, byte_span bytes2, size_t offset1, size_t offset2);
 
 } // namespace kth
 

--- a/src/infrastructure/include/kth/infrastructure/wallet/hd_private.hpp
+++ b/src/infrastructure/include/kth/infrastructure/wallet/hd_private.hpp
@@ -87,7 +87,7 @@ public:
 
 private:
     /// Factories.
-    static hd_private from_seed(data_slice seed, uint64_t prefixes);
+    static hd_private from_seed(byte_span seed, uint64_t prefixes);
     static hd_private from_key(hd_key const& decoded);
     static hd_private from_key(hd_key const& key, uint32_t public_prefix);
     static hd_private from_key(hd_key const& key, uint64_t prefixes);

--- a/src/infrastructure/include/kth/infrastructure/wallet/mnemonic.hpp
+++ b/src/infrastructure/include/kth/infrastructure/wallet/mnemonic.hpp
@@ -39,7 +39,7 @@ using word_list = string_list;
  * selection. The mnemonic can later be converted to a seed for use in wallet
  * creation. Entropy byte count must be evenly divisible by 4.
  */
-KI_API word_list create_mnemonic(data_slice entropy,
+KI_API word_list create_mnemonic(byte_span entropy,
     dictionary const& lexicon=language::en);
 
 /**

--- a/src/infrastructure/src/config/base16.cpp
+++ b/src/infrastructure/src/config/base16.cpp
@@ -22,7 +22,7 @@ base16::operator data_chunk const&() const noexcept {
     return value_;
 }
 
-base16::operator data_slice() const noexcept {
+base16::operator byte_span() const noexcept {
     return value_;
 }
 
@@ -30,7 +30,7 @@ data_chunk const& base16::data() const noexcept {
     return value_;
 }
 
-data_slice base16::as_slice() const noexcept {
+byte_span base16::as_span() const noexcept {
     return value_;
 }
 

--- a/src/infrastructure/src/config/base58.cpp
+++ b/src/infrastructure/src/config/base58.cpp
@@ -22,7 +22,7 @@ base58::operator data_chunk const&() const noexcept {
     return value_;
 }
 
-base58::operator data_slice() const noexcept {
+base58::operator byte_span() const noexcept {
     return value_;
 }
 
@@ -30,7 +30,7 @@ data_chunk const& base58::data() const noexcept {
     return value_;
 }
 
-data_slice base58::as_slice() const noexcept {
+byte_span base58::as_span() const noexcept {
     return value_;
 }
 

--- a/src/infrastructure/src/config/base64.cpp
+++ b/src/infrastructure/src/config/base64.cpp
@@ -22,7 +22,7 @@ base64::operator data_chunk const&() const noexcept {
     return value_;
 }
 
-base64::operator data_slice() const noexcept {
+base64::operator byte_span() const noexcept {
     return value_;
 }
 
@@ -30,7 +30,7 @@ data_chunk const& base64::data() const noexcept {
     return value_;
 }
 
-data_slice base64::as_slice() const noexcept {
+byte_span base64::as_span() const noexcept {
     return value_;
 }
 

--- a/src/infrastructure/src/config/sodium.cpp
+++ b/src/infrastructure/src/config/sodium.cpp
@@ -38,7 +38,7 @@ sodium::operator hash_digest const&() const {
     return value_;
 }
 
-sodium::operator data_slice() const {
+sodium::operator byte_span() const {
     return value_;
 }
 

--- a/src/infrastructure/src/formats/base_16.cpp
+++ b/src/infrastructure/src/formats/base_16.cpp
@@ -17,7 +17,7 @@ static constexpr std::array<char, 16> hex_chars = {
     '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
 };
 
-std::string encode_base16(data_slice data) {
+std::string encode_base16(byte_span data) {
     std::string result(data.size() * 2, '\0');
     auto out = result.data();
     for (auto byte : data) {

--- a/src/infrastructure/src/formats/base_58.cpp
+++ b/src/infrastructure/src/formats/base_58.cpp
@@ -35,7 +35,7 @@ auto search_first_nonzero(const Data& data) -> decltype(data.cbegin()) {
     return first_nonzero;
 }
 
-size_t count_leading_zeros(data_slice unencoded) {
+size_t count_leading_zeros(byte_span unencoded) {
     // Skip and count leading '1's.
     size_t leading_zeros = 0;
     for (uint8_t const byte: unencoded) {
@@ -60,7 +60,7 @@ void pack_value(data_chunk& indexes, size_t carry) {
     KTH_ASSERT(carry == 0);
 }
 
-std::string encode_base58(data_slice unencoded) {
+std::string encode_base58(byte_span unencoded) {
     size_t leading_zeros = count_leading_zeros(unencoded);
 
     // size = log(256) / log(58), rounded up.

--- a/src/infrastructure/src/formats/base_64.cpp
+++ b/src/infrastructure/src/formats/base_64.cpp
@@ -15,7 +15,7 @@
 
 namespace kth {
 
-std::string encode_base64(data_slice unencoded) {
+std::string encode_base64(byte_span unencoded) {
     auto const input = reinterpret_cast<char const*>(unencoded.data());
     auto const size = unencoded.size();
     auto const output_size = simdutf::base64_length_from_binary(size);
@@ -58,7 +58,7 @@ const static char pad = '=';
 const static char table[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-std::string encode_base64(data_slice unencoded)
+std::string encode_base64(byte_span unencoded)
 {
     std::string encoded;
     auto const size = unencoded.size();

--- a/src/infrastructure/src/formats/base_85.cpp
+++ b/src/infrastructure/src/formats/base_85.cpp
@@ -74,7 +74,7 @@ static uint8_t decoder[96] =
 };
 
 // Accepts only byte arrays bounded to 4 bytes.
-bool encode_base85(std::string& out, data_slice in)
+bool encode_base85(std::string& out, byte_span in)
 {
     size_t const size = in.size();
     if (size % 4 != 0) {

--- a/src/infrastructure/src/math/checksum.cpp
+++ b/src/infrastructure/src/math/checksum.cpp
@@ -15,13 +15,13 @@ void append_checksum(data_chunk& data)
     extend_data(data, to_little_endian(checksum));
 }
 
-uint32_t bitcoin_checksum(data_slice data)
+uint32_t bitcoin_checksum(byte_span data)
 {
     auto const hash = bitcoin_hash(data);
     return from_little_endian_unsafe<uint32_t>(hash);
 }
 
-bool verify_checksum(data_slice data)
+bool verify_checksum(byte_span data)
 {
     if (data.size() < checksum_size) {
         return false;

--- a/src/infrastructure/src/math/elliptic_curve.cpp
+++ b/src/infrastructure/src/math/elliptic_curve.cpp
@@ -181,7 +181,7 @@ bool verify(const ec_uncompressed& point) {
 // Detect public keys
 // ----------------------------------------------------------------------------
 
-bool is_compressed_key(data_slice point) {
+bool is_compressed_key(byte_span point) {
     auto const size = point.size();
     if (size != ec_compressed_size) {
         return false;
@@ -191,7 +191,7 @@ bool is_compressed_key(data_slice point) {
     return first == compressed_even || first == compressed_odd;
 }
 
-bool is_uncompressed_key(data_slice point) {
+bool is_uncompressed_key(byte_span point) {
     auto const size = point.size();
     if (size != ec_uncompressed_size) {
         return false;
@@ -201,7 +201,7 @@ bool is_uncompressed_key(data_slice point) {
     return first == uncompressed;
 }
 
-bool is_public_key(data_slice point) {
+bool is_public_key(byte_span point) {
     return is_compressed_key(point) || is_uncompressed_key(point);
 }
 
@@ -334,7 +334,7 @@ bool verify_signature(const ec_uncompressed& point, hash_digest const& hash, con
         verify_signature(context, pubkey, hash, signature);
 }
 
-bool verify_signature(data_slice point, hash_digest const& hash, const ec_signature& signature) {
+bool verify_signature(byte_span point, hash_digest const& hash, const ec_signature& signature) {
     // Copy to avoid exposing external types.
     secp256k1_ecdsa_signature parsed;
     std::copy_n(signature.begin(), ec_signature_size, std::begin(parsed.data));
@@ -345,7 +345,7 @@ bool verify_signature(data_slice point, hash_digest const& hash, const ec_signat
     auto const context = verification.context();
     secp256k1_ecdsa_signature_normalize(context, &normal, &parsed);
 
-    // This uses a data slice and calls secp256k1_ec_pubkey_parse() in place of
+    // This uses a byte span and calls secp256k1_ec_pubkey_parse() in place of
     // parse() so that we can support the der_verify data_chunk optimization.
     secp256k1_pubkey pubkey;
     auto const size = point.size();

--- a/src/infrastructure/src/math/hash.cpp
+++ b/src/infrastructure/src/math/hash.cpp
@@ -27,12 +27,12 @@
 
 namespace kth {
 
-hash_digest bitcoin_hash(data_slice data) {
+hash_digest bitcoin_hash(byte_span data) {
     return sha256_hash(sha256_hash(data));
 }
 
 // #ifdef KTH_CURRENCY_LTC
-// hash_digest litecoin_hash(data_slice data) {
+// hash_digest litecoin_hash(byte_span data) {
 //     hash_digest hash;
 //     scrypt_1024_1_1_256(reinterpret_cast<char const*>(data.data()),
 //                         reinterpret_cast<char*>(hash.data()));
@@ -40,47 +40,47 @@ hash_digest bitcoin_hash(data_slice data) {
 // }
 // #endif //KTH_CURRENCY_LTC
 
-short_hash bitcoin_short_hash(data_slice data) {
+short_hash bitcoin_short_hash(byte_span data) {
     return ripemd160_hash(sha256_hash(data));
 }
 
-short_hash ripemd160_hash(data_slice data) {
+short_hash ripemd160_hash(byte_span data) {
     short_hash hash;
     RMD160(data.data(), data.size(), hash.data());
     return hash;
 }
 
-data_chunk ripemd160_hash_chunk(data_slice data) {
+data_chunk ripemd160_hash_chunk(byte_span data) {
     data_chunk hash(short_hash_size);
     RMD160(data.data(), data.size(), hash.data());
     return hash;
 }
 
-short_hash sha1_hash(data_slice data) {
+short_hash sha1_hash(byte_span data) {
     short_hash hash;
     SHA1_(data.data(), data.size(), hash.data());
     return hash;
 }
 
-data_chunk sha1_hash_chunk(data_slice data) {
+data_chunk sha1_hash_chunk(byte_span data) {
     data_chunk hash(short_hash_size);
     SHA1_(data.data(), data.size(), hash.data());
     return hash;
 }
 
-hash_digest sha256_hash(data_slice data) {
+hash_digest sha256_hash(byte_span data) {
     hash_digest hash;
     SHA256_(data.data(), data.size(), hash.data());
     return hash;
 }
 
-data_chunk sha256_hash_chunk(data_slice data) {
+data_chunk sha256_hash_chunk(byte_span data) {
     data_chunk hash(hash_size);
     SHA256_(data.data(), data.size(), hash.data());
     return hash;
 }
 
-hash_digest sha256_hash(data_slice first, data_slice second) {
+hash_digest sha256_hash(byte_span first, byte_span second) {
     hash_digest hash;
     SHA256CTX context;
     SHA256Init(&context);
@@ -90,25 +90,25 @@ hash_digest sha256_hash(data_slice first, data_slice second) {
     return hash;
 }
 
-hash_digest hmac_sha256_hash(data_slice data, data_slice key) {
+hash_digest hmac_sha256_hash(byte_span data, byte_span key) {
     hash_digest hash;
     HMACSHA256(data.data(), data.size(), key.data(), key.size(), hash.data());
     return hash;
 }
 
-long_hash sha512_hash(data_slice data) {
+long_hash sha512_hash(byte_span data) {
     long_hash hash;
     SHA512_(data.data(), data.size(), hash.data());
     return hash;
 }
 
-long_hash hmac_sha512_hash(data_slice data, data_slice key) {
+long_hash hmac_sha512_hash(byte_span data, byte_span key) {
     long_hash hash;
     HMACSHA512(data.data(), data.size(), key.data(), key.size(), hash.data());
     return hash;
 }
 
-long_hash pkcs5_pbkdf2_hmac_sha512(data_slice passphrase, data_slice salt, size_t iterations) {
+long_hash pkcs5_pbkdf2_hmac_sha512(byte_span passphrase, byte_span salt, size_t iterations) {
     long_hash hash;
     auto const result = pkcs5_pbkdf2(passphrase.data(), passphrase.size(),
         salt.data(), salt.size(), hash.data(), hash.size(), iterations);
@@ -138,7 +138,7 @@ void handle_script_result(int result) {
     }
 }
 
-data_chunk scrypt(data_slice data, data_slice salt, uint64_t N, uint32_t p, uint32_t r, size_t length) {
+data_chunk scrypt(byte_span data, byte_span salt, uint64_t N, uint32_t p, uint32_t r, size_t length) {
     data_chunk output(length);
     auto const result = crypto_scrypt(data.data(), data.size(), salt.data(),
         salt.size(), N, r, p, output.data(), output.size());

--- a/src/infrastructure/src/utility/binary.cpp
+++ b/src/infrastructure/src/utility/binary.cpp
@@ -39,7 +39,7 @@ binary::binary(size_type size, uint32_t number)
     : binary(size, to_little_endian(number))
 {}
 
-binary::binary(size_type size, data_slice blocks)
+binary::binary(size_type size, byte_span blocks)
     : binary()
 {
     // Copy blocks
@@ -212,7 +212,7 @@ bool binary::is_prefix_of(binary const& field) const {
     return is_prefix_of(field.blocks());
 }
 
-bool binary::is_prefix_of(data_slice field) const {
+bool binary::is_prefix_of(byte_span field) const {
     binary const truncated_prefix(size(), field);
     return *this == truncated_prefix;
 }

--- a/src/infrastructure/src/wallet/hd_private.cpp
+++ b/src/infrastructure/src/wallet/hd_private.cpp
@@ -72,7 +72,7 @@ hd_private::hd_private(ec_secret const& secret, const hd_chain_code& chain_code,
 // Factories.
 // ----------------------------------------------------------------------------
 
-hd_private hd_private::from_seed(data_slice seed, uint64_t prefixes) {
+hd_private hd_private::from_seed(byte_span seed, uint64_t prefixes) {
     // This is a magic constant from BIP32.
     static data_chunk const magic(to_chunk("Bitcoin seed"));
 

--- a/src/infrastructure/src/wallet/mnemonic.cpp
+++ b/src/infrastructure/src/wallet/mnemonic.cpp
@@ -67,7 +67,7 @@ bool validate_mnemonic(const word_list& words, const dictionary& lexicon) {
     return std::equal(mnemonic.begin(), mnemonic.end(), words.begin());
 }
 
-word_list create_mnemonic(data_slice entropy, const dictionary &lexicon) {
+word_list create_mnemonic(byte_span entropy, const dictionary &lexicon) {
     if ((entropy.size() % mnemonic_seed_multiple) != 0) {
         return word_list();
     }

--- a/src/infrastructure/test/formats/base_encoding_benchmarks.cpp
+++ b/src/infrastructure/test/formats/base_encoding_benchmarks.cpp
@@ -42,36 +42,36 @@ void benchmark_base16() {
     Bench().title("Base16 Encoding").relative(true)
         .run("encode 32B (hash)", [&] {
             ankerl::nanobench::doNotOptimizeAway(
-                encode_base16(data_slice(small_data.data(), small_data.size()))
+                encode_base16(byte_span(small_data.data(), small_data.size()))
             );
         })
         .run("encode 256B", [&] {
             ankerl::nanobench::doNotOptimizeAway(
-                encode_base16(data_slice(medium_data.data(), medium_data.size()))
+                encode_base16(byte_span(medium_data.data(), medium_data.size()))
             );
         })
         .run("encode 1KB", [&] {
             ankerl::nanobench::doNotOptimizeAway(
-                encode_base16(data_slice(large_data.data(), large_data.size()))
+                encode_base16(byte_span(large_data.data(), large_data.size()))
             );
         })
         .run("encode 16KB", [&] {
             ankerl::nanobench::doNotOptimizeAway(
-                encode_base16(data_slice(xl_data.data(), xl_data.size()))
+                encode_base16(byte_span(xl_data.data(), xl_data.size()))
             );
         })
         .run("encode 64KB", [&] {
             ankerl::nanobench::doNotOptimizeAway(
-                encode_base16(data_slice(xxl_data.data(), xxl_data.size()))
+                encode_base16(byte_span(xxl_data.data(), xxl_data.size()))
             );
         });
 
     // Prepare encoded versions for decoding benchmarks
-    auto small_encoded = encode_base16(data_slice(small_data.data(), small_data.size()));
-    auto medium_encoded = encode_base16(data_slice(medium_data.data(), medium_data.size()));
-    auto large_encoded = encode_base16(data_slice(large_data.data(), large_data.size()));
-    auto xl_encoded = encode_base16(data_slice(xl_data.data(), xl_data.size()));
-    auto xxl_encoded = encode_base16(data_slice(xxl_data.data(), xxl_data.size()));
+    auto small_encoded = encode_base16(byte_span(small_data.data(), small_data.size()));
+    auto medium_encoded = encode_base16(byte_span(medium_data.data(), medium_data.size()));
+    auto large_encoded = encode_base16(byte_span(large_data.data(), large_data.size()));
+    auto xl_encoded = encode_base16(byte_span(xl_data.data(), xl_data.size()));
+    auto xxl_encoded = encode_base16(byte_span(xxl_data.data(), xxl_data.size()));
 
     // Decoding benchmarks
     Bench().title("Base16 Decoding").relative(true)
@@ -118,24 +118,24 @@ void benchmark_base58() {
     Bench().title("Base58 Encoding").relative(true)
         .run("encode 25B (address)", [&] {
             ankerl::nanobench::doNotOptimizeAway(
-                encode_base58(data_slice(small_data.data(), small_data.size()))
+                encode_base58(byte_span(small_data.data(), small_data.size()))
             );
         })
         .run("encode 128B", [&] {
             ankerl::nanobench::doNotOptimizeAway(
-                encode_base58(data_slice(medium_data.data(), medium_data.size()))
+                encode_base58(byte_span(medium_data.data(), medium_data.size()))
             );
         })
         .run("encode 512B", [&] {
             ankerl::nanobench::doNotOptimizeAway(
-                encode_base58(data_slice(large_data.data(), large_data.size()))
+                encode_base58(byte_span(large_data.data(), large_data.size()))
             );
         });
 
     // Prepare encoded versions
-    auto small_encoded = encode_base58(data_slice(small_data.data(), small_data.size()));
-    auto medium_encoded = encode_base58(data_slice(medium_data.data(), medium_data.size()));
-    auto large_encoded = encode_base58(data_slice(large_data.data(), large_data.size()));
+    auto small_encoded = encode_base58(byte_span(small_data.data(), small_data.size()));
+    auto medium_encoded = encode_base58(byte_span(medium_data.data(), medium_data.size()));
+    auto large_encoded = encode_base58(byte_span(large_data.data(), large_data.size()));
 
     // Decoding benchmarks
     Bench().title("Base58 Decoding").relative(true)
@@ -181,36 +181,36 @@ void benchmark_base64() {
     Bench().title("Base64 Encoding").relative(true)
         .run("encode 32B", [&] {
             ankerl::nanobench::doNotOptimizeAway(
-                encode_base64(data_slice(small_data.data(), small_data.size()))
+                encode_base64(byte_span(small_data.data(), small_data.size()))
             );
         })
         .run("encode 256B", [&] {
             ankerl::nanobench::doNotOptimizeAway(
-                encode_base64(data_slice(medium_data.data(), medium_data.size()))
+                encode_base64(byte_span(medium_data.data(), medium_data.size()))
             );
         })
         .run("encode 1KB", [&] {
             ankerl::nanobench::doNotOptimizeAway(
-                encode_base64(data_slice(large_data.data(), large_data.size()))
+                encode_base64(byte_span(large_data.data(), large_data.size()))
             );
         })
         .run("encode 16KB", [&] {
             ankerl::nanobench::doNotOptimizeAway(
-                encode_base64(data_slice(xl_data.data(), xl_data.size()))
+                encode_base64(byte_span(xl_data.data(), xl_data.size()))
             );
         })
         .run("encode 64KB", [&] {
             ankerl::nanobench::doNotOptimizeAway(
-                encode_base64(data_slice(xxl_data.data(), xxl_data.size()))
+                encode_base64(byte_span(xxl_data.data(), xxl_data.size()))
             );
         });
 
     // Prepare encoded versions
-    auto small_encoded = encode_base64(data_slice(small_data.data(), small_data.size()));
-    auto medium_encoded = encode_base64(data_slice(medium_data.data(), medium_data.size()));
-    auto large_encoded = encode_base64(data_slice(large_data.data(), large_data.size()));
-    auto xl_encoded = encode_base64(data_slice(xl_data.data(), xl_data.size()));
-    auto xxl_encoded = encode_base64(data_slice(xxl_data.data(), xxl_data.size()));
+    auto small_encoded = encode_base64(byte_span(small_data.data(), small_data.size()));
+    auto medium_encoded = encode_base64(byte_span(medium_data.data(), medium_data.size()));
+    auto large_encoded = encode_base64(byte_span(large_data.data(), large_data.size()));
+    auto xl_encoded = encode_base64(byte_span(xl_data.data(), xl_data.size()));
+    auto xxl_encoded = encode_base64(byte_span(xxl_data.data(), xxl_data.size()));
 
     // Decoding benchmarks
     Bench().title("Base64 Decoding").relative(true)
@@ -263,27 +263,27 @@ void benchmark_base85() {
         .run("encode 32B", [&] {
             std::string result;
             ankerl::nanobench::doNotOptimizeAway(
-                encode_base85(result, data_slice(small_data.data(), small_data.size()))
+                encode_base85(result, byte_span(small_data.data(), small_data.size()))
             );
         })
         .run("encode 256B", [&] {
             std::string result;
             ankerl::nanobench::doNotOptimizeAway(
-                encode_base85(result, data_slice(medium_data.data(), medium_data.size()))
+                encode_base85(result, byte_span(medium_data.data(), medium_data.size()))
             );
         })
         .run("encode 1KB", [&] {
             std::string result;
             ankerl::nanobench::doNotOptimizeAway(
-                encode_base85(result, data_slice(large_data.data(), large_data.size()))
+                encode_base85(result, byte_span(large_data.data(), large_data.size()))
             );
         });
 
     // Prepare encoded versions
     std::string small_encoded, medium_encoded, large_encoded;
-    encode_base85(small_encoded, data_slice(small_data.data(), small_data.size()));
-    encode_base85(medium_encoded, data_slice(medium_data.data(), medium_data.size()));
-    encode_base85(large_encoded, data_slice(large_data.data(), large_data.size()));
+    encode_base85(small_encoded, byte_span(small_data.data(), small_data.size()));
+    encode_base85(medium_encoded, byte_span(medium_data.data(), medium_data.size()));
+    encode_base85(large_encoded, byte_span(large_data.data(), large_data.size()));
 
     // Decoding benchmarks
     Bench().title("Base85 Decoding").relative(true)
@@ -312,7 +312,7 @@ void benchmark_cross_encoding() {
 
     // Use 256 bytes for fair comparison
     auto test_data = generate_test_data(256);
-    auto data = data_slice(test_data.data(), test_data.size());
+    auto data = byte_span(test_data.data(), test_data.size());
 
     // Compare encoding speeds
     Bench().title("Encoding Comparison (256B)").relative(true)
@@ -382,7 +382,7 @@ void benchmark_bitcoin_operations() {
     Bench().title("Bitcoin Address Operations").relative(true)
         .run("encode address (Base58)", [&] {
             ankerl::nanobench::doNotOptimizeAway(
-                encode_base58(data_slice(address_data.data(), address_data.size()))
+                encode_base58(byte_span(address_data.data(), address_data.size()))
             );
         });
 
@@ -392,7 +392,7 @@ void benchmark_bitcoin_operations() {
     Bench().title("Script Encoding").relative(true)
         .run("encode script (hex)", [&] {
             ankerl::nanobench::doNotOptimizeAway(
-                encode_base16(data_slice(script_data.data(), script_data.size()))
+                encode_base16(byte_span(script_data.data(), script_data.size()))
             );
         });
 }

--- a/src/infrastructure/test/utility/data.cpp
+++ b/src/infrastructure/test/utility/data.cpp
@@ -20,7 +20,7 @@ TEST_CASE("infrastructure data to byte array", "[infrastructure][data]") {
     REQUIRE(result[0] == expected);
 }
 
-TEST_CASE("infrastructure data build chunk from empty slices", "[infrastructure][data]") {
+TEST_CASE("infrastructure data build chunk from empty spans", "[infrastructure][data]") {
     auto const result = build_chunk({});
     REQUIRE(result.empty());
 }
@@ -39,7 +39,7 @@ TEST_CASE("infrastructure data build chunk from single slice", "[infrastructure]
     REQUIRE(result[1] == expected);
 }
 
-TEST_CASE("infrastructure data build chunk from multiple slices", "[infrastructure][data]") {
+TEST_CASE("infrastructure data build chunk from multiple spans", "[infrastructure][data]") {
     size_t const size1 = 2;
     size_t const size2 = 1;
     size_t const size3 = 3;
@@ -69,7 +69,7 @@ TEST_CASE("infrastructure data build chunk with extra reserve capacity", "[infra
     REQUIRE(result.capacity() == size1 + size2 + size3 + reserve);
 }
 
-TEST_CASE("infrastructure data build array from empty slices", "[infrastructure][data]") {
+TEST_CASE("infrastructure data build array from empty spans", "[infrastructure][data]") {
     uint8_t const expected = 42;
     std::array<uint8_t, 3> value{ { 0, expected, 0 } };
     auto const result = build_array(value, {});
@@ -92,7 +92,7 @@ TEST_CASE("infrastructure data build array under capacity", "[infrastructure][da
     REQUIRE(value[2] == expected3);
 }
 
-TEST_CASE("infrastructure data build array exact fill from multiple slices", "[infrastructure][data]") {
+TEST_CASE("infrastructure data build array exact fill from multiple spans", "[infrastructure][data]") {
     size_t const size1 = 2;
     size_t const size2 = 1;
     size_t const size3 = 3;


### PR DESCRIPTION
## Summary

- Replace `data_slice` type alias with `byte_span` (`std::span<uint8_t const>`)
- Rename `as_slice()` methods to `as_span()`
- Rename local variables from `slice`/`slices` to `span`/`spans`
- Update related comments to reference "span" instead of "slice"
- Keep `slice<>()` template function unchanged (array slicing operation)

## Test plan

- [x] Build compiles successfully
- [x] All tests pass