### PR TITLE
refactor: apply east const style

### DIFF
--- a/scripts/east_const.sh
+++ b/scripts/east_const.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# East const conversion script
+# Usage: ./scripts/east_const.sh
+# This script is idempotent - running it multiple times produces no additional changes
+
+set -e
+
+# =============================================================================
+# Types to convert
+# =============================================================================
+BASIC_TYPES="uint8_t|uint16_t|uint32_t|uint64_t|int8_t|int16_t|int32_t|int64_t|size_t|bool|auto"
+CLASS_TYPES="authority|byte_array|dictionary|mnemonic_result_list|one_byte|hd_chain_code|ek_salt|ec_compressed|dictionary_list|synchronizer_terminate|string_list|long_hash|hash|generator|error_category_impl|ek_entropy|ec_signature|metric_attribute|threading_model|message|get_data|fee_filter|binary|ek_seed|parse_encrypted_private|ec_uncompressed|recoverable_signature|quarter_hash|parse_encrypted_token|parse_encrypted_public|outs|ins|half_hash|endorsement|event_handler|address|reject|result_handler|not_found|header|transaction_entry|time_t|hash256|secp256k1_pubkey|arith_uint256|unspent_outputs|unspent_transaction|output_point|settings|short_hash|file_offset|heights|microseconds|input|output|transaction|points_value|wif_uncompressed|message_signature|block_const_ptr_list|settings_list|program|word_list|secp256k1_context"
+
+ALL_TYPES="$BASIC_TYPES|$CLASS_TYPES"
+
+# =============================================================================
+# Find files (excluding external code)
+# =============================================================================
+FILES=$(find src -type f \( -name "*.hpp" -o -name "*.cpp" -o -name "*.ipp" \) \
+  ! -path "*/secp256k1/*" \
+  ! -path "*/consensus/*" \
+  ! -path "*/external/*")
+
+echo "Processing $(echo "$FILES" | wc -l | tr -d ' ') files..."
+
+# =============================================================================
+# Apply transformations to each file once
+# =============================================================================
+for file in $FILES; do
+  sed -i '' -E "
+    # Line start with spaces: const TYPE  -> TYPE const
+    s/^([[:space:]]+)const ($ALL_TYPES) /\1\2 const /g
+
+    # After ( : (const TYPE  -> (TYPE const
+    s/\(const ($ALL_TYPES) /(\1 const /g
+
+    # After , : , const TYPE  -> , TYPE const
+    s/, const ($ALL_TYPES) /, \1 const /g
+
+    # References: const TYPE& -> TYPE const&
+    s/const ($ALL_TYPES)&/\1 const\&/g
+
+    # References with space: const TYPE & -> TYPE const&
+    s/const ($ALL_TYPES) &/\1 const\&/g
+
+    # After ( with reference: (const TYPE& -> (TYPE const&
+    s/\(const ($ALL_TYPES)&/(\1 const\&/g
+
+    # After ( with reference and space: (const TYPE & -> (TYPE const&
+    s/\(const ($ALL_TYPES) &/(\1 const\&/g
+
+    # Templates: const TYPE<...>& -> TYPE<...> const&
+    s/const ($ALL_TYPES)<([^>]+)>&/\1<\2> const\&/g
+
+    # Templates with space: const TYPE<...> & -> TYPE<...> const&
+    s/const ($ALL_TYPES)<([^>]+)> &/\1<\2> const\&/g
+
+    # Namespaced templates: const NS::TYPE<...>& -> NS::TYPE<...> const&
+    s/const (std::[a-zA-Z_]+)<([^>]+)>&/\1<\2> const\&/g
+
+    # Namespaced templates with space: const NS::TYPE<...> & -> NS::TYPE<...> const&
+    s/const (std::[a-zA-Z_]+)<([^>]+)> &/\1<\2> const\&/g
+
+    # Pointers: const TYPE* -> TYPE const*
+    s/const ($ALL_TYPES)\*/\1 const*/g
+
+    # Pointers with space: const TYPE * -> TYPE const*
+    s/const ($ALL_TYPES) \*/\1 const*/g
+
+    # Reference format: const & -> const&
+    s/const &/const\& /g
+
+    # Fix double space after const&
+    s/const&  /const\& /g
+  " "$file"
+done
+
+echo "Done - east const conversion complete"

--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -260,13 +260,13 @@ public:
     /// fetch the inpoint (spender) of an outpoint.
     void fetch_spend(const domain::chain::output_point& outpoint, spend_fetch_handler handler) const override;
     /// fetch outputs, values and spends for an address_hash.
-    void fetch_history(const short_hash& address_hash, size_t limit, size_t from_height, history_fetch_handler handler) const override;
+    void fetch_history(short_hash const& address_hash, size_t limit, size_t from_height, history_fetch_handler handler) const override;
 
     /// Fetch all the txns used by the wallet
-    void fetch_confirmed_transactions(const short_hash& address_hash, size_t limit, size_t from_height, confirmed_transactions_fetch_handler handler) const override;
+    void fetch_confirmed_transactions(short_hash const& address_hash, size_t limit, size_t from_height, confirmed_transactions_fetch_handler handler) const override;
 
 //     /// fetch stealth results.
-//     void fetch_stealth(const binary& filter, size_t from_height, stealth_fetch_handler handler) const override;
+//     void fetch_stealth(binary const& filter, size_t from_height, stealth_fetch_handler handler) const override;
 
     // Transaction Pool.
     //-------------------------------------------------------------------------
@@ -373,7 +373,7 @@ private:
     // These are thread safe.
     std::atomic<bool> stopped_;
     settings const& settings_;
-    const time_t notify_limit_seconds_;
+    time_t const notify_limit_seconds_;
     kth::atomic<block_const_ptr> last_block_;
 
     //TODO(kth):  dissabled this tx cache because we don't want special treatment for the last txn, it affects the explorer rpc methods

--- a/src/blockchain/include/kth/blockchain/interface/safe_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/safe_chain.hpp
@@ -117,10 +117,10 @@ struct KB_API safe_chain {
 
     virtual void fetch_spend(const domain::chain::output_point& outpoint, spend_fetch_handler handler) const = 0;
 
-    virtual void fetch_history(const short_hash& address_hash, size_t limit, size_t from_height, history_fetch_handler handler) const = 0;
-    virtual void fetch_confirmed_transactions(const short_hash& address_hash, size_t limit, size_t from_height, confirmed_transactions_fetch_handler handler) const = 0;
+    virtual void fetch_history(short_hash const& address_hash, size_t limit, size_t from_height, history_fetch_handler handler) const = 0;
+    virtual void fetch_confirmed_transactions(short_hash const& address_hash, size_t limit, size_t from_height, confirmed_transactions_fetch_handler handler) const = 0;
 
-    // virtual void fetch_stealth(const binary& filter, size_t from_height, stealth_fetch_handler handler) const = 0;
+    // virtual void fetch_stealth(binary const& filter, size_t from_height, stealth_fetch_handler handler) const = 0;
 
     // Transaction Pool.
     //-------------------------------------------------------------------------
@@ -176,7 +176,7 @@ struct KB_API safe_chain {
 
     //TODO(Mario) temporary duplication
     /// Get a determination of whether the block hash exists in the store.
-    virtual bool get_block_exists_safe(hash_digest const & block_hash) const = 0;
+    virtual bool get_block_exists_safe(hash_digest const& block_hash) const = 0;
 
 };
 

--- a/src/blockchain/include/kth/blockchain/pools/transaction_entry.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/transaction_entry.hpp
@@ -75,7 +75,7 @@ struct KB_API transaction_entry {
 
     /// Serializer for debugging (temporary).
     friend
-    std::ostream& operator<<(std::ostream& out, const transaction_entry& of);
+    std::ostream& operator<<(std::ostream& out, transaction_entry const& of);
 
 private:
     // These are non-const to allow for default copy construction.

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -1011,14 +1011,14 @@ std::vector<kth::blockchain::mempool_transaction_summary> block_chain::get_mempo
 
     std::vector<kth::blockchain::mempool_transaction_summary> ret;
     std::unordered_set<kth::domain::wallet::payment_address> addrs;
-    for (auto const & payment_address : payment_addresses) {
+    for (auto const& payment_address : payment_addresses) {
         kth::domain::wallet::payment_address address(payment_address);
         if (address){
             addrs.insert(address);
         }
     }
 
-    database_.transactions_unconfirmed().for_each_result([&](kth::database::transaction_unconfirmed_result const &tx_res) {
+    database_.transactions_unconfirmed().for_each_result([&](kth::database::transaction_unconfirmed_result const& tx_res) {
         auto tx = tx_res.transaction();
         tx.recompute_hash();
         size_t i = 0;
@@ -1074,7 +1074,7 @@ std::vector<domain::chain::transaction> block_chain::get_mempool_transactions_fr
 
     std::vector<domain::chain::transaction> ret;
 
-    database_.transactions_unconfirmed().for_each_result([&](kth::database::transaction_unconfirmed_result const &tx_res) {
+    database_.transactions_unconfirmed().for_each_result([&](kth::database::transaction_unconfirmed_result const& tx_res) {
         auto tx = tx_res.transaction();
         tx.recompute_hash();
 
@@ -1138,7 +1138,7 @@ void block_chain::fill_tx_list_from_mempool(domain::message::compact_block const
 
     // spdlog::info("[blockchain] fill_tx_list_from_mempool header_hash -> {} k0 {} k1 {}", encode_hash(header_hash), k0, k1);
 
-    database_.transactions_unconfirmed().for_each([&](domain::chain::transaction const &tx) {
+    database_.transactions_unconfirmed().for_each([&](domain::chain::transaction const& tx) {
         uint64_t shortid = sip_hash_uint256(k0, k1, tx.hash()) & uint64_t(0xffffffffffff);
         // spdlog::info("[blockchain] mempool tx -> {} shortid {}", encode_hash(tx.hash()), shortid);
         auto idit = shorttxids.find(shortid);
@@ -1182,7 +1182,7 @@ safe_chain::mempool_mini_hash_map block_chain::get_mempool_mini_hash_map(domain:
 
     safe_chain::mempool_mini_hash_map mempool;
 
-    database_.transactions_unconfirmed().for_each([&](domain::chain::transaction const &tx) {
+    database_.transactions_unconfirmed().for_each([&](domain::chain::transaction const& tx) {
 
         auto sh = sip_hash_uint256(k0, k1, tx.hash());
 
@@ -1448,7 +1448,7 @@ void block_chain::fetch_history(short_hash const& address_hash, size_t limit, si
 
 }
 
-void block_chain::fetch_confirmed_transactions(const short_hash& address_hash, size_t limit, size_t from_height, confirmed_transactions_fetch_handler handler) const {
+void block_chain::fetch_confirmed_transactions(short_hash const& address_hash, size_t limit, size_t from_height, confirmed_transactions_fetch_handler handler) const {
     if (stopped()) {
         handler(error::service_stopped, {});
         return;
@@ -1463,7 +1463,7 @@ void block_chain::fetch_confirmed_transactions(const short_hash& address_hash, s
 
 
 #ifdef KTH_DB_STEALTH
-void block_chain::fetch_stealth(const binary& filter, size_t from_height, stealth_fetch_handler handler) const {
+void block_chain::fetch_stealth(binary const& filter, size_t from_height, stealth_fetch_handler handler) const {
     if (stopped()) {
         handler(error::service_stopped, {});
         return;

--- a/src/blockchain/src/pools/block_organizer.cpp
+++ b/src/blockchain/src/pools/block_organizer.cpp
@@ -96,7 +96,7 @@ void block_organizer::organize(block_const_ptr block, result_handler handler) {
     // Reset the reusable promise.
     resume_ = std::promise<code>();
 
-    const result_handler complete = std::bind(&block_organizer::signal_completion, this, _1);
+    result_handler const complete = std::bind(&block_organizer::signal_completion, this, _1);
     auto const check_handler = std::bind(&block_organizer::handle_check, this, _1, block, complete);
 
     // Checks that are independent of chain state.

--- a/src/blockchain/src/pools/branch.cpp
+++ b/src/blockchain/src/pools/branch.cpp
@@ -193,7 +193,7 @@ void branch::populate_spent(output_point const& outpoint) const {
     // TODO(legacy): use hash table storage of block's inputs for block pool entries.
     auto const blocks = [&outpoint](block_const_ptr block) {
         auto const transactions = [&outpoint](transaction const& tx) {
-            auto const prevout_match = [&outpoint](const input& input) {
+            auto const prevout_match = [&outpoint](input const& input) {
                 return input.previous_output() == outpoint;
             };
 

--- a/src/blockchain/src/pools/transaction_entry.cpp
+++ b/src/blockchain/src/pools/transaction_entry.cpp
@@ -110,7 +110,7 @@ void transaction_entry::remove_child(ptr child) {
     }
 }
 
-std::ostream& operator<<(std::ostream& out, const transaction_entry& of) {
+std::ostream& operator<<(std::ostream& out, transaction_entry const& of) {
     out << encode_hash(of.hash_)
         << " " << of.parents_.size()
         << " " << of.children_.size();

--- a/src/blockchain/test/transaction_entry.cpp
+++ b/src/blockchain/test/transaction_entry.cpp
@@ -62,7 +62,7 @@ transaction_entry::ptr make_instance() {
 // construct1/tx
 
 TEST_CASE("transaction entry  construct1  default tx  expected values", "[transaction entry tests]") {
-    const transaction_entry instance(make_tx());
+    transaction_entry const instance(make_tx());
     REQUIRE(instance.is_anchor());
     REQUIRE(instance.fees() == 0);
     REQUIRE(instance.forks() == 0);
@@ -77,7 +77,7 @@ TEST_CASE("transaction entry  construct1  default tx  expected values", "[transa
 // construct2/hash
 
 TEST_CASE("transaction entry  construct1  default block hash  expected values", "[transaction entry tests]") {
-    const transaction_entry instance(make_tx()->hash());
+    transaction_entry const instance(make_tx()->hash());
     REQUIRE(instance.is_anchor());
     REQUIRE(instance.fees() == 0);
     REQUIRE(instance.forks() == 0);
@@ -123,7 +123,7 @@ TEST_CASE("transaction entry  mark  true false  expected", "[transaction entry t
 // is_marked
 
 TEST_CASE("transaction entry  mark  default  false", "[transaction entry tests]") {
-    const transaction_entry instance(make_tx());
+    transaction_entry const instance(make_tx());
     REQUIRE( ! instance.is_marked());
 }
 

--- a/src/c-api/src/chain/chain_async.cpp
+++ b/src/c-api/src/chain/chain_async.cpp
@@ -168,7 +168,7 @@ void kth_chain_async_history(kth_chain_t chain, void* ctx, kth_payment_address_t
 }
 
 void kth_chain_async_confirmed_transactions(kth_chain_t chain, void* ctx, kth_payment_address_t address, uint64_t max, uint64_t start_height, kth_transactions_by_address_fetch_handler_t handler) {
-    safe_chain(chain).fetch_confirmed_transactions(kth_wallet_payment_address_const_cpp(address).hash20(), max, start_height, [chain, ctx, handler](std::error_code const& ec, const std::vector<kth::hash_digest>& txs) {
+    safe_chain(chain).fetch_confirmed_transactions(kth_wallet_payment_address_const_cpp(address).hash20(), max, start_height, [chain, ctx, handler](std::error_code const& ec, std::vector<kth::hash_digest> const& txs) {
         handler(chain, ctx, kth::to_c_err(ec), kth::leak_if_success(txs, ec));
     });
 }

--- a/src/c-api/src/chain/chain_sync.cpp
+++ b/src/c-api/src/chain/chain_sync.cpp
@@ -343,7 +343,7 @@ kth_error_code_t kth_chain_sync_confirmed_transactions(kth_chain_t chain, kth_pa
     std::latch latch(1); //Note: workaround to fix an error on some versions of Boost.Threads
     kth_error_code_t res;
 
-    safe_chain(chain).fetch_confirmed_transactions(kth_wallet_payment_address_const_cpp(address).hash20(), max, start_height, [&](std::error_code const& ec, const std::vector<kth::hash_digest>& txs) {
+    safe_chain(chain).fetch_confirmed_transactions(kth_wallet_payment_address_const_cpp(address).hash20(), max, start_height, [&](std::error_code const& ec, std::vector<kth::hash_digest> const& txs) {
         *out_tx_hashes = kth::leak_if_success(txs, ec);
         res = kth::to_c_err(ec);
         latch.count_down();

--- a/src/c-api/src/vm/program.cpp
+++ b/src/c-api/src/vm/program.cpp
@@ -44,7 +44,7 @@ kth_program_t kth_vm_program_construct_from_script_transaction(kth_script_t scri
 // program(chain::script const& script, chain::transaction const& transaction, uint32_t input_index, uint32_t forks, data_stack&& stack, uint64_t value, script_version version = script_version::zero);
 // kth_program_t kth_vm_program_construct_from_script_transaction_stack(kth_script_t script, kth_transaction_t transaction, uint32_t input_index, uint32_t forks, kth_data_stack_t stack, uint64_t value, kth_script_version_t version);
 
-// program(chain::script const& script, const program& x);
+// program(chain::script const& script, program const& x);
 kth_program_t kth_vm_program_construct_from_script_program(kth_script_t script, kth_program_t program) {
     auto const& script_cpp = kth_chain_script_const_cpp(script);
     auto const& program_cpp = kth_vm_program_const_cpp(program);

--- a/src/database/include/kth/database/databases/history_database.ipp
+++ b/src/database/include/kth/database/databases/history_database.ipp
@@ -227,7 +227,7 @@ std::vector<hash_digest> internal_database_basis<Clock>::get_history_txns(short_
 
         if (entry_res3 && (from_height == 0 || entry_res3->height() >= from_height)) {
             // Avoid inserting the same tx
-            auto const & pair = temp.insert(entry_res3->point().hash());
+            auto const& pair = temp.insert(entry_res3->point().hash());
             if (pair.second){
                 // Add valid txns to the result vector
                 result.push_back(*pair.first);
@@ -246,7 +246,7 @@ std::vector<hash_digest> internal_database_basis<Clock>::get_history_txns(short_
 
             if (entry_res4 && (from_height == 0 || entry_res4->height() >= from_height)) {
                 // Avoid inserting the same tx
-                auto const & pair = temp.insert(entry_res4->point().hash());
+                auto const& pair = temp.insert(entry_res4->point().hash());
                 if (pair.second){
                     // Add valid txns to the result vector
                     result.push_back(*pair.first);

--- a/src/database/include/kth/database/databases/internal_database.ipp
+++ b/src/database/include/kth/database/databases/internal_database.ipp
@@ -760,8 +760,8 @@ inline
 int compare_uint64(KTH_DB_val const* a, KTH_DB_val const* b) {
 
     //TODO(fernando): check this casts... something smells bad
-    const uint64_t va = *(const uint64_t *)kth_db_get_data(*a);
-    const uint64_t vb = *(const uint64_t *)kth_db_get_data(*b);
+    uint64_t const va = *(uint64_t const *)kth_db_get_data(*a);
+    uint64_t const vb = *(uint64_t const *)kth_db_get_data(*b);
 
     //std::println("va: {}", va);
     //std::println("vb: {}", va);

--- a/src/database/include/kth/database/databases/temp.cpp
+++ b/src/database/include/kth/database/databases/temp.cpp
@@ -30,7 +30,7 @@ void BlockchainLMDB::do_resize(uint64_t increase_size)
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   CRITICAL_REGION_LOCAL(m_synchronization_lock);
-  const uint64_t add_size = 1LL << 30;
+  constexpr uint64_t add_size = 1LL << 30;
   // check disk capacity
   try {
     kth::path path(m_folder);
@@ -118,7 +118,7 @@ void BlockchainLMDB::check_and_resize_for_batch(uint64_t batch_num_blocks, uint6
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   LOG_PRINT_L1("[" << __func__ << "] " << "checking DB size");
-  const uint64_t min_increase_size = 512 * (1 << 20);
+  constexpr uint64_t min_increase_size = 512 * (1 << 20);
   uint64_t threshold_size = 0;
   uint64_t increase_size = 0;
   if (batch_num_blocks > 0)
@@ -379,7 +379,7 @@ void BlockchainLMDB::open(std::string const& filename, int const db_flags)
   if(get_result == KTH_DB_SUCCESS) {
 
     //TODO: check this cast
-    const uint32_t db_version = *(const uint32_t*) kth_db_get_data(v);
+    uint32_t const db_version = *(uint32_t const*) kth_db_get_data(v);
     if (db_version > VERSION) {
       MWARNING("Existing lmdb database was made by a later version (" << db_version << "). We don't know how it will change yet.");
       compatible = false;
@@ -456,7 +456,7 @@ void BlockchainLMDB::close()
   m_open = false;
 }
 
-void BlockchainLMDB::safesyncmode(const bool onoff)
+void BlockchainLMDB::safesyncmode(bool const onoff)
 {
   MINFO("switching safe mode " << (onoff ? "on" : "off"));
   mdb_env_set_flags(m_env, KTH_DB_NOSYNC|KTH_DB_MAPASYNC, !onoff);

--- a/src/database/test/hash_table.cpp
+++ b/src/database/test/hash_table.cpp
@@ -63,7 +63,7 @@ void create_database_file() {
     REQUIRE(header.create());
     REQUIRE(header.start());
 
-    const file_offset slab_start = header_size;
+    file_offset const slab_start = header_size;
 
     slab_manager alloc(file, slab_start);
     REQUIRE(alloc.create());

--- a/src/database/test/history_database.cpp
+++ b/src/database/test/history_database.cpp
@@ -34,42 +34,42 @@ BOOST_FIXTURE_TEST_SUITE(database_tests, history_database_directory_setup_fixtur
 #ifdef KTH_DB_HISTORY
 TEST_CASE("history database  test", "[None]")
 {
-    const short_hash key1 = "a006500b7ddfd568e2b036c65a4f4d6aaa0cbd9b"_base16;
+    short_hash const key1 = "a006500b7ddfd568e2b036c65a4f4d6aaa0cbd9b"_base16;
     output_point out11{ "4129e76f363f9742bc98dd3d40c99c9066e4d53b8e10e5097bd6f7b5059d7c53"_hash, 110 };
-    size_t const out_h11 = 110;
-    const uint64_t value11 = 4;
+    constexpr size_t out_h11 = 110;
+    constexpr uint64_t value11 = 4;
     output_point out12{ "eefa5d23968584be9d8d064bcf99c24666e4d53b8e10e5097bd6f7b5059d7c53"_hash, 4 };
-    size_t const out_h12 = 120;
-    const uint64_t value12 = 8;
+    constexpr size_t out_h12 = 120;
+    constexpr uint64_t value12 = 8;
     output_point out13{ "4129e76f363f9742bc98dd3d40c99c90eefa5d23968584be9d8d064bcf99c246"_hash, 8 };
-    size_t const out_h13 = 222;
-    const uint64_t value13 = 6;
+    constexpr size_t out_h13 = 222;
+    constexpr uint64_t value13 = 6;
 
     input_point spend11{ "4742b3eac32d35961f9da9d42d495ff1d90aba96944cac3e715047256f7016d1"_hash, 0 };
-    size_t const spend_h11 = 115;
+    constexpr size_t spend_h11 = 115;
     input_point spend13{ "3cc768bbaef30587c72c6eba8dbf6aeec4ef24172ae6fe357f2e24c2b0fa44d5"_hash, 0 };
-    size_t const spend_h13 = 320;
+    constexpr size_t spend_h13 = 320;
 
-    const short_hash key2 = "9c6b3bdaa612ceab88d49d4431ed58f26e69b90d"_base16;
+    short_hash const key2 = "9c6b3bdaa612ceab88d49d4431ed58f26e69b90d"_base16;
     output_point out21{ "80d9e7012b5b171bf78e75b52d2d149580d9e7012b5b171bf78e75b52d2d1495"_hash, 9 };
-    size_t const out_h21 = 3982;
-    const uint64_t value21 = 65;
+    constexpr size_t out_h21 = 3982;
+    constexpr uint64_t value21 = 65;
     output_point out22{ "4742b3eac32d35961f9da9d42d495ff13cc768bbaef30587c72c6eba8dbf6aee"_hash, 0 };
-    size_t const out_h22 = 78;
-    const uint64_t value22 = 9;
+    constexpr size_t out_h22 = 78;
+    constexpr uint64_t value22 = 9;
 
     input_point spend22{ "3cc768bbaef30587c72c6eba8dbfffffc4ef24172ae6fe357f2e24c2b0fa44d5"_hash, 0 };
-    size_t const spend_h22 = 900;
+    constexpr size_t spend_h22 = 900;
 
-    const short_hash key3 = "3eb84f6a98478e516325b70fecf9903e1ce7528b"_base16;
+    short_hash const key3 = "3eb84f6a98478e516325b70fecf9903e1ce7528b"_base16;
     output_point out31{ "d90aba96944cac3e715047256f7016d1d90aba96944cac3e715047256f7016d1"_hash, 0 };
-    size_t const out_h31 = 378;
-    const uint64_t value31 = 34;
+    constexpr size_t out_h31 = 378;
+    constexpr uint64_t value31 = 34;
 
-    const short_hash key4 = "d60db39ca8ce4caf0f7d2b7d3111535d9543473f"_base16;
+    short_hash const key4 = "d60db39ca8ce4caf0f7d2b7d3111535d9543473f"_base16;
     ////output_point out42{ "aaaaaaaaaaacac3e715047256f7016d1d90aaa96944cac3e715047256f7016d1"_hash, 0};
-    size_t const out_h41 = 74448;
-    const uint64_t value41 = 990;
+    constexpr size_t out_h41 = 74448;
+    constexpr uint64_t value41 = 990;
 
     store::create(DIRECTORY "/lookup");
     store::create(DIRECTORY "/rows");

--- a/src/database/test/unspent_outputs.cpp
+++ b/src/database/test/unspent_outputs.cpp
@@ -14,27 +14,27 @@ using namespace kth::database;
 BOOST_AUTO_TEST_SUITE(unspent_outputs_tests)
 
 BOOST_AUTO_TEST_CASE(unspent_outputs__construct__capacity_0__disabled) {
-    const unspent_outputs cache(0);
+    unspent_outputs const cache(0);
     BOOST_REQUIRE(cache.disabled());
 }
 
 BOOST_AUTO_TEST_CASE(unspent_outputs__construct__capacity_42__not_disabled) {
-    const unspent_outputs cache(42);
+    unspent_outputs const cache(42);
     BOOST_REQUIRE( ! cache.disabled());
 }
 
 BOOST_AUTO_TEST_CASE(unspent_outputs__construct__capacity_0__size_0) {
-    const unspent_outputs cache(0);
+    unspent_outputs const cache(0);
     BOOST_REQUIRE_EQUAL(cache.size(), 0u);
 }
 
 BOOST_AUTO_TEST_CASE(unspent_outputs__construct__capacity_42__empty) {
-    const unspent_outputs cache(42);
+    unspent_outputs const cache(42);
     BOOST_REQUIRE(cache.empty());
 }
 
 BOOST_AUTO_TEST_CASE(unspent_outputs__hit_rate__default__1) {
-    const unspent_outputs cache(0);
+    unspent_outputs const cache(0);
     BOOST_REQUIRE_EQUAL(cache.hit_rate(), 1.0f);
 }
 

--- a/src/database/test/unspent_transaction.cpp
+++ b/src/database/test/unspent_transaction.cpp
@@ -18,7 +18,7 @@ BOOST_AUTO_TEST_CASE(unspent_transaction__move__coinbase_tx_hash_height__expecte
     static const transaction tx{ 0, 0, { { { null_hash, point::null_index }, {}, 0 } }, {} };
     static auto const expected_height = 42u;
     unspent_transaction instance(tx, expected_height, 0, false);
-    const unspent_transaction moved(std::move(instance));
+    unspent_transaction const moved(std::move(instance));
     BOOST_REQUIRE(moved.hash() == tx.hash());
     BOOST_REQUIRE_EQUAL(moved.height(), expected_height);
     BOOST_REQUIRE_EQUAL(moved.is_coinbase(), true);
@@ -27,8 +27,8 @@ BOOST_AUTO_TEST_CASE(unspent_transaction__move__coinbase_tx_hash_height__expecte
 BOOST_AUTO_TEST_CASE(unspent_transaction__copy__coinbase_tx_hash_height__expected) {
     static const transaction tx{ 0, 0, { { { null_hash, point::null_index }, {}, 0 } }, {} };
     static auto const expected_height = 42u;
-    const unspent_transaction instance(tx, expected_height, 0, false);
-    const unspent_transaction copied(instance);
+    unspent_transaction const instance(tx, expected_height, 0, false);
+    unspent_transaction const copied(instance);
     BOOST_REQUIRE(copied.hash() == tx.hash());
     BOOST_REQUIRE_EQUAL(copied.height(), expected_height);
     BOOST_REQUIRE_EQUAL(copied.is_coinbase(), true);
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(unspent_transaction__outputs__construct1__tx_hash__empty) {
 
 BOOST_AUTO_TEST_CASE(unspent_transaction__outputs__construct2__empty) {
     static const transaction tx;
-    const output_point point{ tx.hash(), 42 };
+    output_point const point{ tx.hash(), 42 };
     BOOST_REQUIRE(unspent_transaction(point).outputs()->empty());
 }
 
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(unspent_transaction__move_assign__coinbase_tx_hash_height__
     static const transaction tx{ 0, 0, { { { null_hash, point::null_index }, {}, 0 } }, {} };
     static auto const expected_height = 42u;
     unspent_transaction instance(tx, expected_height, 0, false);
-    const unspent_transaction moved = std::move(instance);
+    unspent_transaction const moved = std::move(instance);
     BOOST_REQUIRE(moved.hash() == tx.hash());
     BOOST_REQUIRE_EQUAL(moved.height(), expected_height);
     BOOST_REQUIRE_EQUAL(moved.is_coinbase(), true);
@@ -96,8 +96,8 @@ BOOST_AUTO_TEST_CASE(unspent_transaction__move_assign__coinbase_tx_hash_height__
 BOOST_AUTO_TEST_CASE(unspent_transaction__copy_assign__coinbase_tx_hash_height__expected) {
     static const transaction tx{ 0, 0, { { { null_hash, point::null_index }, {}, 0 } }, {} };
     static auto const expected_height = 42u;
-    const unspent_transaction instance(tx, expected_height, 0, false);
-    const unspent_transaction copied = instance;
+    unspent_transaction const instance(tx, expected_height, 0, false);
+    unspent_transaction const copied = instance;
     BOOST_REQUIRE(copied.hash() == tx.hash());
     BOOST_REQUIRE_EQUAL(copied.height(), expected_height);
     BOOST_REQUIRE_EQUAL(copied.is_coinbase(), true);

--- a/src/database/tools/initchain/initchain.cpp
+++ b/src/database/tools/initchain/initchain.cpp
@@ -35,7 +35,7 @@ int main(int argc, char** argv) {
     }
 
     // This creates default configuration database only!
-    const settings configuration;
+    settings const configuration;
 
     if ( ! data_base(configuration).create(block::genesis_mainnet())) {
         std::println(stderr, "Failed to initialize database files.");

--- a/src/domain/include/kth/domain/chain/transaction.hpp
+++ b/src/domain/include/kth/domain/chain/transaction.hpp
@@ -124,9 +124,9 @@ public:
 
     void set_version(uint32_t value);
     void set_locktime(uint32_t value);
-    void set_inputs(const ins& value);
+    void set_inputs(ins const& value);
     void set_inputs(ins&& value);
-    void set_outputs(const outs& value);
+    void set_outputs(outs const& value);
     void set_outputs(outs&& value);
 
     hash_digest outputs_hash() const;

--- a/src/domain/include/kth/domain/chain/transaction_basis.hpp
+++ b/src/domain/include/kth/domain/chain/transaction_basis.hpp
@@ -64,7 +64,7 @@ namespace detail {
 
 // Write a length-prefixed collection of inputs or outputs to the sink.
 template <class Sink, class Put>
-void write(Sink& sink, const std::vector<Put>& puts, bool wire) {
+void write(Sink& sink, std::vector<Put> const& puts, bool wire) {
     sink.write_variable_little_endian(puts.size());
 
     auto const serialize = [&](const Put& put) {
@@ -175,18 +175,18 @@ struct KD_API transaction_basis {
     ins& inputs();
 
     [[nodiscard]]
-    const ins& inputs() const;
+    ins const& inputs() const;
 
-    void set_inputs(const ins& value);
+    void set_inputs(ins const& value);
     void set_inputs(ins&& value);
 
     // [[deprecated]] // unsafe
     outs& outputs();
 
     [[nodiscard]]
-    const outs& outputs() const;
+    outs const& outputs() const;
 
-    void set_outputs(const outs& value);
+    void set_outputs(outs const& value);
     void set_outputs(outs&& value);
 
     // Validation.

--- a/src/domain/include/kth/domain/config/endorsement.hpp
+++ b/src/domain/include/kth/domain/config/endorsement.hpp
@@ -76,7 +76,7 @@ struct KD_API endorsement {
      * @return                The output stream reference.
      */
     friend std::ostream& operator<<(std::ostream& output,
-                                    const endorsement& argument);
+                                    endorsement const& argument);
 
 private:
     /**

--- a/src/domain/include/kth/domain/config/script.hpp
+++ b/src/domain/include/kth/domain/config/script.hpp
@@ -43,7 +43,7 @@ struct KD_API script {
      * Initialization constructor.
      * @param[in]  tokens  The mnemonic tokens to initialize with.
      */
-    script(const std::vector<std::string>& tokens);
+    script(std::vector<std::string> const& tokens);
 
     /**
      * Copy constructor.

--- a/src/domain/include/kth/domain/machine/program.hpp
+++ b/src/domain/include/kth/domain/machine/program.hpp
@@ -64,7 +64,7 @@ struct KD_API program {
     );
 
     /// Create using copied tx, input, forks, value, stack (prevout run).
-    program(chain::script const& script, const program& x);
+    program(chain::script const& script, program const& x);
 
     /// Create using copied tx, input, forks, value and moved stack (p2sh run).
     program(chain::script const& script, program&& x, bool move);

--- a/src/domain/include/kth/domain/message/alert_payload.hpp
+++ b/src/domain/include/kth/domain/message/alert_payload.hpp
@@ -23,7 +23,7 @@ namespace kth::domain::message {
 
 struct KD_API alert_payload {
     alert_payload() = default;
-    alert_payload(uint32_t version, uint64_t relay_until, uint64_t expiration, uint32_t id, uint32_t cancel, const std::vector<uint32_t>& set_cancel, uint32_t min_version, uint32_t max_version, const std::vector<std::string>& set_sub_version, uint32_t priority, std::string const& comment, std::string const& status_bar, std::string const& reserved);
+    alert_payload(uint32_t version, uint64_t relay_until, uint64_t expiration, uint32_t id, uint32_t cancel, std::vector<uint32_t> const& set_cancel, uint32_t min_version, uint32_t max_version, std::vector<std::string> const& set_sub_version, uint32_t priority, std::string const& comment, std::string const& status_bar, std::string const& reserved);
     alert_payload(uint32_t version, uint64_t relay_until, uint64_t expiration, uint32_t id, uint32_t cancel, std::vector<uint32_t>&& set_cancel, uint32_t min_version, uint32_t max_version, std::vector<std::string>&& set_sub_version, uint32_t priority, std::string&& comment, std::string&& status_bar, std::string&& reserved);
 
     bool operator==(alert_payload const& x) const;
@@ -57,9 +57,9 @@ struct KD_API alert_payload {
     std::vector<uint32_t>& set_cancel();
 
     [[nodiscard]]
-    const std::vector<uint32_t>& set_cancel() const;
+    std::vector<uint32_t> const& set_cancel() const;
 
-    void set_set_cancel(const std::vector<uint32_t>& value);
+    void set_set_cancel(std::vector<uint32_t> const& value);
     void set_set_cancel(std::vector<uint32_t>&& value);
 
     [[nodiscard]]
@@ -75,9 +75,9 @@ struct KD_API alert_payload {
     std::vector<std::string>& set_sub_version();
 
     [[nodiscard]]
-    const std::vector<std::string>& set_sub_version() const;
+    std::vector<std::string> const& set_sub_version() const;
 
-    void set_set_sub_version(const std::vector<std::string>& value);
+    void set_set_sub_version(std::vector<std::string> const& value);
     void set_set_sub_version(std::vector<std::string>&& value);
 
     [[nodiscard]]
@@ -226,7 +226,7 @@ struct KD_API alert_payload {
 
 
     static
-    const ec_uncompressed satoshi_public_key;
+    ec_uncompressed const satoshi_public_key;
 
 private:
     uint32_t version_{0};

--- a/src/domain/include/kth/domain/message/get_block_transactions.hpp
+++ b/src/domain/include/kth/domain/message/get_block_transactions.hpp
@@ -28,7 +28,7 @@ struct KD_API get_block_transactions {
     using const_ptr = std::shared_ptr<const get_block_transactions>;
 
     get_block_transactions();
-    get_block_transactions(hash_digest const& block_hash, const std::vector<uint64_t>& indexes);
+    get_block_transactions(hash_digest const& block_hash, std::vector<uint64_t> const& indexes);
     get_block_transactions(hash_digest const& block_hash, std::vector<uint64_t>&& indexes);
 
     bool operator==(get_block_transactions const& x) const;
@@ -44,9 +44,9 @@ struct KD_API get_block_transactions {
     std::vector<uint64_t>& indexes();
 
     [[nodiscard]]
-    const std::vector<uint64_t>& indexes() const;
+    std::vector<uint64_t> const& indexes() const;
 
-    void set_indexes(const std::vector<uint64_t>& values);
+    void set_indexes(std::vector<uint64_t> const& values);
     void set_indexes(std::vector<uint64_t>&& values);
 
     static

--- a/src/domain/include/kth/domain/utility/property_tree.hpp
+++ b/src/domain/include/kth/domain/utility/property_tree.hpp
@@ -93,7 +93,7 @@ KD_API pt::ptree property_tree(const config::input& input);
  * @param[in]  json    Use json array formatting.
  * @return             A property tree.
  */
-KD_API pt::ptree property_tree(const std::vector<config::input>& inputs,
+KD_API pt::ptree property_tree(std::vector<config::input> const& inputs,
                                bool json);
 
 /**
@@ -156,7 +156,7 @@ KD_API pt::ptree property_tree(config::transaction const& transaction, bool json
  * @param[in]  json          Use json array formatting.
  * @return                   A property tree.
  */
-KD_API pt::ptree property_tree(const std::vector<config::transaction>& transactions,
+KD_API pt::ptree property_tree(std::vector<config::transaction> const& transactions,
                                bool json);
 
 /**
@@ -196,7 +196,7 @@ KD_API pt::ptree property_tree(hash_digest const& hash, size_t height, size_t in
  * @param[in]  settings   The list of settings.
  * @returns               A new property tree containing the settings.
  */
-KD_API pt::ptree property_tree(const settings_list& settings);
+KD_API pt::ptree property_tree(settings_list const& settings);
 
 } // namespace kth::domain
 

--- a/src/domain/include/kth/domain/wallet/ec_private.hpp
+++ b/src/domain/include/kth/domain/wallet/ec_private.hpp
@@ -84,7 +84,7 @@ struct KD_API ec_private {
     ec_private(wif_compressed const& wif, uint8_t version = mainnet_p2kh);
     
     explicit
-    ec_private(const wif_uncompressed& wif, uint8_t version = mainnet_p2kh);
+    ec_private(wif_uncompressed const& wif, uint8_t version = mainnet_p2kh);
 
     /// The version is 16 bits. The most significant byte is the WIF prefix and
     /// the least significant byte is the address perfix. 0x8000 by default.
@@ -146,7 +146,7 @@ private:
     ec_private from_compressed(wif_compressed const& wif, uint8_t address_version);
 
     static
-    ec_private from_uncompressed(const wif_uncompressed& wif, uint8_t address_version);
+    ec_private from_uncompressed(wif_uncompressed const& wif, uint8_t address_version);
 
     /// Members.
     /// These should be const, apart from the need to implement assignment.

--- a/src/domain/include/kth/domain/wallet/encrypted_keys.hpp
+++ b/src/domain/include/kth/domain/wallet/encrypted_keys.hpp
@@ -112,7 +112,7 @@ enum ek_flag : uint8_t {
 KD_API bool create_key_pair(encrypted_private& out_private,
                             ec_compressed& out_point,
                             encrypted_token const& token,
-                            const ek_seed& seed,
+                            ek_seed const& seed,
                             uint8_t version,
                             bool compressed = true);
 
@@ -134,7 +134,7 @@ KD_API bool create_key_pair(encrypted_private& out_private,
                             encrypted_public& out_public,
                             ec_compressed& out_point,
                             encrypted_token const& token,
-                            const ek_seed& seed,
+                            ek_seed const& seed,
                             uint8_t version,
                             bool compressed = true);
 
@@ -149,7 +149,7 @@ KD_API bool create_key_pair(encrypted_private& out_private,
  */
 KD_API bool create_token(encrypted_token& out_token,
                          std::string const& passphrase,
-                         const ek_entropy& entropy);
+                         ek_entropy const& entropy);
 
 /**
  * Create an intermediate passphrase for subsequent key pair generation.
@@ -163,7 +163,7 @@ KD_API bool create_token(encrypted_token& out_token,
  */
 KD_API bool create_token(encrypted_token& out_token,
                          std::string const& passphrase,
-                         const ek_salt& salt,
+                         ek_salt const& salt,
                          uint32_t lot,
                          uint32_t sequence);
 

--- a/src/domain/include/kth/domain/wallet/message.hpp
+++ b/src/domain/include/kth/domain/wallet/message.hpp
@@ -62,7 +62,7 @@ KD_API bool sign_message(message_signature& out_signature, byte_span message, ec
  * @return false if the signature does not match the address or if there are
  * any errors in the signature encoding.
  */
-KD_API bool verify_message(byte_span message, payment_address const& address, const message_signature& signature);
+KD_API bool verify_message(byte_span message, payment_address const& address, message_signature const& signature);
 
 /// Exposed primarily for independent testability.
 KD_API bool recovery_id_to_magic(uint8_t& out_magic, uint8_t recovery_id, bool compressed);

--- a/src/domain/src/chain/block.cpp
+++ b/src/domain/src/chain/block.cpp
@@ -332,8 +332,8 @@ chain::block block::genesis_chipnet() {
 // With a 32 bit chain the size of the result should not exceed 43 and with a
 // 64 bit chain should not exceed 75, using a limit of: 10 + log2(height) + 1.
 size_t block::locator_size(size_t top) {
-    const auto first_ten_or_top = std::min(size_t{10}, top);
-    const auto remaining = top - first_ten_or_top;
+    auto const first_ten_or_top = std::min(size_t{10}, top);
+    auto const remaining = top - first_ten_or_top;
 
     // Set log2(0) -> 0, log2(1) -> 1 and round up higher exponential backoff
     // results to next whole number by adding 0.5 and truncating.

--- a/src/domain/src/config/endorsement.cpp
+++ b/src/domain/src/config/endorsement.cpp
@@ -43,7 +43,7 @@ endorsement::endorsement(data_chunk const& value)
     : value_(value) {
 }
 
-endorsement::endorsement(const endorsement& x)
+endorsement::endorsement(endorsement const& x)
     : endorsement(x.value_) {
 }
 
@@ -66,7 +66,7 @@ std::istream& operator>>(std::istream& input, endorsement& argument) {
     return input;
 }
 
-std::ostream& operator<<(std::ostream& output, const endorsement& argument) {
+std::ostream& operator<<(std::ostream& output, endorsement const& argument) {
     output << encode_endorsement(argument.value_);
     return output;
 }

--- a/src/domain/src/config/script.cpp
+++ b/src/domain/src/config/script.cpp
@@ -40,7 +40,7 @@ script::script(data_chunk const& value) {
     value_ = std::move(*script_exp);
 }
 
-script::script(const std::vector<std::string>& tokens) {
+script::script(std::vector<std::string> const& tokens) {
     auto const mnemonic = join(tokens);
     std::stringstream(mnemonic) >> *this;
 }

--- a/src/domain/src/machine/program.cpp
+++ b/src/domain/src/machine/program.cpp
@@ -92,7 +92,7 @@ program::program(
 }
 
 // Condition, alternate, jump and operation_count are not copied.
-program::program(script const& script, const program& x)
+program::program(script const& script, program const& x)
     : script_(script),
       transaction_(x.transaction_),
       input_index_(x.input_index_),

--- a/src/domain/src/message/alert_payload.cpp
+++ b/src/domain/src/message/alert_payload.cpp
@@ -27,10 +27,10 @@ alert_payload::alert_payload(
     uint64_t expiration,
     uint32_t id,
     uint32_t cancel,
-    const std::vector<uint32_t>& set_cancel,
+    std::vector<uint32_t> const& set_cancel,
     uint32_t min_version,
     uint32_t max_version,
-    const std::vector<std::string>& set_sub_version,
+    std::vector<std::string> const& set_sub_version,
     uint32_t priority,
     std::string const& comment,
     std::string const& status_bar,
@@ -238,11 +238,11 @@ std::vector<uint32_t>& alert_payload::set_cancel() {
     return set_cancel_;
 }
 
-const std::vector<uint32_t>& alert_payload::set_cancel() const {
+std::vector<uint32_t> const& alert_payload::set_cancel() const {
     return set_cancel_;
 }
 
-void alert_payload::set_set_cancel(const std::vector<uint32_t>& value) {
+void alert_payload::set_set_cancel(std::vector<uint32_t> const& value) {
     set_cancel_ = value;
 }
 
@@ -270,11 +270,11 @@ std::vector<std::string>& alert_payload::set_sub_version() {
     return set_sub_version_;
 }
 
-const std::vector<std::string>& alert_payload::set_sub_version() const {
+std::vector<std::string> const& alert_payload::set_sub_version() const {
     return set_sub_version_;
 }
 
-void alert_payload::set_set_sub_version(const std::vector<std::string>& value) {
+void alert_payload::set_set_sub_version(std::vector<std::string> const& value) {
     set_sub_version_ = value;
 }
 

--- a/src/domain/src/message/get_block_transactions.cpp
+++ b/src/domain/src/message/get_block_transactions.cpp
@@ -23,7 +23,7 @@ get_block_transactions::get_block_transactions()
     : block_hash_(null_hash)
 {}
 
-get_block_transactions::get_block_transactions(hash_digest const& block_hash, const std::vector<uint64_t>& indexes)
+get_block_transactions::get_block_transactions(hash_digest const& block_hash, std::vector<uint64_t> const& indexes)
     : block_hash_(block_hash)
     , indexes_(indexes)
 {}
@@ -125,11 +125,11 @@ std::vector<uint64_t>& get_block_transactions::indexes() {
     return indexes_;
 }
 
-const std::vector<uint64_t>& get_block_transactions::indexes() const {
+std::vector<uint64_t> const& get_block_transactions::indexes() const {
     return indexes_;
 }
 
-void get_block_transactions::set_indexes(const std::vector<uint64_t>& values) {
+void get_block_transactions::set_indexes(std::vector<uint64_t> const& values) {
     indexes_ = values;
 }
 

--- a/src/domain/src/utility/property_tree.cpp
+++ b/src/domain/src/utility/property_tree.cpp
@@ -111,7 +111,7 @@ ptree property_tree(const config::input& input) {
     return tree;
 }
 
-ptree property_tree(const std::vector<config::input>& inputs, bool json) {
+ptree property_tree(std::vector<config::input> const& inputs, bool json) {
     auto const tx_inputs = cast<input, chain::input>(inputs);
 
     ptree tree;
@@ -200,7 +200,7 @@ ptree property_tree(const config::transaction& transaction, bool json) {
     return tree;
 }
 
-ptree property_tree(const std::vector<config::transaction>& transactions, bool json) {
+ptree property_tree(std::vector<config::transaction> const& transactions, bool json) {
     ptree tree;
     tree.add_child("transactions", property_tree_list_of_lists("transaction",
                                                                transactions, json));
@@ -241,7 +241,7 @@ ptree property_tree(hash_digest const& hash, size_t height, size_t index) {
 
 // settings
 
-ptree property_tree(const settings_list& settings) {
+ptree property_tree(settings_list const& settings) {
     ptree list;
 
     for (auto const& setting : settings) {

--- a/src/domain/src/wallet/ec_private.cpp
+++ b/src/domain/src/wallet/ec_private.cpp
@@ -43,7 +43,7 @@ ec_private::ec_private(wif_compressed const& wif, uint8_t version)
     : ec_private(from_compressed(wif, version))
 {}
 
-ec_private::ec_private(const wif_uncompressed& wif, uint8_t version)
+ec_private::ec_private(wif_uncompressed const& wif, uint8_t version)
     : ec_private(from_uncompressed(wif, version))
 {}
 
@@ -91,7 +91,7 @@ ec_private ec_private::from_compressed(wif_compressed const& wif, uint8_t addres
     return ec_private(secret, version, true);
 }
 
-ec_private ec_private::from_uncompressed(const wif_uncompressed& wif, uint8_t address_version) {
+ec_private ec_private::from_uncompressed(wif_uncompressed const& wif, uint8_t address_version) {
     if ( ! is_wif(wif)) {
         return ec_private();
     }

--- a/src/domain/src/wallet/message.cpp
+++ b/src/domain/src/wallet/message.cpp
@@ -36,7 +36,7 @@ hash_digest hash_message(byte_span message) {
 
 static
 bool recover(short_hash& out_hash, bool compressed, ec_signature const& compact, uint8_t recovery_id, hash_digest const& message_digest) {
-    const recoverable_signature recoverable{
+    recoverable_signature const recoverable{
         compact,
         recovery_id};
 

--- a/src/domain/src/wallet/parse_encrypted_keys/parse_encrypted_key.hpp
+++ b/src/domain/src/wallet/parse_encrypted_keys/parse_encrypted_key.hpp
@@ -20,10 +20,10 @@ template <size_t PrefixSize>
 class parse_encrypted_key
     : public parse_encrypted_prefix<PrefixSize> {
 public:
-    parse_encrypted_key(const byte_array<PrefixSize>& prefix,
-                        const one_byte& flags,
-                        const ek_salt& salt,
-                        const ek_entropy& entropy);
+    parse_encrypted_key(byte_array<PrefixSize> const& prefix,
+                        one_byte const& flags,
+                        ek_salt const& salt,
+                        ek_entropy const& entropy);
 
     bool compressed() const;
     bool lot_sequence() const;
@@ -34,9 +34,9 @@ public:
     ek_entropy entropy() const;
 
 private:
-    const one_byte flags_;
-    const ek_salt salt_;
-    const ek_entropy entropy_;
+    one_byte const flags_;
+    ek_salt const salt_;
+    ek_entropy const entropy_;
 };
 
 } // namespace kth::domain::wallet

--- a/src/domain/src/wallet/parse_encrypted_keys/parse_encrypted_key.ipp
+++ b/src/domain/src/wallet/parse_encrypted_keys/parse_encrypted_key.ipp
@@ -17,10 +17,10 @@ namespace kth::domain::wallet {
 
 template <size_t PrefixSize>
 parse_encrypted_key<PrefixSize>::parse_encrypted_key(
-    const byte_array<PrefixSize>& prefix,
-    const one_byte& flags,
-    const ek_salt& salt,
-    const ek_entropy& entropy)
+    byte_array<PrefixSize> const& prefix,
+    one_byte const& flags,
+    ek_salt const& salt,
+    ek_entropy const& entropy)
     : parse_encrypted_prefix<PrefixSize>(prefix),
       flags_(flags),
       salt_(salt),

--- a/src/domain/src/wallet/parse_encrypted_keys/parse_encrypted_prefix.hpp
+++ b/src/domain/src/wallet/parse_encrypted_keys/parse_encrypted_prefix.hpp
@@ -29,7 +29,7 @@ public:
     static constexpr uint8_t prefix_size = Size;
 
 protected:
-    explicit parse_encrypted_prefix(const byte_array<Size>& value);
+    explicit parse_encrypted_prefix(byte_array<Size> const& value);
 
     uint8_t context() const;
     byte_array<Size> prefix() const;

--- a/src/domain/src/wallet/parse_encrypted_keys/parse_encrypted_prefix.ipp
+++ b/src/domain/src/wallet/parse_encrypted_keys/parse_encrypted_prefix.ipp
@@ -15,7 +15,7 @@ namespace kth::domain::wallet {
 
 template <size_t Size>
 parse_encrypted_prefix<Size>::parse_encrypted_prefix(
-    const byte_array<Size>& value)
+    byte_array<Size> const& value)
     : prefix_(value), valid_(false) {
 }
 

--- a/src/domain/src/wallet/parse_encrypted_keys/parse_encrypted_private.hpp
+++ b/src/domain/src/wallet/parse_encrypted_keys/parse_encrypted_private.hpp
@@ -41,8 +41,8 @@ private:
     static
     const byte_array<magic_size> magic_;
 
-    const quarter_hash data1_;
-    const half_hash data2_;
+    quarter_hash const data1_;
+    half_hash const data2_;
 };
 
 } // namespace kth::domain::wallet

--- a/src/domain/src/wallet/parse_encrypted_keys/parse_encrypted_public.hpp
+++ b/src/domain/src/wallet/parse_encrypted_keys/parse_encrypted_public.hpp
@@ -38,7 +38,7 @@ private:
     static
     const byte_array<magic_size> magic_;
 
-    const one_byte sign_;
+    one_byte const sign_;
     hash_digest const data_;
 };
 

--- a/src/domain/src/wallet/parse_encrypted_keys/parse_encrypted_token.hpp
+++ b/src/domain/src/wallet/parse_encrypted_keys/parse_encrypted_token.hpp
@@ -43,8 +43,8 @@ private:
     static
     const byte_array<magic_size> magic_;
 
-    const ek_entropy entropy_;
-    const one_byte sign_;
+    ek_entropy const entropy_;
+    one_byte const sign_;
     hash_digest const data_;
 };
 

--- a/src/domain/src/wallet/select_outputs.cpp
+++ b/src/domain/src/wallet/select_outputs.cpp
@@ -15,7 +15,7 @@ namespace kth::domain::wallet {
 
 using namespace kth::domain::chain;
 
-void select_outputs::greedy(points_value& out, const points_value& unspent, uint64_t minimum_value) {
+void select_outputs::greedy(points_value& out, points_value const& unspent, uint64_t minimum_value) {
     out.points.clear();
 
     // The minimum required value does not exist.
@@ -71,7 +71,7 @@ void select_outputs::greedy(points_value& out, const points_value& unspent, uint
     KTH_ASSERT_MSG(false, "unreachable code reached");
 }
 
-void select_outputs::individual(points_value& out, const points_value& unspent, uint64_t minimum_value) {
+void select_outputs::individual(points_value& out, points_value const& unspent, uint64_t minimum_value) {
     out.points.clear();
     out.points.reserve(unspent.points.size());
 
@@ -91,7 +91,7 @@ void select_outputs::individual(points_value& out, const points_value& unspent, 
     std::sort(out.points.begin(), out.points.end(), lesser);
 }
 
-void select_outputs::select(points_value& out, const points_value& unspent, uint64_t minimum_value, algorithm option) {
+void select_outputs::select(points_value& out, points_value const& unspent, uint64_t minimum_value, algorithm option) {
     switch (option) {
         case algorithm::individual: {
             individual(out, unspent, minimum_value);

--- a/src/domain/src/wallet/stealth_address.cpp
+++ b/src/domain/src/wallet/stealth_address.cpp
@@ -157,7 +157,7 @@ stealth_address stealth_address::from_stealth(data_chunk const& decoded) {
 
     // Deserialize the filter bytes/blocks.
     data_chunk const raw_filter(iterator, iterator + filter_bytes);
-    const binary filter(filter_bits, raw_filter);
+    binary const filter(filter_bits, raw_filter);
     return {filter, scan_key, spend_keys, signatures, version};
 }
 

--- a/src/domain/test/aserti3-2d/genenerate_test_vectors.cpp
+++ b/src/domain/test/aserti3-2d/genenerate_test_vectors.cpp
@@ -92,19 +92,19 @@ int64_t time_incr_by_random_ramp_down(uint64_t iteration) {
     return int64_t(dist(trng)) * (1 + int64_t(iteration / 10));
 }
 
-void print_run_iteration(const uint64_t iteration,
-                         const uint64_t height,
-                         const uint64_t time,
-                         const uint32_t target_nbits) {
+void print_run_iteration(uint64_t const iteration,
+                         uint64_t const height,
+                         uint64_t const time,
+                         uint32_t const target_nbits) {
     std::printf("%" PRIu64 " %" PRIu64 " %" PRIu64 " 0x%08x\n", iteration, height, time, target_nbits);
 }
 
 // Perform one parameterized run to produce ASERT test vectors.
 void perform_run(const run_params& r_params, const Consensus::Params& chainparams) {
     assert(r_params.start_height >= r_params.anchor_height);
-    const arith_uint256 powLimit = UintToArith256(chainparams.powLimit);
-    const arith_uint256 refTarget = arith_uint256().SetCompact(r_params.anchor_nbits);
-    const uint32_t check_nbits = refTarget.GetCompact();
+    arith_uint256 const powLimit = UintToArith256(chainparams.powLimit);
+    arith_uint256 const refTarget = arith_uint256().SetCompact(r_params.anchor_nbits);
+    uint32_t const check_nbits = refTarget.GetCompact();
     assert(check_nbits == r_params.anchor_nbits);
 
     // Print run header info
@@ -150,7 +150,7 @@ void perform_run(const run_params& r_params, const Consensus::Params& chainparam
 void produce_asert_test_vectors() {
     DummyConfig config(CBaseChainParams::MAIN);
     const Consensus::Params &chainparams = config.GetChainParams().GetConsensus();
-    const arith_uint256 powLimit = UintToArith256(chainparams.powLimit);
+    arith_uint256 const powLimit = UintToArith256(chainparams.powLimit);
     uint32_t powLimit_nBits = powLimit.GetCompact();
 
     // Table of runs used to produce the test vectors.

--- a/src/domain/test/math/stealth.cpp
+++ b/src/domain/test/math/stealth.cpp
@@ -107,26 +107,26 @@ TEST_CASE("bitfield test1", "[stealth]") {
 
 TEST_CASE("bitfield test2", "[stealth]") {
     data_chunk const blocks{{0x8b, 0xf4, 0x1c, 0x69}};
-    const binary prefix(27, blocks);
+    binary const prefix(27, blocks);
     data_chunk const raw_bitfield{{0x8b, 0xf4, 0x1c, 0x79}};
     REQUIRE(raw_bitfield.size() * 8 >= prefix.size());
-    const binary compare(prefix.size(), raw_bitfield);
+    binary const compare(prefix.size(), raw_bitfield);
     REQUIRE(prefix == compare);
 }
 
 TEST_CASE("bitfield test3", "[stealth]") {
     data_chunk const blocks{{0x69, 0x1c, 0xf4, 0x8b}};
-    const binary prefix(32, blocks);
+    binary const prefix(32, blocks);
     data_chunk const raw_bitfield{{0x69, 0x1c, 0xf4, 0x8b}};
-    const binary compare(prefix.size(), raw_bitfield);
+    binary const compare(prefix.size(), raw_bitfield);
     REQUIRE(prefix == compare);
 }
 
 TEST_CASE("bitfield test4", "[stealth]") {
     data_chunk const blocks{{0x69, 0x1c, 0xf4, 0x8b}};
-    const binary prefix(29, blocks);
+    binary const prefix(29, blocks);
     data_chunk const raw_bitfield{{0x69, 0x1c, 0xf4, 0x8b}};
-    const binary compare(prefix.size(), raw_bitfield);
+    binary const compare(prefix.size(), raw_bitfield);
     REQUIRE(prefix == compare);
 }
 

--- a/src/domain/test/message/fee_filter.cpp
+++ b/src/domain/test/message/fee_filter.cpp
@@ -11,21 +11,21 @@ using namespace kth::domain::message;
 // Start Test Suite: fee filter tests
 
 TEST_CASE("fee filter  constructor 1  always invalid", "[fee filter]") {
-    const fee_filter instance;
+    fee_filter const instance;
     REQUIRE( ! instance.is_valid());
 }
 
 TEST_CASE("fee filter  constructor 2  always  equals params", "[fee filter]") {
     uint64_t const value = 6434u;
-    const fee_filter instance(value);
+    fee_filter const instance(value);
     REQUIRE(instance.is_valid());
     REQUIRE(value == instance.minimum_fee());
 }
 
 TEST_CASE("fee filter  constructor 3  always  equals params", "[fee filter]") {
     uint64_t const fee = 6434u;
-    const fee_filter value(fee);
-    const fee_filter instance(value);
+    fee_filter const value(fee);
+    fee_filter const instance(value);
     REQUIRE(instance.is_valid());
     REQUIRE(fee == instance.minimum_fee());
     REQUIRE(value == instance);
@@ -33,8 +33,8 @@ TEST_CASE("fee filter  constructor 3  always  equals params", "[fee filter]") {
 
 TEST_CASE("fee filter  constructor 4  always  equals params", "[fee filter]") {
     uint64_t const fee = 6434u;
-    const fee_filter value(fee);
-    const fee_filter instance(std::move(value));
+    fee_filter const value(fee);
+    fee_filter const instance(std::move(value));
     REQUIRE(instance.is_valid());
     REQUIRE(fee == instance.minimum_fee());
 }
@@ -55,7 +55,7 @@ TEST_CASE("fee filter from data insufficient version failure", "[fee filter]") {
 }
 
 TEST_CASE("fee filter from data roundtrip  success", "[fee filter]") {
-    const fee_filter expected{123};
+    fee_filter const expected{123};
     auto const data = expected.to_data(fee_filter::version_maximum);
     byte_reader reader(data);
     auto const result_exp = fee_filter::from_data(reader, fee_filter::version_maximum);
@@ -90,25 +90,25 @@ TEST_CASE("fee filter  operator assign equals  always  matches equivalent", "[fe
 }
 
 TEST_CASE("fee filter  operator boolean equals  duplicates  returns true", "[fee filter]") {
-    const fee_filter expected(2453u);
+    fee_filter const expected(2453u);
     fee_filter instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("fee filter  operator boolean equals  differs  returns false", "[fee filter]") {
-    const fee_filter expected(2453u);
+    fee_filter const expected(2453u);
     fee_filter instance;
     REQUIRE( ! (instance == expected));
 }
 
 TEST_CASE("fee filter  operator boolean not equals  duplicates  returns false", "[fee filter]") {
-    const fee_filter expected(2453u);
+    fee_filter const expected(2453u);
     fee_filter instance(expected);
     REQUIRE( ! (instance != expected));
 }
 
 TEST_CASE("fee filter  operator boolean not equals  differs  returns true", "[fee filter]") {
-    const fee_filter expected(2453u);
+    fee_filter const expected(2453u);
     fee_filter instance;
     REQUIRE(instance != expected);
 }

--- a/src/domain/test/message/get_data.cpp
+++ b/src/domain/test/message/get_data.cpp
@@ -11,7 +11,7 @@ using namespace kth::domain::message;
 // Start Test Suite: get data tests
 
 TEST_CASE("get data  constructor 1  always invalid", "[get data]") {
-    const get_data instance;
+    get_data const instance;
     REQUIRE( ! instance.is_valid());
 }
 
@@ -25,7 +25,7 @@ TEST_CASE("get data  constructor 2  always  equals params", "[get data]") {
                   0xc3, 0x0d, 0x6f, 0x55, 0x7d, 0x71, 0x12, 0x1a,
                   0x37, 0xc0, 0xb0, 0x32, 0xf0, 0xd6, 0x6e, 0xdf}}}};
 
-    const get_data instance(values);
+    get_data const instance(values);
     REQUIRE(instance.is_valid());
     REQUIRE(values == instance.inventories());
 }
@@ -36,7 +36,7 @@ TEST_CASE("get data  constructor 3  always  equals params", "[get data]") {
     inventory_vector::list const values{
         inventory_vector(type, hash)};
 
-    const get_data instance(std::move(values));
+    get_data const instance(std::move(values));
     REQUIRE(instance.is_valid());
     auto const inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
@@ -49,7 +49,7 @@ TEST_CASE("get data  constructor 4  always  equals params", "[get data]") {
     static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     static hash_list const hashes{hash};
 
-    const get_data instance(hashes, type);
+    get_data const instance(hashes, type);
     REQUIRE(instance.is_valid());
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
@@ -61,7 +61,7 @@ TEST_CASE("get data  constructor 5  always  equals params", "[get data]") {
     static auto const type = inventory_vector::type_id::error;
     static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
-    const get_data instance{{type, hash}};
+    get_data const instance{{type, hash}};
     REQUIRE(instance.is_valid());
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
@@ -73,9 +73,9 @@ TEST_CASE("get data  constructor 6  always  equals params", "[get data]") {
     static auto const type = inventory_vector::type_id::error;
     static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
-    const get_data value{{type, hash}};
+    get_data const value{{type, hash}};
     REQUIRE(value.is_valid());
-    const get_data instance(value);
+    get_data const instance(value);
     auto const inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
     REQUIRE(type == inventories[0].type());
@@ -87,9 +87,9 @@ TEST_CASE("get data  constructor 7  always  equals params", "[get data]") {
     static auto const type = inventory_vector::type_id::error;
     static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
-    const get_data value{{type, hash}};
+    get_data const value{{type, hash}};
     REQUIRE(value.is_valid());
-    const get_data instance(std::move(value));
+    get_data const instance(std::move(value));
     auto const inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
     REQUIRE(type == inventories[0].type());
@@ -153,37 +153,37 @@ TEST_CASE("get data  operator assign equals  always  matches equivalent", "[get 
 
 TEST_CASE("get data  operator boolean equals  duplicates  returns true", "[get data]") {
     static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
-    const get_data expected{
+    get_data const expected{
         inventory_vector(inventory_vector::type_id::error, hash)};
 
-    const get_data instance(expected);
+    get_data const instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("get data  operator boolean equals  differs  returns false", "[get data]") {
     static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
-    const get_data expected{
+    get_data const expected{
         inventory_vector(inventory_vector::type_id::error, hash)};
 
-    const get_data instance;
+    get_data const instance;
     REQUIRE(instance != expected);
 }
 
 TEST_CASE("get data  operator boolean not equals  duplicates  returns false", "[get data]") {
     static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
-    const get_data expected{
+    get_data const expected{
         inventory_vector(inventory_vector::type_id::error, hash)};
 
-    const get_data instance(expected);
+    get_data const instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("get data  operator boolean not equals  differs  returns true", "[get data]") {
     static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
-    const get_data expected{
+    get_data const expected{
         inventory_vector(inventory_vector::type_id::error, hash)};
 
-    const get_data instance;
+    get_data const instance;
     REQUIRE(instance != expected);
 }
 

--- a/src/infrastructure/include/kth/infrastructure/config/hash256.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/hash256.hpp
@@ -48,7 +48,7 @@ public:
      * Override the equality operator.
      * @param[in]  other  The other object with which to compare.
      */
-    [[nodiscard]] bool operator==(const hash256& x) const noexcept;
+    [[nodiscard]] bool operator==(hash256 const& x) const noexcept;
 
     /**
      * Cast to internal type.
@@ -73,7 +73,7 @@ public:
      * @return                The output stream reference.
      */
     friend
-    std::ostream& operator<<(std::ostream& output, const hash256& argument);
+    std::ostream& operator<<(std::ostream& output, hash256 const& argument);
 
 private:
     hash_digest value_{null_hash};

--- a/src/infrastructure/include/kth/infrastructure/impl/machine/number.ipp
+++ b/src/infrastructure/include/kth/infrastructure/impl/machine/number.ipp
@@ -412,7 +412,7 @@ std::expected<number, code> number::safe_mul(number const& x, number const& y) {
 // Minimally encoded
 //-----------------------------------------------------------------------------
 
-// bool ScriptNumEncoding::IsMinimallyEncoded(const std::vector<uint8_t> &vch, size_t maxIntegerSize) {
+// bool ScriptNumEncoding::IsMinimallyEncoded(std::vector<uint8_t> const&vch, size_t maxIntegerSize) {
 //     if (vch.size() > maxIntegerSize) {
 //         return false;
 //     }

--- a/src/infrastructure/include/kth/infrastructure/impl/utility/collection.ipp
+++ b/src/infrastructure/include/kth/infrastructure/impl/utility/collection.ipp
@@ -16,7 +16,7 @@
 namespace kth {
 
 template <typename Source, typename Target>
-std::vector<Target> cast(const std::vector<Source>& source) {
+std::vector<Target> cast(std::vector<Source> const& source) {
     std::vector<Target> target(source.size());
     target.assign(source.begin(), source.end());
     return target;
@@ -31,7 +31,7 @@ std::vector<T>& distinct(std::vector<T>& list) {
 }
 
 template <typename Pair, typename Key>
-int find_pair_position(const std::vector<Pair>& list, const Key& key) {
+int find_pair_position(std::vector<Pair> const& list, const Key& key) {
     auto const predicate = [&](const Pair& pair) {
         return pair.first == key;
     };

--- a/src/infrastructure/include/kth/infrastructure/impl/utility/data.ipp
+++ b/src/infrastructure/include/kth/infrastructure/impl/utility/data.ipp
@@ -67,7 +67,7 @@ void extend_data(Target& bytes, const Extension& x) {
 
 // std::array<> is used in place of byte_array<> to enable Size deduction.
 template <size_t Start, size_t End, size_t Size>
-byte_array<End - Start> slice(const std::array<uint8_t, Size>& bytes) {
+byte_array<End - Start> slice(std::array<uint8_t, Size> const& bytes) {
     static_assert(End <= Size, "Slice end must not exceed array size.");
     byte_array<End - Start> out;
     std::copy(std::begin(bytes) + Start, std::begin(bytes) + End, out.begin());
@@ -75,23 +75,23 @@ byte_array<End - Start> slice(const std::array<uint8_t, Size>& bytes) {
 }
 
 template <size_t Left, size_t Right>
-byte_array<Left + Right> splice(const std::array<uint8_t, Left>& left, const std::array<uint8_t, Right>& right) {
+byte_array<Left + Right> splice(std::array<uint8_t, Left> const& left, std::array<uint8_t, Right> const& right) {
     byte_array<Left + Right> out;
     /* safe to ignore */ build_array<Left + Right>(out, { left, right });
     return out;
 }
 
 template <size_t Left, size_t Middle, size_t Right>
-byte_array<Left + Middle + Right> splice(const std::array<uint8_t, Left>& left,
-    const std::array<uint8_t, Middle>& middle,
-    const std::array<uint8_t, Right>& right) {
+byte_array<Left + Middle + Right> splice(std::array<uint8_t, Left> const& left,
+    std::array<uint8_t, Middle> const& middle,
+    std::array<uint8_t, Right> const& right) {
     byte_array<Left + Middle + Right> out;
     /* safe to ignore */ build_array(out, { left, middle, right });
     return out;
 }
 
 template <size_t Size>
-byte_array_parts<Size / 2> split(const byte_array<Size>& bytes) {
+byte_array_parts<Size / 2> split(byte_array<Size> const& bytes) {
     static_assert(Size != 0, "Split requires a non-zero parameter.");
     static_assert(Size % 2 == 0, "Split requires an even length parameter.");
     static size_t const half = Size / 2;

--- a/src/infrastructure/include/kth/infrastructure/impl/utility/ostream_writer.ipp
+++ b/src/infrastructure/include/kth/infrastructure/impl/utility/ostream_writer.ipp
@@ -11,7 +11,7 @@
 namespace kth {
 
 template <unsigned Size>
-void ostream_writer::write_forward(const byte_array<Size>& value)
+void ostream_writer::write_forward(byte_array<Size> const& value)
 {
     auto const size = value.size();
     if (size > 0) {
@@ -20,7 +20,7 @@ void ostream_writer::write_forward(const byte_array<Size>& value)
 }
 
 template <unsigned Size>
-void ostream_writer::write_reverse(const byte_array<Size>& value)
+void ostream_writer::write_reverse(byte_array<Size> const& value)
 {
     for (unsigned i = 0; i < Size; i++) {
         write_byte(value[Size - (i + 1)]);

--- a/src/infrastructure/include/kth/infrastructure/log/features/metric.hpp
+++ b/src/infrastructure/include/kth/infrastructure/log/features/metric.hpp
@@ -49,7 +49,7 @@ public:
     void metric(const metric_type& value);
 
 protected:
-    const metric_attribute& get_metric_attribute() const;
+    metric_attribute const& get_metric_attribute() const;
 
     template <typename Arguments>
     boost::log::record open_record_unlocked(Arguments const& arguments);

--- a/src/infrastructure/include/kth/infrastructure/math/checksum.hpp
+++ b/src/infrastructure/include/kth/infrastructure/math/checksum.hpp
@@ -26,7 +26,7 @@ static constexpr size_t checksum_size = sizeof(uint32_t);
  * checksum.
  */
 template <size_t Size>
-bool build_checked_array(byte_array<Size>& out, const std::initializer_list<byte_span>& spans);
+bool build_checked_array(byte_array<Size>& out, std::initializer_list<byte_span> const& spans);
 
 /**
  * Appends a four-byte checksum into the end of an array.
@@ -44,7 +44,7 @@ bool insert_checksum(byte_array<Size>& out);
  */
 template <size_t Size>
 bool unwrap(uint8_t& out_version, byte_array<UNWRAP_SIZE(Size)>& out_payload,
-    const std::array<uint8_t, Size>& wrapped);
+    std::array<uint8_t, Size> const& wrapped);
 
 /**
  * Unwrap a wrapped payload and return the checksum.
@@ -57,7 +57,7 @@ bool unwrap(uint8_t& out_version, byte_array<UNWRAP_SIZE(Size)>& out_payload,
 template <size_t Size>
 bool unwrap(uint8_t& out_version,
     byte_array<UNWRAP_SIZE(Size)>& out_payload, uint32_t& out_checksum,
-    const std::array<uint8_t, Size>& wrapped);
+    std::array<uint8_t, Size> const& wrapped);
 
 /**
  * Wrap arbitrary data.
@@ -67,7 +67,7 @@ bool unwrap(uint8_t& out_version,
  */
 template <size_t Size>
 std::array<uint8_t, WRAP_SIZE(Size)> wrap(uint8_t version,
-    const std::array<uint8_t, Size>& payload);
+    std::array<uint8_t, Size> const& payload);
 
 /**
  * Appends a four-byte checksum of a data chunk to itself.

--- a/src/infrastructure/include/kth/infrastructure/utility/data.hpp
+++ b/src/infrastructure/include/kth/infrastructure/utility/data.hpp
@@ -72,25 +72,25 @@ void extend_data(Target& bytes, const Extension& x);
  * Extracty a subarray from start position with length end minus start.
  */
 template <size_t Start, size_t End, size_t Size>
-byte_array<End - Start> slice(const std::array<uint8_t, Size>& bytes);
+byte_array<End - Start> slice(std::array<uint8_t, Size> const& bytes);
 
 /**
  * Break an evenly-sized array array into two equal length parts.
  */
 template <size_t Size>
-byte_array_parts<Size / 2> split(const byte_array<Size>& bytes);
+byte_array_parts<Size / 2> split(byte_array<Size> const& bytes);
 
 /**
  * Concatenate two arrays into a new array.
  */
 template <size_t Left, size_t Right>
-byte_array<Left + Right> splice(const std::array<uint8_t, Left>& left, const std::array<uint8_t, Right>& right);
+byte_array<Left + Right> splice(std::array<uint8_t, Left> const& left, std::array<uint8_t, Right> const& right);
 
 /**
  * Concatenate three arrays into a new array.
  */
 template <size_t Left, size_t Middle, size_t Right>
-byte_array<Left + Middle + Right> splice(const std::array<uint8_t, Left>& left, const std::array<uint8_t, Middle>& middle, const std::array<uint8_t, Right>& right);
+byte_array<Left + Middle + Right> splice(std::array<uint8_t, Left> const& left, std::array<uint8_t, Middle> const& middle, std::array<uint8_t, Right> const& right);
 
 /**
  * Convert a byte span to an array. Underfill is ok.

--- a/src/infrastructure/include/kth/infrastructure/utility/deadline.hpp
+++ b/src/infrastructure/include/kth/infrastructure/utility/deadline.hpp
@@ -35,7 +35,7 @@ class KI_API deadline
 {
 public:
     using ptr = std::shared_ptr<deadline>;
-    using handler = std::function<void (code const &)>;
+    using handler = std::function<void (code const&)>;
 
 
 #if ! defined(__EMSCRIPTEN__)

--- a/src/infrastructure/include/kth/infrastructure/utility/dispatcher.hpp
+++ b/src/infrastructure/include/kth/infrastructure/utility/dispatcher.hpp
@@ -35,7 +35,7 @@ namespace kth {
 /// If the ios service is stopped jobs will not be dispatched.
 class KI_API dispatcher : noncopyable {
 public:
-    using delay_handler = std::function<void (code const &)>;
+    using delay_handler = std::function<void (code const&)>;
 
     dispatcher(threadpool& pool, std::string const& name);
 
@@ -155,7 +155,7 @@ public:
     ////
     /////// Executes the job against each member of a collection concurrently.
     ////template <typename Element, typename Handler, typename... Args>
-    ////void parallel(const std::vector<Element>& collection,
+    ////void parallel(std::vector<Element> const& collection,
     ////    std::string const& name, Handler&& handler, Args... args)
     ////{
     ////    // Failures are suppressed, success always returned to handler.
@@ -168,7 +168,7 @@ public:
     ////
     /////// Disperses the job against each member of a collection without order.
     ////template <typename Element, typename Handler, typename... Args>
-    ////void disperse(const std::vector<Element>& collection,
+    ////void disperse(std::vector<Element> const& collection,
     ////    std::string const& name, Handler&& handler, Args... args)
     ////{
     ////    // Failures are suppressed, success always returned to handler.
@@ -181,7 +181,7 @@ public:
     ////
     /////// Disperses the job against each member of a collection with order.
     ////template <typename Element, typename Handler, typename... Args>
-    ////void serialize(const std::vector<Element>& collection,
+    ////void serialize(std::vector<Element> const& collection,
     ////    std::string const& name, Handler&& handler, Args... args)
     ////{
     ////    // Failures are suppressed, success always returned to handler.
@@ -194,7 +194,7 @@ public:
     ////
     /////// Sequences the job against each member of a collection with order.
     ////template <typename Element, typename Handler, typename... Args>
-    ////void sequential(const std::vector<Element>& collection,
+    ////void sequential(std::vector<Element> const& collection,
     ////    std::string const& name, Handler&& handler, Args... args)
     ////{
     ////    // Failures are suppressed, success always returned to handler.

--- a/src/infrastructure/include/kth/infrastructure/utility/ostream_writer.hpp
+++ b/src/infrastructure/include/kth/infrastructure/utility/ostream_writer.hpp
@@ -24,10 +24,10 @@ public:
     // ostream_writer(data_sink& stream);
 
     template <unsigned Size>
-    void write_forward(const byte_array<Size>& value);
+    void write_forward(byte_array<Size> const& value);
 
     template <unsigned Size>
-    void write_reverse(const byte_array<Size>& value);
+    void write_reverse(byte_array<Size> const& value);
 
     template <typename Integer>
     void write_big_endian(Integer value);

--- a/src/infrastructure/include/kth/infrastructure/utility/string.hpp
+++ b/src/infrastructure/include/kth/infrastructure/utility/string.hpp
@@ -65,7 +65,7 @@ std::string serialize(const Value& value, std::string const& fallback="");
  * @param[in]  delimiter  The delimiter, defaults to " ".
  * @return                The resulting string.
  */
-KI_API std::string join(const string_list& words,
+KI_API std::string join(string_list const& words,
     std::string const& delimiter=" ");
 
 /**

--- a/src/infrastructure/include/kth/infrastructure/utility/synchronizer.hpp
+++ b/src/infrastructure/include/kth/infrastructure/utility/synchronizer.hpp
@@ -139,7 +139,7 @@ private:
     decay_handler handler_;
     std::string const name_;
     size_t const clearance_count_;
-    const synchronizer_terminate terminate_;
+    synchronizer_terminate const terminate_;
 
     // We use pointer to reference the same value/mutex across instance copies.
     std::shared_ptr<size_t> counter_;

--- a/src/infrastructure/include/kth/infrastructure/wallet/hd_private.hpp
+++ b/src/infrastructure/include/kth/infrastructure/wallet/hd_private.hpp
@@ -95,7 +95,7 @@ private:
     static hd_private from_string(std::string const& encoded, uint32_t public_prefix);
     static hd_private from_string(std::string const& encoded, uint64_t prefixes);
 
-    hd_private(ec_secret const& secret, const hd_chain_code& chain_code, hd_lineage const& lineage);
+    hd_private(ec_secret const& secret, hd_chain_code const& chain_code, hd_lineage const& lineage);
 
     /// Members.
     /// This should be const, apart from the need to implement assignment.

--- a/src/infrastructure/include/kth/infrastructure/wallet/hd_public.hpp
+++ b/src/infrastructure/include/kth/infrastructure/wallet/hd_public.hpp
@@ -82,15 +82,15 @@ struct KI_API hd_public {
     operator bool const() const;    //NOLINT
 
     explicit
-    operator const ec_compressed&() const;
+    operator ec_compressed const&() const;
 
     /// Serializer.
     std::string encoded() const;
 
     /// Accessors.
-    const hd_chain_code& chain_code() const;
+    hd_chain_code const& chain_code() const;
     hd_lineage const& lineage() const;
-    const ec_compressed& point() const;
+    ec_compressed const& point() const;
 
     /// Methods.
     hd_key to_hd_key() const;
@@ -99,7 +99,7 @@ struct KI_API hd_public {
 protected:
     /// Factories.
     static
-    hd_public from_secret(ec_secret const& secret, const hd_chain_code& chain_code, hd_lineage const& lineage);
+    hd_public from_secret(ec_secret const& secret, hd_chain_code const& chain_code, hd_lineage const& lineage);
 
     /// Helpers.
     uint32_t fingerprint() const;
@@ -124,7 +124,7 @@ private:
     static
     hd_public from_string(std::string const& encoded, uint32_t prefix);
 
-    hd_public(const ec_compressed& point, const hd_chain_code& chain_code, hd_lineage const& lineage);
+    hd_public(ec_compressed const& point, hd_chain_code const& chain_code, hd_lineage const& lineage);
 };
 
 } // namespace kth::infrastructure::wallet

--- a/src/infrastructure/include/kth/infrastructure/wallet/mnemonic.hpp
+++ b/src/infrastructure/include/kth/infrastructure/wallet/mnemonic.hpp
@@ -47,26 +47,26 @@ KI_API word_list create_mnemonic(byte_span entropy,
  * words are spelled correctly and the checksum matches.
  * The words must have been created using mnemonic encoding.
  */
-KI_API bool validate_mnemonic(const word_list& words,
-    const dictionary &lexicon);
+KI_API bool validate_mnemonic(word_list const& words,
+    dictionary const& lexicon);
 
 /**
  * Checks that a mnemonic is valid in at least one of the provided languages.
  */
-KI_API bool validate_mnemonic(const word_list& mnemonic,
-    const dictionary_list& lexicons=language::all);
+KI_API bool validate_mnemonic(word_list const& mnemonic,
+    dictionary_list const& lexicons=language::all);
 
 /**
  * Convert a mnemonic with no passphrase to a wallet-generation seed.
  */
-KI_API long_hash decode_mnemonic(const word_list& mnemonic);
+KI_API long_hash decode_mnemonic(word_list const& mnemonic);
 
 /**
  * Convert a mnemonic and passphrase to a wallet-generation seed.
  * Any passphrase can be used and will change the resulting seed.
  * The passphrase has to be normalized using ICU.
  */
-KI_API long_hash decode_mnemonic_normalized_passphrase(const word_list& mnemonic, std::string const& normalized_passphrase);
+KI_API long_hash decode_mnemonic_normalized_passphrase(word_list const& mnemonic, std::string const& normalized_passphrase);
 
 #ifdef WITH_ICU
 
@@ -74,7 +74,7 @@ KI_API long_hash decode_mnemonic_normalized_passphrase(const word_list& mnemonic
  * Convert a mnemonic and passphrase to a wallet-generation seed.
  * Any passphrase can be used and will change the resulting seed.
  */
-KI_API long_hash decode_mnemonic(const word_list& mnemonic,
+KI_API long_hash decode_mnemonic(word_list const& mnemonic,
     std::string const& passphrase);
 
 #endif

--- a/src/infrastructure/src/config/hash256.cpp
+++ b/src/infrastructure/src/config/hash256.cpp
@@ -52,7 +52,7 @@ std::istream& operator>>(std::istream& input, hash256& argument) {
     return input;
 }
 
-std::ostream& operator<<(std::ostream& output, const hash256& argument) {
+std::ostream& operator<<(std::ostream& output, hash256 const& argument) {
     output << encode_hash(argument.value_);
     return output;
 }

--- a/src/infrastructure/src/error.cpp
+++ b/src/infrastructure/src/error.cpp
@@ -21,7 +21,7 @@ public:
 };
 
 static
-const error_category_impl& get_error_category_instance() {
+error_category_impl const& get_error_category_instance() {
     static error_category_impl instance;
     return instance;
 }

--- a/src/infrastructure/src/formats/base_64.cpp
+++ b/src/infrastructure/src/formats/base_64.cpp
@@ -53,9 +53,9 @@ bool decode_base64(data_chunk& out, std::string_view in) {
 
 namespace kth {
 
-const static char pad = '=';
+constexpr char pad = '=';
 
-const static char table[] =
+constexpr char table[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 std::string encode_base64(byte_span unencoded)
@@ -104,7 +104,7 @@ std::string encode_base64(byte_span unencoded)
 
 bool decode_base64(data_chunk& out, std::string_view in)
 {
-    const static uint32_t mask = 0x000000FF;
+    constexpr uint32_t mask = 0x000000FF;
 
     auto const length = in.length();
     if ((length % 4) != 0) {

--- a/src/infrastructure/src/math/elliptic_curve.cpp
+++ b/src/infrastructure/src/math/elliptic_curve.cpp
@@ -35,12 +35,12 @@ int to_flags(bool compressed) {
 // These allow strong typing of private keys without redundant code.
 
 template <size_t Size>
-bool parse(const secp256k1_context* context, secp256k1_pubkey& out, const byte_array<Size>& point) {
+bool parse(secp256k1_context const* context, secp256k1_pubkey& out, byte_array<Size> const& point) {
     return secp256k1_ec_pubkey_parse(context, &out, point.data(), Size) == 1;
 }
 
 template <size_t Size>
-bool serialize(const secp256k1_context* context, byte_array<Size>& out, const secp256k1_pubkey point) {
+bool serialize(secp256k1_context const* context, byte_array<Size>& out, secp256k1_pubkey const point) {
     auto size = Size;
     auto const flags = to_flags(Size == ec_compressed_size);
     secp256k1_ec_pubkey_serialize(context, out.data(), &size, &point, flags);
@@ -48,7 +48,7 @@ bool serialize(const secp256k1_context* context, byte_array<Size>& out, const se
 }
 
 template <size_t Size>
-bool ec_add(const secp256k1_context* context, byte_array<Size>& in_out, ec_secret const& secret) {
+bool ec_add(secp256k1_context const* context, byte_array<Size>& in_out, ec_secret const& secret) {
     secp256k1_pubkey pubkey;
     return parse(context, pubkey, in_out) &&
         secp256k1_ec_pubkey_tweak_add(context, &pubkey, secret.data()) == 1 &&
@@ -56,7 +56,7 @@ bool ec_add(const secp256k1_context* context, byte_array<Size>& in_out, ec_secre
 }
 
 template <size_t Size>
-bool ec_multiply(const secp256k1_context* context, byte_array<Size>& in_out, ec_secret const& secret) {
+bool ec_multiply(secp256k1_context const* context, byte_array<Size>& in_out, ec_secret const& secret) {
     secp256k1_pubkey pubkey;
     return parse(context, pubkey, in_out) &&
         secp256k1_ec_pubkey_tweak_mul(context, &pubkey, secret.data()) == 1 &&
@@ -64,14 +64,14 @@ bool ec_multiply(const secp256k1_context* context, byte_array<Size>& in_out, ec_
 }
 
 template <size_t Size>
-bool secret_to_public(const secp256k1_context* context, byte_array<Size>& out, ec_secret const& secret) {
+bool secret_to_public(secp256k1_context const* context, byte_array<Size>& out, ec_secret const& secret) {
     secp256k1_pubkey pubkey;
     return secp256k1_ec_pubkey_create(context, &pubkey, secret.data()) == 1 &&
         serialize(context, out, pubkey);
 }
 
 template <size_t Size>
-bool recover_public(const secp256k1_context* context, byte_array<Size>& out, const recoverable_signature& recoverable, hash_digest const& hash) {
+bool recover_public(secp256k1_context const* context, byte_array<Size>& out, recoverable_signature const& recoverable, hash_digest const& hash) {
     secp256k1_pubkey pubkey;
     secp256k1_ecdsa_recoverable_signature sign;
     auto const recovery_id = safe_to_signed<int>(recoverable.recovery_id);
@@ -83,9 +83,9 @@ bool recover_public(const secp256k1_context* context, byte_array<Size>& out, con
            serialize(context, out, pubkey);
 }
 
-bool verify_signature(const secp256k1_context* context,
-    const secp256k1_pubkey point, hash_digest const& hash,
-    const ec_signature& signature) {
+bool verify_signature(secp256k1_context const* context,
+    secp256k1_pubkey const point, hash_digest const& hash,
+    ec_signature const& signature) {
 
     // Copy to avoid exposing external types.
     secp256k1_ecdsa_signature parsed;
@@ -136,13 +136,13 @@ bool ec_multiply(ec_secret& left, ec_secret const& right) {
 // Convert keys
 // ----------------------------------------------------------------------------
 
-bool compress(ec_compressed& out, const ec_uncompressed& point) {
+bool compress(ec_compressed& out, ec_uncompressed const& point) {
     secp256k1_pubkey pubkey;
     auto const context = verification.context();
     return parse(context, pubkey, point) && serialize(context, out, pubkey);
 }
 
-bool decompress(ec_uncompressed& out, const ec_compressed& point) {
+bool decompress(ec_uncompressed& out, ec_compressed const& point) {
     secp256k1_pubkey pubkey;
     auto const context = verification.context();
     return parse(context, pubkey, point) && serialize(context, out, pubkey);
@@ -166,13 +166,13 @@ bool verify(ec_secret const& secret) {
     return secp256k1_ec_seckey_verify(context, secret.data()) == 1;
 }
 
-bool verify(const ec_compressed& point) {
+bool verify(ec_compressed const& point) {
     secp256k1_pubkey pubkey;
     auto const context = verification.context();
     return parse(context, pubkey, point);
 }
 
-bool verify(const ec_uncompressed& point) {
+bool verify(ec_uncompressed const& point) {
     secp256k1_pubkey pubkey;
     auto const context = verification.context();
     return parse(context, pubkey, point);
@@ -205,11 +205,11 @@ bool is_public_key(byte_span point) {
     return is_compressed_key(point) || is_uncompressed_key(point);
 }
 
-bool is_even_key(const ec_compressed& point) {
+bool is_even_key(ec_compressed const& point) {
     return point.front() == ec_even_sign;
 }
 
-bool is_endorsement(const endorsement& endorsement) {
+bool is_endorsement(endorsement const& endorsement) {
     auto const size = endorsement.size();
     return size >= min_endorsement_size && size <= max_endorsement_size;
 }
@@ -320,21 +320,21 @@ bool sign_schnorr(ec_signature& out, ec_secret const& secret, hash_digest const&
     return true;
 }
 
-bool verify_signature(const ec_compressed& point, hash_digest const& hash, const ec_signature& signature) {
+bool verify_signature(ec_compressed const& point, hash_digest const& hash, ec_signature const& signature) {
     secp256k1_pubkey pubkey;
     auto const context = verification.context();
     return parse(context, pubkey, point) &&
         verify_signature(context, pubkey, hash, signature);
 }
 
-bool verify_signature(const ec_uncompressed& point, hash_digest const& hash, const ec_signature& signature) {
+bool verify_signature(ec_uncompressed const& point, hash_digest const& hash, ec_signature const& signature) {
     secp256k1_pubkey pubkey;
     auto const context = verification.context();
     return parse(context, pubkey, point) &&
         verify_signature(context, pubkey, hash, signature);
 }
 
-bool verify_signature(byte_span point, hash_digest const& hash, const ec_signature& signature) {
+bool verify_signature(byte_span point, hash_digest const& hash, ec_signature const& signature) {
     // Copy to avoid exposing external types.
     secp256k1_ecdsa_signature parsed;
     std::copy_n(signature.begin(), ec_signature_size, std::begin(parsed.data));
@@ -375,12 +375,12 @@ bool sign_recoverable(recoverable_signature& out, ec_secret const& secret, hash_
     return result;
 }
 
-bool recover_public(ec_compressed& out, const recoverable_signature& recoverable, hash_digest const& hash) {
+bool recover_public(ec_compressed& out, recoverable_signature const& recoverable, hash_digest const& hash) {
     auto const context = verification.context();
     return recover_public(context, out, recoverable, hash);
 }
 
-bool recover_public(ec_uncompressed& out, const recoverable_signature& recoverable, hash_digest const& hash) {
+bool recover_public(ec_uncompressed& out, recoverable_signature const& recoverable, hash_digest const& hash) {
     auto const context = verification.context();
     return recover_public(context, out, recoverable, hash);
 }

--- a/src/infrastructure/src/unicode/unicode.cpp
+++ b/src/infrastructure/src/unicode/unicode.cpp
@@ -81,7 +81,7 @@ static std::string normal_form(std::string const& value, norm_type form)
 {
     auto backend = localization_backend_manager::global();
     backend.select(KI_LOCALE_BACKEND);
-    const generator locale(backend);
+    generator const locale(backend);
     return normalize(value, form, locale(KI_LOCALE_UTF8));
 }
 

--- a/src/infrastructure/src/utility/string.cpp
+++ b/src/infrastructure/src/utility/string.cpp
@@ -11,7 +11,7 @@
 
 namespace kth {
 
-std::string join(const string_list& words, std::string const& delimiter) {
+std::string join(string_list const& words, std::string const& delimiter) {
     return boost::join(words, delimiter);
 }
 

--- a/src/infrastructure/src/wallet/__parse_encrypted_keys/__parse_encrypted_key.hpp
+++ b/src/infrastructure/src/wallet/__parse_encrypted_keys/__parse_encrypted_key.hpp
@@ -21,8 +21,8 @@ class parse_encrypted_key
   : public parse_encrypted_prefix<PrefixSize>
 {
 public:
-    parse_encrypted_key(const byte_array<PrefixSize>& prefix,
-        const one_byte& flags, const ek_salt& salt, const ek_entropy& entropy);
+    parse_encrypted_key(byte_array<PrefixSize> const& prefix,
+        one_byte const& flags, ek_salt const& salt, ek_entropy const& entropy);
 
     bool compressed() const;
     bool lot_sequence() const;
@@ -33,9 +33,9 @@ public:
     ek_entropy entropy() const;
 
 private:
-    const one_byte flags_;
-    const ek_salt salt_;
-    const ek_entropy entropy_;
+    one_byte const flags_;
+    ek_salt const salt_;
+    ek_entropy const entropy_;
 };
 
 } // namespace kth::infrastructure::wallet

--- a/src/infrastructure/src/wallet/__parse_encrypted_keys/__parse_encrypted_key.ipp
+++ b/src/infrastructure/src/wallet/__parse_encrypted_keys/__parse_encrypted_key.ipp
@@ -17,8 +17,8 @@ namespace kth::infrastructure::wallet {
 
 template <size_t PrefixSize>
 parse_encrypted_key<PrefixSize>::parse_encrypted_key(
-    const byte_array<PrefixSize>& prefix, const one_byte& flags,
-    const ek_salt& salt, const ek_entropy& entropy)
+    byte_array<PrefixSize> const& prefix, one_byte const& flags,
+    ek_salt const& salt, ek_entropy const& entropy)
   : parse_encrypted_prefix<PrefixSize>(prefix),
     flags_(flags), salt_(salt), entropy_(entropy)
 {

--- a/src/infrastructure/src/wallet/__parse_encrypted_keys/__parse_encrypted_prefix.hpp
+++ b/src/infrastructure/src/wallet/__parse_encrypted_keys/__parse_encrypted_prefix.hpp
@@ -30,7 +30,7 @@ public:
     static constexpr uint8_t prefix_size = Size;
 
 protected:
-    explicit parse_encrypted_prefix(const byte_array<Size>& value);
+    explicit parse_encrypted_prefix(byte_array<Size> const& value);
 
     uint8_t context() const;
     byte_array<Size> prefix() const;

--- a/src/infrastructure/src/wallet/__parse_encrypted_keys/__parse_encrypted_prefix.ipp
+++ b/src/infrastructure/src/wallet/__parse_encrypted_keys/__parse_encrypted_prefix.ipp
@@ -15,7 +15,7 @@ namespace kth::infrastructure::wallet {
 
 template <size_t Size>
 parse_encrypted_prefix<Size>::parse_encrypted_prefix(
-    const byte_array<Size>& value)
+    byte_array<Size> const& value)
   : prefix_(value), valid_(false)
 {
 }

--- a/src/infrastructure/src/wallet/hd_private.cpp
+++ b/src/infrastructure/src/wallet/hd_private.cpp
@@ -64,7 +64,7 @@ hd_private::hd_private(std::string const& encoded, uint64_t prefixes)
     : hd_private(from_string(encoded, prefixes))
 {}
 
-hd_private::hd_private(ec_secret const& secret, const hd_chain_code& chain_code, hd_lineage const& lineage)
+hd_private::hd_private(ec_secret const& secret, hd_chain_code const& chain_code, hd_lineage const& lineage)
     : hd_public(from_secret(secret, chain_code, lineage))
     , secret_(secret)
 {}

--- a/src/infrastructure/src/wallet/hd_public.cpp
+++ b/src/infrastructure/src/wallet/hd_public.cpp
@@ -58,14 +58,14 @@ hd_public::hd_public(std::string const& encoded, uint32_t prefix)
     : hd_public(from_string(encoded, prefix))
 {}
 
-hd_public::hd_public(const ec_compressed& point, const hd_chain_code& chain_code, hd_lineage const& lineage)
+hd_public::hd_public(ec_compressed const& point, hd_chain_code const& chain_code, hd_lineage const& lineage)
     : valid_(true), point_(point), chain_(chain_code), lineage_(lineage)
 {}
 
 // Factories.
 // ----------------------------------------------------------------------------
 
-hd_public hd_public::from_secret(ec_secret const& secret, const hd_chain_code& chain_code, hd_lineage const& lineage) {
+hd_public hd_public::from_secret(ec_secret const& secret, hd_chain_code const& chain_code, hd_lineage const& lineage) {
     ec_compressed point;
     return secret_to_public(point, secret) ? hd_public(point, chain_code, lineage) : hd_public{};
 }
@@ -144,7 +144,7 @@ hd_public::operator bool const() const {
     return valid_;
 }
 
-hd_public::operator const ec_compressed&() const {
+hd_public::operator ec_compressed const&() const {
     return point_;
 }
 
@@ -158,7 +158,7 @@ std::string hd_public::encoded() const {
 // Accessors.
 // ----------------------------------------------------------------------------
 
-const hd_chain_code& hd_public::chain_code() const {
+hd_chain_code const& hd_public::chain_code() const {
     return chain_;
 }
 
@@ -166,7 +166,7 @@ hd_lineage const& hd_public::lineage() const {
     return lineage_;
 }
 
-const ec_compressed& hd_public::point() const {
+ec_compressed const& hd_public::point() const {
     return point_;
 }
 

--- a/src/infrastructure/src/wallet/mnemonic.cpp
+++ b/src/infrastructure/src/wallet/mnemonic.cpp
@@ -32,7 +32,7 @@ uint8_t bip39_shift(size_t bit) {
     return (1 << (byte_bits - (bit % byte_bits) - 1));
 }
 
-bool validate_mnemonic(const word_list& words, const dictionary& lexicon) {
+bool validate_mnemonic(word_list const& words, dictionary const& lexicon) {
     auto const word_count = words.size();
     if ((word_count % mnemonic_word_multiple) != 0) {
         return false;
@@ -67,7 +67,7 @@ bool validate_mnemonic(const word_list& words, const dictionary& lexicon) {
     return std::equal(mnemonic.begin(), mnemonic.end(), words.begin());
 }
 
-word_list create_mnemonic(byte_span entropy, const dictionary &lexicon) {
+word_list create_mnemonic(byte_span entropy, dictionary const& lexicon) {
     if ((entropy.size() % mnemonic_seed_multiple) != 0) {
         return word_list();
     }
@@ -106,7 +106,7 @@ word_list create_mnemonic(byte_span entropy, const dictionary &lexicon) {
     return words;
 }
 
-bool validate_mnemonic(const word_list& mnemonic, const dictionary_list& lexicons) {
+bool validate_mnemonic(word_list const& mnemonic, dictionary_list const& lexicons) {
     for (auto const& lexicon: lexicons) {
         if (validate_mnemonic(mnemonic, *lexicon)) {
             return true;
@@ -116,13 +116,13 @@ bool validate_mnemonic(const word_list& mnemonic, const dictionary_list& lexicon
     return false;
 }
 
-long_hash decode_mnemonic(const word_list& mnemonic) {
+long_hash decode_mnemonic(word_list const& mnemonic) {
     auto const sentence = join(mnemonic);
     std::string const salt(passphrase_prefix);
     return pkcs5_pbkdf2_hmac_sha512(to_chunk(sentence), to_chunk(salt), hmac_iterations);
 }
 
-long_hash decode_mnemonic_normalized_passphrase(const word_list& mnemonic, std::string const& normalized_passphrase) {
+long_hash decode_mnemonic_normalized_passphrase(word_list const& mnemonic, std::string const& normalized_passphrase) {
     auto const sentence = join(mnemonic);
     std::string const prefix(passphrase_prefix);
     auto const salt = prefix + normalized_passphrase;
@@ -132,7 +132,7 @@ long_hash decode_mnemonic_normalized_passphrase(const word_list& mnemonic, std::
 
 #ifdef WITH_ICU
 
-long_hash decode_mnemonic(const word_list& mnemonic, std::string const& passphrase) {
+long_hash decode_mnemonic(word_list const& mnemonic, std::string const& passphrase) {
     auto const sentence = join(mnemonic);
     std::string const prefix(passphrase_prefix);
     auto const salt = to_normal_nfkd_form(prefix + passphrase);

--- a/src/infrastructure/test/config/authority.cpp
+++ b/src/infrastructure/test/config/authority.cpp
@@ -73,63 +73,63 @@ TEST_CASE("authority port default zero", "[authority port]") {
 }
 
 TEST_CASE("authority port copy expected", "[authority port]") {
-    const uint16_t expected_port = 42;
-    const authority other(test_ipv6_address, expected_port);
-    const authority host(other);
+    constexpr uint16_t expected_port = 42;
+    authority const other(test_ipv6_address, expected_port);
+    authority const host(other);
     REQUIRE(host.port() == expected_port);
 }
 
 TEST_CASE("authority should extract port from IPv4 address with port", "[authority port]") {
-    const uint16_t expected_port = 42;
+    constexpr uint16_t expected_port = 42;
     std::stringstream address;
     address << KI_AUTHORITY_IPV4_ADDRESS ":" << expected_port;
-    const authority host(address.str());
+    authority const host(address.str());
     REQUIRE(host.port() == expected_port);
 }
 
 TEST_CASE("authority should extract port from IPv6 address with port", "[authority port]") {
-    const uint16_t expected_port = 42;
+    constexpr uint16_t expected_port = 42;
     std::stringstream address;
     address << "[" KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS "]:" << expected_port;
-    const authority host(address.str());
+    authority const host(address.str());
     REQUIRE(host.port() == expected_port);
 }
 
 TEST_CASE("authority should extract port from network address", "[authority port]") {
-    const uint16_t expected_port = 42;
+    constexpr uint16_t expected_port = 42;
     message::network_address const address {
         0, 0, test_ipv6_address, expected_port
     };
 
-    const authority host(address);
+    authority const host(address);
     REQUIRE(host.port() == expected_port);
 }
 
 TEST_CASE("authority should extract port from IP address constructor", "[authority port]") {
-    const uint16_t expected_port = 42;
-    const authority host(test_ipv6_address, expected_port);
+    constexpr uint16_t expected_port = 42;
+    authority const host(test_ipv6_address, expected_port);
     REQUIRE(host.port() == expected_port);
 }
 
 TEST_CASE("authority should extract port from hostname constructor", "[authority port]") {
-    const uint16_t expected_port = 42;
-    const authority host(KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS, expected_port);
+    constexpr uint16_t expected_port = 42;
+    authority const host(KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS, expected_port);
     REQUIRE(host.port() == expected_port);
 }
 
 #if ! defined(__EMSCRIPTEN__)
 TEST_CASE("authority  port  boost address  expected", "[authority  port]") {
-    const uint16_t expected_port = 42;
+    constexpr uint16_t expected_port = 42;
     auto const address = ::asio::ip::make_address(KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS);
-    const authority host(address, expected_port);
+    authority const host(address, expected_port);
     REQUIRE(host.port() == expected_port);
 }
 
 TEST_CASE("authority  port  boost endpoint  expected", "[authority  port]") {
-    const uint16_t expected_port = 42;
+    constexpr uint16_t expected_port = 42;
     auto const address = ::asio::ip::make_address(KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS);
     kth::asio::endpoint tcp_endpoint(address, expected_port);
-    const authority host(tcp_endpoint);
+    authority const host(tcp_endpoint);
     REQUIRE(host.port() == expected_port);
 }
 #endif
@@ -146,12 +146,12 @@ TEST_CASE("authority  bool  default  false", "[authority  ip]") {
 }
 
 TEST_CASE("authority  bool  zero port  false", "[authority  ip]") {
-    const authority host(test_ipv6_address, 0);
+    authority const host(test_ipv6_address, 0);
     REQUIRE( ! host);
 }
 
 TEST_CASE("authority  bool  nonzero port  true", "[authority  ip]") {
-    const authority host(test_ipv6_address, 42);
+    authority const host(test_ipv6_address, 42);
     REQUIRE(host);
 }
 
@@ -168,30 +168,30 @@ TEST_CASE("authority  ip  default  unspecified", "[authority  ip]") {
 
 TEST_CASE("authority  ip  copy  expected", "[authority  ip]") {
     auto const& expected_ip = test_ipv6_address;
-    const authority other(expected_ip, 42);
-    const authority host(other);
+    authority const other(expected_ip, 42);
+    authority const host(other);
     REQUIRE(ip_equal(host.ip(), expected_ip));
 }
 
 TEST_CASE("authority should parse IPv4 address from string", "[authority ip]") {
-    const authority host(KI_AUTHORITY_IPV4_ADDRESS ":42");
+    authority const host(KI_AUTHORITY_IPV4_ADDRESS ":42");
     REQUIRE(ip_equal(host.ip(), test_mapped_ip_address));
 }
 
 TEST_CASE("authority should parse IPv6 address from string", "[authority ip]") {
-    const authority host("[" KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS "]:42");
+    authority const host("[" KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS "]:42");
     REQUIRE(ip_equal(host.ip(), test_ipv6_address));
 }
 
 TEST_CASE("authority should parse IPv6 compatible address from string", "[authority ip]") {
     // KI_AUTHORITY_IPV6_COMPATIBLE_ADDRESS A|B variants are equivalent.
-    const authority host("[" KI_AUTHORITY_IPV6_COMPATIBLE_ADDRESS "]:42");
+    authority const host("[" KI_AUTHORITY_IPV6_COMPATIBLE_ADDRESS "]:42");
     REQUIRE(ip_equal(host.ip(), test_compatible_ip_address));
 }
 
 TEST_CASE("authority should parse IPv6 alternative compatible address from string", "[authority ip]") {
     // KI_AUTHORITY_IPV6_COMPATIBLE_ADDRESS A|B variants are equivalent.
-    const authority host("[" KI_AUTHORITY_IPV6_ALTERNATIVE_COMPATIBLE_ADDRESS "]:42");
+    authority const host("[" KI_AUTHORITY_IPV6_ALTERNATIVE_COMPATIBLE_ADDRESS "]:42");
     REQUIRE(ip_equal(host.ip(), test_compatible_ip_address));
 }
 
@@ -201,42 +201,42 @@ TEST_CASE("authority should extract IP from network address", "[authority ip]") 
         0, 0, test_ipv6_address, 42
     };
 
-    const authority host(address);
+    authority const host(address);
     REQUIRE(ip_equal(host.ip(), test_ipv6_address));
 }
 
 TEST_CASE("authority should extract IP from IP address constructor", "[authority ip]") {
     auto const& expected_ip = test_ipv6_address;
-    const authority host(expected_ip, 42);
+    authority const host(expected_ip, 42);
     REQUIRE(ip_equal(host.ip(), expected_ip));
 }
 
 TEST_CASE("authority should parse IPv4 from hostname string", "[authority ip]") {
-    const authority host(KI_AUTHORITY_IPV4_ADDRESS, 42);
+    authority const host(KI_AUTHORITY_IPV4_ADDRESS, 42);
     REQUIRE(ip_equal(host.ip(), test_mapped_ip_address));
 }
 
 TEST_CASE("authority should parse IPv6 from hostname string", "[authority ip]") {
-    const authority host(KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS, 42);
+    authority const host(KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS, 42);
     REQUIRE(ip_equal(host.ip(), test_ipv6_address));
 }
 
 TEST_CASE("authority should parse IPv6 from bracketed hostname string", "[authority ip]") {
-    const authority host("[" KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS "]", 42);
+    authority const host("[" KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS "]", 42);
     REQUIRE(ip_equal(host.ip(), test_ipv6_address));
 }
 
 #if ! defined(__EMSCRIPTEN__)
 TEST_CASE("authority  ip  boost address  expected", "[authority  ip]") {
     auto const address = ::asio::ip::make_address(KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS);
-    const authority host(address, 42);
+    authority const host(address, 42);
     REQUIRE(ip_equal(host.ip(), test_ipv6_address));
 }
 
 TEST_CASE("authority  ip  boost endpoint  expected", "[authority  ip]") {
     auto const address = ::asio::ip::make_address(KI_AUTHORITY_IPV4_ADDRESS);
     kth::asio::endpoint tcp_endpoint(address, 42);
-    const authority host(tcp_endpoint);
+    authority const host(tcp_endpoint);
     REQUIRE(ip_equal(host.ip(), test_mapped_ip_address));
 }
 #endif
@@ -254,19 +254,19 @@ TEST_CASE("authority  to hostname  default  ipv6 unspecified", "[authority  to h
 
 TEST_CASE("authority  to hostname  ipv4 mapped ip address  ipv4", "[authority  to hostname]") {
     // A mapped ip address serializes as IPv4.
-    const authority host(test_mapped_ip_address, 0);
+    authority const host(test_mapped_ip_address, 0);
     REQUIRE(host.to_hostname() == KI_AUTHORITY_IPV4_ADDRESS);
 }
 
 TEST_CASE("authority  to hostname  ipv4 compatible ip address  ipv6 alternative", "[authority  to hostname]") {
     // A compatible ip address serializes as alternative notation IPv6.
-    const authority host(test_compatible_ip_address, 0);
+    authority const host(test_compatible_ip_address, 0);
     REQUIRE(host.to_hostname() == "[" KI_AUTHORITY_IPV6_ALTERNATIVE_COMPATIBLE_ADDRESS "]");
 }
 
 TEST_CASE("authority  to hostname  ipv6 address  ipv6 compressed", "[authority  to hostname]") {
     // An ipv6 address serializes using compression.
-    const authority host(test_ipv6_address, 0);
+    authority const host(test_ipv6_address, 0);
     REQUIRE(host.to_hostname() == "[" KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS "]");
 }
 
@@ -290,7 +290,7 @@ TEST_CASE("authority  to network address  ipv4 mapped ip address  ipv4", "[autho
         0, 0, test_mapped_ip_address, 42,
     };
 
-    const authority host(expected_address.ip(), expected_address.port());
+    authority const host(expected_address.ip(), expected_address.port());
     REQUIRE(net_equal(host.to_network_address(), expected_address));
 }
 
@@ -299,7 +299,7 @@ TEST_CASE("authority  to network address  ipv4 compatible ip address  ipv6 alter
         0, 0, test_compatible_ip_address, 42,
     };
 
-    const authority host(expected_address.ip(), expected_address.port());
+    authority const host(expected_address.ip(), expected_address.port());
     REQUIRE(net_equal(host.to_network_address(), expected_address));
 }
 
@@ -308,7 +308,7 @@ TEST_CASE("authority  to network address  ipv6 address  ipv6 compressed", "[auth
         0, 0, test_ipv6_address, 42,
     };
 
-    const authority host(expected_address.ip(), expected_address.port());
+    authority const host(expected_address.ip(), expected_address.port());
     REQUIRE(net_equal(host.to_network_address(), expected_address));
 }
 
@@ -325,7 +325,7 @@ TEST_CASE("authority  to string  default  unspecified", "[authority  to string]"
 
 TEST_CASE("authority  to string  unspecified  unspecified", "[authority  to string]") {
     auto const line = "[" KI_AUTHORITY_IPV6_UNSPECIFIED_ADDRESS "]";
-    const authority host(line);
+    authority const host(line);
     REQUIRE(host.to_string() == line);
 }
 
@@ -343,49 +343,49 @@ TEST_CASE("authority  to string  unspecified  unspecified", "[authority  to stri
 
 TEST_CASE("authority  to string  ipv4  expected", "[authority  to string]") {
     auto const line = KI_AUTHORITY_IPV4_ADDRESS;
-    const authority host(line);
+    authority const host(line);
     REQUIRE(host.to_string() == line);
 }
 
 TEST_CASE("authority  to string  ipv4 port  expected", "[authority  to string]") {
     auto const line = KI_AUTHORITY_IPV4_ADDRESS ":42";
-    const authority host(line);
+    authority const host(line);
     REQUIRE(host.to_string() == line);
 }
 
 TEST_CASE("authority  to string  ipv6  expected", "[authority  to string]") {
     auto const line = "[" KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS "]";
-    const authority host(line);
+    authority const host(line);
     REQUIRE(host.to_string() == line);
 }
 
 TEST_CASE("authority  to string  ipv6 port  expected", "[authority  to string]") {
     auto const line = "[" KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS "]:42";
-    const authority host(line);
+    authority const host(line);
     REQUIRE(host.to_string() == line);
 }
 
 TEST_CASE("authority  to string  ipv6 compatible  expected", "[authority  to string]") {
     // A compatible ip address serializes as alternative notation IPv6.
-    const authority host("[" KI_AUTHORITY_IPV6_COMPATIBLE_ADDRESS "]");
+    authority const host("[" KI_AUTHORITY_IPV6_COMPATIBLE_ADDRESS "]");
     REQUIRE(host.to_string() == "[" KI_AUTHORITY_IPV6_ALTERNATIVE_COMPATIBLE_ADDRESS "]");
 }
 
 TEST_CASE("authority  to string  ipv6 alternative compatible port  expected", "[authority  to string]") {
     // A compatible ip address serializes as alternative notation IPv6.
-    const authority host("[" KI_AUTHORITY_IPV6_COMPATIBLE_ADDRESS "]:42");
+    authority const host("[" KI_AUTHORITY_IPV6_COMPATIBLE_ADDRESS "]:42");
     REQUIRE(host.to_string() == "[" KI_AUTHORITY_IPV6_ALTERNATIVE_COMPATIBLE_ADDRESS "]:42");
 }
 
 TEST_CASE("authority  to string  ipv6 alternative compatible  expected", "[authority  to string]") {
     auto const line = "[" KI_AUTHORITY_IPV6_ALTERNATIVE_COMPATIBLE_ADDRESS "]";
-    const authority host(line);
+    authority const host(line);
     REQUIRE(host.to_string() == line);
 }
 
 TEST_CASE("authority  to string  ipv6 compatible port  expected", "[authority  to string]") {
     auto const line = "[" KI_AUTHORITY_IPV6_ALTERNATIVE_COMPATIBLE_ADDRESS "]:42";
-    const authority host(line);
+    authority const host(line);
     REQUIRE(host.to_string() == line);
 }
 
@@ -403,44 +403,44 @@ TEST_CASE("authority  equality  default default  true", "[authority  equality]")
 
 TEST_CASE("authority  equality  default unspecified port  false", "[authority  equality]") {
     authority const host1 {};
-    const authority host2(KI_AUTHORITY_IPV6_UNSPECIFIED_ADDRESS, 42);
+    authority const host2(KI_AUTHORITY_IPV6_UNSPECIFIED_ADDRESS, 42);
     REQUIRE( ! (host1 == host2));
 }
 
 TEST_CASE("authority  equality  ipv4 ipv4  true", "[authority  equality]") {
-    const authority host1(KI_AUTHORITY_IPV4_ADDRESS);
-    const authority host2(KI_AUTHORITY_IPV4_ADDRESS);
+    authority const host1(KI_AUTHORITY_IPV4_ADDRESS);
+    authority const host2(KI_AUTHORITY_IPV4_ADDRESS);
     REQUIRE(host1 == host2);
 }
 
 TEST_CASE("authority  equality  ipv4 ipv4 port  true", "[authority  equality]") {
-    const authority host1(KI_AUTHORITY_IPV4_ADDRESS);
-    const authority host2(KI_AUTHORITY_IPV4_ADDRESS, 42);
+    authority const host1(KI_AUTHORITY_IPV4_ADDRESS);
+    authority const host2(KI_AUTHORITY_IPV4_ADDRESS, 42);
     REQUIRE( ! (host1 == host2));
 }
 
 TEST_CASE("authority  equality  ipv4 ipv6  false", "[authority  equality]") {
-    const authority host1(KI_AUTHORITY_IPV4_ADDRESS);
-    const authority host2("[" KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS "]");
+    authority const host1(KI_AUTHORITY_IPV4_ADDRESS);
+    authority const host2("[" KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS "]");
     REQUIRE( ! (host1 == host2));
 }
 
 TEST_CASE("authority  equality  ipv6 ipv6  true", "[authority  equality]") {
-    const authority host1("[" KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS "]");
-    const authority host2("[" KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS "]");
+    authority const host1("[" KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS "]");
+    authority const host2("[" KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS "]");
     REQUIRE(host1 == host2);
 }
 
 TEST_CASE("authority  equality  ipv6 ipv6 port  false", "[authority  equality]") {
-    const authority host1("[" KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS "]");
-    const authority host2(KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS, 42);
+    authority const host1("[" KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS "]");
+    authority const host2(KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS, 42);
     REQUIRE( ! (host1 == host2));
 }
 
 TEST_CASE("authority  equality  compatible alternative  true", "[authority  equality]") {
     // A compatible ip address is equivalent to its alternative addressing.
-    const authority host1("[" KI_AUTHORITY_IPV6_COMPATIBLE_ADDRESS "]");
-    const authority host2("[" KI_AUTHORITY_IPV6_ALTERNATIVE_COMPATIBLE_ADDRESS "]");
+    authority const host1("[" KI_AUTHORITY_IPV6_COMPATIBLE_ADDRESS "]");
+    authority const host2("[" KI_AUTHORITY_IPV6_ALTERNATIVE_COMPATIBLE_ADDRESS "]");
     REQUIRE(host1 == host2);
 }
 
@@ -458,13 +458,13 @@ TEST_CASE("authority  inequality  default default  false", "[authority  inequali
 
 TEST_CASE("authority  inequality  default unspecified port  true", "[authority  inequality]") {
     authority const host1 {};
-    const authority host2(KI_AUTHORITY_IPV6_UNSPECIFIED_ADDRESS, 42);
+    authority const host2(KI_AUTHORITY_IPV6_UNSPECIFIED_ADDRESS, 42);
     REQUIRE(host1 != host2);
 }
 
 TEST_CASE("authority  inequality  ipv6 ipv6  false", "[authority  inequality]") {
-    const authority host1("[" KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS "]");
-    const authority host2("[" KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS "]");
+    authority const host1("[" KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS "]");
+    authority const host2("[" KI_AUTHORITY_IPV6_COMPRESSED_ADDRESS "]");
     REQUIRE( ! (host1 != host2));
 }
 

--- a/src/infrastructure/test/config/hash256.cpp
+++ b/src/infrastructure/test/config/hash256.cpp
@@ -18,7 +18,7 @@ using namespace kth::infrastructure::config;
 // Start Test Suite: hash256  construct
 
 TEST_CASE("hash256  construct  default  null hash", "[hash256  construct]") {
-    const hash256 uninitialized_hash;
+    hash256 const uninitialized_hash;
     auto const expectation = encode_hash(kth::null_hash);
     auto const result = encode_hash(uninitialized_hash);
     REQUIRE(expectation == result);

--- a/src/infrastructure/test/utility/data.cpp
+++ b/src/infrastructure/test/utility/data.cpp
@@ -267,7 +267,7 @@ TEST_CASE("data  to array slice  double long hash  expected", "[data tests]") {
 TEST_CASE("data  to chunk  long hash  expected", "[data tests]") {
     uint8_t const l = 42;
     uint8_t const u = 24;
-    const long_hash source
+    long_hash const source
     {
         {
             l, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/src/infrastructure/test/utility/serializer.cpp
+++ b/src/infrastructure/test/utility/serializer.cpp
@@ -93,7 +93,7 @@ TEST_CASE("serializer - roundtrip error code", "[serializer tests]") {
 }
 
 TEST_CASE("serializer - roundtrip 2 bytes little endian", "[serializer tests]") {
-    const uint16_t expected = 43707;
+    constexpr uint16_t expected = 43707;
     data_chunk data(2);
     auto sink = make_unsafe_serializer(data.begin());
 
@@ -107,7 +107,7 @@ TEST_CASE("serializer - roundtrip 2 bytes little endian", "[serializer tests]") 
 }
 
 TEST_CASE("serializer - roundtrip 4 bytes little endian", "[serializer tests]") {
-    const uint32_t expected = 2898120443;
+    constexpr uint32_t expected = 2898120443;
     data_chunk data(4);
     auto sink = make_unsafe_serializer(data.begin());
 
@@ -121,7 +121,7 @@ TEST_CASE("serializer - roundtrip 4 bytes little endian", "[serializer tests]") 
 }
 
 TEST_CASE("serializer - roundtrip 8 bytes little endian", "[serializer tests]") {
-    uint64_t const expected = 0xd4b14be5d8f02abe;
+    constexpr uint64_t expected = 0xd4b14be5d8f02abe;
     data_chunk data(8);
     auto sink = make_unsafe_serializer(data.begin());
 
@@ -135,7 +135,7 @@ TEST_CASE("serializer - roundtrip 8 bytes little endian", "[serializer tests]") 
 }
 
 TEST_CASE("serializer - roundtrip 2 bytes big endian", "[serializer tests]") {
-    const uint16_t expected = 43707;
+    constexpr uint16_t expected = 43707;
     data_chunk data(2);
     auto sink = make_unsafe_serializer(data.begin());
 
@@ -149,7 +149,7 @@ TEST_CASE("serializer - roundtrip 2 bytes big endian", "[serializer tests]") {
 }
 
 TEST_CASE("serializer - roundtrip 4 bytes big endian", "[serializer tests]") {
-    const uint32_t expected = 2898120443;
+    constexpr uint32_t expected = 2898120443;
     data_chunk data(4);
     auto sink = make_unsafe_serializer(data.begin());
 

--- a/src/network/include/kth/network/protocols/protocol_version_31402.hpp
+++ b/src/network/include/kth/network/protocols/protocol_version_31402.hpp
@@ -60,11 +60,11 @@ protected:
 
     p2p& network_;
     std::string const user_agent_;
-    const uint32_t own_version_;
-    const uint64_t own_services_;
-    const uint64_t invalid_services_;
-    const uint32_t minimum_version_;
-    const uint64_t minimum_services_;
+    uint32_t const own_version_;
+    uint64_t const own_services_;
+    uint64_t const invalid_services_;
+    uint32_t const minimum_version_;
+    uint64_t const minimum_services_;
 };
 
 } // namespace kth::network

--- a/src/network/src/protocols/protocol_address_31402.cpp
+++ b/src/network/src/protocols/protocol_address_31402.cpp
@@ -82,7 +82,7 @@ bool protocol_address_31402::handle_receive_get_address(code const& ec, get_addr
     network_.fetch_addresses(addresses);
 
     if ( ! addresses.empty()) {
-        const address address_subset(addresses);
+        address const address_subset(addresses);
         SEND2(address_subset, handle_send, _1, self_.command);
 
         spdlog::debug("[network] Sending addresses to [{}] ({})", authority(), self_.addresses().size());

--- a/src/network/src/protocols/protocol_seed_31402.cpp
+++ b/src/network/src/protocols/protocol_seed_31402.cpp
@@ -30,7 +30,7 @@ protocol_seed_31402::protocol_seed_31402(p2p& network, channel::ptr channel)
 
 void protocol_seed_31402::start(event_handler handler) {
     auto const& settings = network_.network_settings();
-    const event_handler complete = BIND2(handle_seeding_complete, _1, handler);
+    event_handler const complete = BIND2(handle_seeding_complete, _1, handler);
 
     if (settings.host_pool_capacity == 0) {
         complete(error::not_found);
@@ -55,7 +55,7 @@ void protocol_seed_31402::send_own_address(settings const& settings) {
         return;
     }
 
-    const address self(network_address::list{network_address{ settings.self.to_network_address() } });
+    address const self(network_address::list{network_address{ settings.self.to_network_address() } });
 
     SEND1(self, handle_send_address, _1);
 }

--- a/src/network/src/protocols/protocol_version_70002.cpp
+++ b/src/network/src/protocols/protocol_version_70002.cpp
@@ -60,7 +60,7 @@ domain::message::version protocol_version_70002::version_factory() const {
 
 bool protocol_version_70002::sufficient_peer(version_const_ptr message) {
     if (message->value() < minimum_version_) {
-        const reject version_rejection {
+        reject const version_rejection {
             reject::reason_code::obsolete,
             version::command,
             insufficient_version
@@ -68,7 +68,7 @@ bool protocol_version_70002::sufficient_peer(version_const_ptr message) {
 
         SEND2(version_rejection, handle_send, _1, reject::command);
     } else if ((message->services() & minimum_services_) != minimum_services_) {
-        const reject obsolete_rejection {
+        reject const obsolete_rejection {
             reject::reason_code::obsolete,
             version::command,
             insufficient_services

--- a/src/network/src/sessions/session_outbound.cpp
+++ b/src/network/src/sessions/session_outbound.cpp
@@ -141,7 +141,7 @@ void session_outbound::handle_channel_stop(code const& ec, channel::ptr channel)
 // Pend outgoing connections so we can detect connection to self.
 
 void session_outbound::start_channel(channel::ptr channel, result_handler handle_started) {
-    const result_handler unpend_handler = BIND3(do_unpend, _1, channel, handle_started);
+    result_handler const unpend_handler = BIND3(do_unpend, _1, channel, handle_started);
 
     auto const ec = pend(channel);
 

--- a/src/node/include/kth/node/full_node.hpp
+++ b/src/node/include/kth/node/full_node.hpp
@@ -513,7 +513,7 @@ private:
     //blockchain::block_chain chain_;
 
 #if ! defined(__EMSCRIPTEN__)
-    const uint32_t protocol_maximum_;
+    uint32_t const protocol_maximum_;
 #endif
 
     const node::settings& node_settings_;

--- a/src/node/include/kth/node/protocols/protocol_header_sync.hpp
+++ b/src/node/include/kth/node/protocols/protocol_header_sync.hpp
@@ -43,7 +43,7 @@ private:
     // This is guarded by protocol_timer/deadline contract (exactly one call).
     size_t current_second_;
 
-    const uint32_t minimum_rate_;
+    uint32_t const minimum_rate_;
     size_t const start_size_;
 };
 

--- a/src/node/include/kth/node/protocols/protocol_transaction_in.hpp
+++ b/src/node/include/kth/node/protocols/protocol_transaction_in.hpp
@@ -39,7 +39,7 @@ private:
 
     // These are thread safe.
     blockchain::safe_chain& chain_;
-    const uint64_t minimum_relay_fee_;
+    uint64_t const minimum_relay_fee_;
     bool const relay_from_peer_;
     bool const refresh_pool_;
 };

--- a/src/node/include/kth/node/utility/check_list.hpp
+++ b/src/node/include/kth/node/utility/check_list.hpp
@@ -26,7 +26,7 @@ struct KND_API check_list {
 
     /// Reserve the entries indicated by the given heights.
     /// Any entry not reserved here will be ignored upon enqueue.
-    void reserve(const heights& heights);
+    void reserve(heights const& heights);
 
     /// Place a hash on the queue at the height if it has a reservation.
     void enqueue(hash_digest&& hash, size_t height);

--- a/src/node/include/kth/node/utility/reservations.hpp
+++ b/src/node/include/kth/node/utility/reservations.hpp
@@ -79,7 +79,7 @@ private:
     // Thread safe.
     check_list& hashes_;
     std::atomic<size_t> max_request_;
-    const uint32_t timeout_;
+    uint32_t const timeout_;
 
     // Protected by block exclusivity and limited call scope.
     blockchain::fast_chain& chain_;

--- a/src/node/src/protocols/protocol_block_out.cpp
+++ b/src/node/src/protocols/protocol_block_out.cpp
@@ -349,7 +349,7 @@ void protocol_block_out::send_block(code const& ec, block_const_ptr message, siz
 
         // TODO: move not_found to derived class protocol_block_out_70001.
         KTH_ASSERT( ! inventory->inventories().empty());
-        const not_found reply{ inventory->inventories().back() };
+        not_found const reply{ inventory->inventories().back() };
         SEND2(reply, handle_send, _1, reply.command);
         handle_send_next(error::success, inventory);
         return;
@@ -375,7 +375,7 @@ void protocol_block_out::send_merkle_block(code const& ec, merkle_block_const_pt
 
         // TODO: move not_found to derived class protocol_block_out_70001.
         KTH_ASSERT( ! inventory->inventories().empty());
-        const not_found reply{ inventory->inventories().back() };
+        not_found const reply{ inventory->inventories().back() };
         SEND2(reply, handle_send, _1, reply.command);
         handle_send_next(error::success, inventory);
         return;
@@ -401,7 +401,7 @@ void protocol_block_out::send_compact_block(code const& ec, compact_block_const_
 
         // TODO: move not_found to derived class protocol_block_out_70001.
         KTH_ASSERT( ! inventory->inventories().empty());
-        const not_found reply{ inventory->inventories().back() };
+        not_found const reply{ inventory->inventories().back() };
         SEND2(reply, handle_send, _1, reply.command);
         handle_send_next(error::success, inventory);
         return;

--- a/src/node/src/protocols/protocol_double_spend_proof_out.cpp
+++ b/src/node/src/protocols/protocol_double_spend_proof_out.cpp
@@ -111,7 +111,7 @@ void protocol_double_spend_proof_out::send_ds_proof(code const& ec, double_spend
         spdlog::debug("[node] DSProof requested by [{}] not found.", authority());
 
         KTH_ASSERT( ! inventory->inventories().empty());
-        const not_found reply{ inventory->inventories().back() };
+        not_found const reply{ inventory->inventories().back() };
         SEND2(reply, handle_send, _1, reply.command);
         handle_send_next(error::success, inventory);
         return;

--- a/src/node/src/protocols/protocol_transaction_out.cpp
+++ b/src/node/src/protocols/protocol_transaction_out.cpp
@@ -175,7 +175,7 @@ void protocol_transaction_out::send_transaction(code const& ec, transaction_cons
 
         // TODO: move not_found to derived class protocol_block_out_70001.
         KTH_ASSERT( ! inventory->inventories().empty());
-        const not_found reply{ inventory->inventories().back() };
+        not_found const reply{ inventory->inventories().back() };
         SEND2(reply, handle_send, _1, reply.command);
         handle_send_next(error::success, inventory);
         return;

--- a/src/node/src/utility/check_list.cpp
+++ b/src/node/src/utility/check_list.cpp
@@ -31,7 +31,7 @@ size_t check_list::size() const {
     ///////////////////////////////////////////////////////////////////////////
 }
 
-void check_list::reserve(const heights& heights) {
+void check_list::reserve(heights const& heights) {
     ///////////////////////////////////////////////////////////////////////////
     // Critical Section
     unique_lock lock(mutex_);

--- a/src/node/src/utility/header_list.cpp
+++ b/src/node/src/utility/header_list.cpp
@@ -133,7 +133,7 @@ bool header_list::link(const domain::chain::header& header) const {
     return header.previous_block_hash() == list_.back().hash();
 }
 
-bool header_list::check(const header& header) const {
+bool header_list::check(header const& header) const {
     // This is a hack for successful compile - this is dead code.
     static auto const retarget = true;
 
@@ -141,7 +141,7 @@ bool header_list::check(const header& header) const {
     return ! header.check(retarget);
 }
 
-bool header_list::accept(const header& header) const {
+bool header_list::accept(header const& header) const {
     //// Parallel header download precludes validation of minimum_version,
     //// work_required and median_time_past, however checkpoints are verified.
     ////return !header.accept(...);

--- a/src/node/src/utility/reservation.cpp
+++ b/src/node/src/utility/reservation.cpp
@@ -145,7 +145,7 @@ void reservation::clear_history() {
 
 // It is possible to get a rate update after idling and before starting anew.
 // This can reduce the average during startup of the new channel until start.
-void reservation::update_rate(size_t events, const microseconds& database) {
+void reservation::update_rate(size_t events, microseconds const& database) {
     // Critical Section
     ///////////////////////////////////////////////////////////////////////////
     history_mutex_.lock();

--- a/src/node/test/utility.cpp
+++ b/src/node/test/utility.cpp
@@ -40,7 +40,7 @@ domain::message::headers::ptr message_factory(size_t count,
     auto& elements = headers->elements();
 
     for (size_t height = 0; height < count; ++height) {
-        const header current_header{ 0, previous_hash, {}, 0, 0, 0 };
+        header const current_header{ 0, previous_hash, {}, 0, 0, 0 };
         elements.push_back(current_header);
         previous_hash = current_header.hash();
     }
@@ -133,7 +133,7 @@ bool blockchain_fixture::get_output(domain::chain::output& out_output,
     return false;
 }
 
-bool blockchain_fixture::get_spender_hash(hash_digest& out_hash, const output_point& outpoint) const {
+bool blockchain_fixture::get_spender_hash(hash_digest& out_hash, output_point const& outpoint) const {
     return false;
 }
 
@@ -159,7 +159,7 @@ bool blockchain_fixture::fill(block_const_ptr block, size_t height) {
     return import_result_;
 }
 
-bool blockchain_fixture::push(const block_const_ptr_list& blocks,
+bool blockchain_fixture::push(block_const_ptr_list const& blocks,
     size_t height) {
     return false;
 }

--- a/src/node/test/utility.hpp
+++ b/src/node/test/utility.hpp
@@ -73,7 +73,7 @@ public:
     // ------------------------------------------------------------------------
     bool stub(header_const_ptr header, size_t height);
     bool fill(block_const_ptr block, size_t height);
-    bool push(const block_const_ptr_list& blocks, size_t height);
+    bool push(block_const_ptr_list const& blocks, size_t height);
     bool pop(block_const_ptr_list& out_blocks, hash_digest const& fork_hash);
 
 private:


### PR DESCRIPTION
## Summary
- Convert west const (`const TYPE`) to east const (`TYPE const`) across the codebase
- Use `constexpr` (west style) for compile-time constants with literal values
- Use `TYPE const` (east style) for runtime values, function parameters, and class members
- Add reusable conversion script at `scripts/east_const.sh`

## Patterns converted
- `const TYPE var` → `TYPE const var`
- `const TYPE& var` → `TYPE const& var`
- `const TYPE* var` → `TYPE const* var`
- `const TYPE<T>& var` → `TYPE<T> const& var`
- `const std::vector<T>& var` → `std::vector<T> const& var`

## Exclusions
External code is excluded: `secp256k1/`, `consensus/`, `external/`

## Test plan
- [ ] Build passes
- [ ] Tests pass
- [ ] Script is idempotent (running again produces no changes)