### PR TITLE
feat(c-api): expose wallet::create_tx_template + create_token_split_tx_template

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -331,7 +331,6 @@ set(kth_headers
   include/kth/capi/u32_list.h
   include/kth/capi/u64_list.h
 
-  include/kth/capi/chain/coin_selection_algorithm.h
   include/kth/capi/chain/opcode.h
   include/kth/capi/chain/operation_list.h
   include/kth/capi/chain/operation.h
@@ -350,6 +349,7 @@ set(kth_headers
   include/kth/capi/wallet/cashaddr.h
   include/kth/capi/wallet/cashtoken_minting.h
   include/kth/capi/wallet/coin_selection.h
+  include/kth/capi/wallet/coin_selection_algorithm.h
   include/kth/capi/wallet/coin_selection_result.h
   include/kth/capi/wallet/coin_selection_strategy.h
   include/kth/capi/wallet/ec_public.h

--- a/src/c-api/include/kth/capi/capi.h
+++ b/src/c-api/include/kth/capi/capi.h
@@ -20,7 +20,6 @@
 #include <kth/capi/chain/block_list.h>
 #include <kth/capi/chain/chain_async.h>
 #include <kth/capi/chain/chain_sync.h>
-#include <kth/capi/chain/coin_selection_algorithm.h>
 #include <kth/capi/chain/compact_block.h>
 #include <kth/capi/chain/double_spend_proof.h>
 #include <kth/capi/chain/double_spend_proof_spender.h>
@@ -100,6 +99,7 @@
 #include <kth/capi/wallet/cashaddr.h>
 #include <kth/capi/wallet/cashtoken_minting.h>
 #include <kth/capi/wallet/coin_selection.h>
+#include <kth/capi/wallet/coin_selection_algorithm.h>
 #include <kth/capi/wallet/coin_selection_result.h>
 #include <kth/capi/wallet/coin_selection_strategy.h>
 #include <kth/capi/wallet/encrypted_keys.h>

--- a/src/c-api/include/kth/capi/helpers.hpp
+++ b/src/c-api/include/kth/capi/helpers.hpp
@@ -29,7 +29,7 @@
 #include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/machine/script_version.hpp>
 
-#include <kth/capi/chain/coin_selection_algorithm.h>
+#include <kth/capi/wallet/coin_selection_algorithm.h>
 #include <kth/capi/wallet/coin_selection_strategy.h>
 #include <kth/domain/wallet/coin_selection.hpp>
 #include <kth/capi/chain/opcode.h>

--- a/src/c-api/include/kth/capi/wallet/coin_selection.h
+++ b/src/c-api/include/kth/capi/wallet/coin_selection.h
@@ -10,6 +10,7 @@
 #include <kth/capi/primitives.h>
 #include <kth/capi/visibility.h>
 #include <kth/capi/wallet/primitives.h>
+#include <kth/capi/wallet/coin_selection_algorithm.h>
 #include <kth/capi/wallet/coin_selection_strategy.h>
 
 #ifdef __cplusplus
@@ -63,6 +64,77 @@ kth_error_code_t kth_wallet_coin_selection_select_utxos_both_unsafe(kth_utxo_lis
 /** @return Owned `kth_double_list_mut_t`. Caller must release with `kth_core_double_list_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_double_list_mut_t kth_wallet_coin_selection_make_change_ratios(kth_size_t change_count);
+
+/**
+ * Build an unsigned BCH-only transaction template by selecting UTXOs and
+ * distributing change across `change_addresses` using `change_ratios`.
+ *
+ * @param destination_address Borrowed; must be non-null.
+ * @param change_addresses Borrowed; must be non-null. Empty list is rejected.
+ * @param change_ratios Borrowed; must be non-null and have the same length as
+ *                     `change_addresses`. Values must sum to 1.0.
+ * @param[out] out_tx        On success, owned `kth_transaction_mut_t` (release via `kth_chain_transaction_destruct`). Untouched on error.
+ * @param[out] out_indices   On success, owned `kth_u32_list_mut_t` of selected UTXO indices (release via `kth_core_u32_list_destruct`). Untouched on error.
+ * @param[out] out_addresses On success, owned `kth_payment_address_list_mut_t` of one address per output (release via `kth_wallet_payment_address_list_destruct`). Untouched on error.
+ * @param[out] out_amounts   On success, owned `kth_u64_list_mut_t` of one BCH amount per output (release via `kth_core_u64_list_destruct`). Untouched on error.
+ */
+KTH_EXPORT
+kth_error_code_t kth_wallet_coin_selection_create_tx_template(
+    kth_utxo_list_const_t available_utxos,
+    uint64_t amount_to_send,
+    kth_payment_address_const_t destination_address,
+    kth_payment_address_list_const_t change_addresses,
+    kth_double_list_const_t change_ratios,
+    kth_coin_selection_algorithm_t selection_algo,
+    KTH_OUT_OWNED kth_transaction_mut_t* out_tx,
+    KTH_OUT_OWNED kth_u32_list_mut_t* out_indices,
+    KTH_OUT_OWNED kth_payment_address_list_mut_t* out_addresses,
+    KTH_OUT_OWNED kth_u64_list_mut_t* out_amounts);
+
+/**
+ * Same as `kth_wallet_coin_selection_create_tx_template` but generates
+ * random change ratios internally (equivalent to calling
+ * `kth_wallet_coin_selection_make_change_ratios` and passing the result).
+ *
+ * @param destination_address Borrowed; must be non-null.
+ * @param change_addresses Borrowed; must be non-null. Empty list is rejected.
+ * @param[out] out_tx        On success, owned `kth_transaction_mut_t` (release via `kth_chain_transaction_destruct`). Untouched on error.
+ * @param[out] out_indices   On success, owned `kth_u32_list_mut_t` of selected UTXO indices (release via `kth_core_u32_list_destruct`). Untouched on error.
+ * @param[out] out_addresses On success, owned `kth_payment_address_list_mut_t` of one address per output (release via `kth_wallet_payment_address_list_destruct`). Untouched on error.
+ * @param[out] out_amounts   On success, owned `kth_u64_list_mut_t` of one BCH amount per output (release via `kth_core_u64_list_destruct`). Untouched on error.
+ */
+KTH_EXPORT
+kth_error_code_t kth_wallet_coin_selection_create_tx_template_default_ratios(
+    kth_utxo_list_const_t available_utxos,
+    uint64_t amount_to_send,
+    kth_payment_address_const_t destination_address,
+    kth_payment_address_list_const_t change_addresses,
+    kth_coin_selection_algorithm_t selection_algo,
+    KTH_OUT_OWNED kth_transaction_mut_t* out_tx,
+    KTH_OUT_OWNED kth_u32_list_mut_t* out_indices,
+    KTH_OUT_OWNED kth_payment_address_list_mut_t* out_addresses,
+    KTH_OUT_OWNED kth_u64_list_mut_t* out_amounts);
+
+/**
+ * Build an unsigned transaction that splits "dirty" token UTXOs into clean
+ * ones (token-only output at dust BCH + a separate BCH-only output for the
+ * freed excess). Only fungible tokens are supported.
+ *
+ * @param outpoints_to_split Borrowed; must be non-null. The dirty outpoints to clean.
+ * @param available_utxos Borrowed; must be non-null. Used to look up the outpoints.
+ * @param destination_address Borrowed; must be non-null.
+ * @param[out] out_tx        On success, owned `kth_transaction_mut_t` (release via `kth_chain_transaction_destruct`). Untouched on error.
+ * @param[out] out_addresses On success, owned `kth_payment_address_list_mut_t` of one address per output (release via `kth_wallet_payment_address_list_destruct`). Untouched on error.
+ * @param[out] out_amounts   On success, owned `kth_u64_list_mut_t` of one BCH amount per output (release via `kth_core_u64_list_destruct`). Untouched on error.
+ */
+KTH_EXPORT
+kth_error_code_t kth_wallet_coin_selection_create_token_split_tx_template(
+    kth_output_point_list_const_t outpoints_to_split,
+    kth_utxo_list_const_t available_utxos,
+    kth_payment_address_const_t destination_address,
+    KTH_OUT_OWNED kth_transaction_mut_t* out_tx,
+    KTH_OUT_OWNED kth_payment_address_list_mut_t* out_addresses,
+    KTH_OUT_OWNED kth_u64_list_mut_t* out_amounts);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/include/kth/capi/wallet/coin_selection_algorithm.h
+++ b/src/c-api/include/kth/capi/wallet/coin_selection_algorithm.h
@@ -4,8 +4,8 @@
 
 // This file is auto-generated. Do not edit manually.
 
-#ifndef KTH_CAPI_CHAIN_COIN_SELECTION_H_
-#define KTH_CAPI_CHAIN_COIN_SELECTION_H_
+#ifndef KTH_CAPI_WALLET_COIN_SELECTION_ALGORITHM_H_
+#define KTH_CAPI_WALLET_COIN_SELECTION_ALGORITHM_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -22,4 +22,4 @@ typedef enum {
 } // extern "C"
 #endif
 
-#endif /* KTH_CAPI_CHAIN_COIN_SELECTION_H_ */
+#endif /* KTH_CAPI_WALLET_COIN_SELECTION_ALGORITHM_H_ */

--- a/src/c-api/src/wallet/coin_selection.cpp
+++ b/src/c-api/src/wallet/coin_selection.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <expected>
+#include <system_error>
 #include <utility>
 
 #include <kth/capi/wallet/coin_selection.h>
@@ -9,6 +11,28 @@
 #include <kth/capi/conversions.hpp>
 #include <kth/capi/helpers.hpp>
 #include <kth/domain/wallet/coin_selection.hpp>
+
+// Both `create_tx_template` overloads return the same
+// `expected<tuple<tx, indices, addresses, amounts>, error_code>` shape
+// and therefore unpack identically. Centralising the unpack here means
+// a future tuple change (extra field, reorder) only edits one site.
+namespace {
+
+kth_error_code_t emit_tx_template_result(
+    std::expected<kth::domain::wallet::tx_template_result, std::error_code>&& result,
+    kth_transaction_mut_t* out_tx,
+    kth_u32_list_mut_t* out_indices,
+    kth_payment_address_list_mut_t* out_addresses,
+    kth_u64_list_mut_t* out_amounts) {
+    if ( ! result) return kth::to_c_err(result.error());
+    *out_tx        = kth::leak(std::move(std::get<0>(*result)));
+    *out_indices   = kth::leak(std::move(std::get<1>(*result)));
+    *out_addresses = kth::leak(std::move(std::get<2>(*result)));
+    *out_amounts   = kth::leak(std::move(std::get<3>(*result)));
+    return kth_ec_success;
+}
+
+} // namespace
 
 // ---------------------------------------------------------------------------
 extern "C" {
@@ -106,6 +130,96 @@ kth_error_code_t kth_wallet_coin_selection_select_utxos_both_unsafe(kth_utxo_lis
 kth_double_list_mut_t kth_wallet_coin_selection_make_change_ratios(kth_size_t change_count) {
     auto const change_count_cpp = kth::sz(change_count);
     return kth::leak_list<double>(kth::domain::wallet::make_change_ratios(change_count_cpp));
+}
+
+kth_error_code_t kth_wallet_coin_selection_create_tx_template(
+    kth_utxo_list_const_t available_utxos,
+    uint64_t amount_to_send,
+    kth_payment_address_const_t destination_address,
+    kth_payment_address_list_const_t change_addresses,
+    kth_double_list_const_t change_ratios,
+    kth_coin_selection_algorithm_t selection_algo,
+    KTH_OUT_OWNED kth_transaction_mut_t* out_tx,
+    KTH_OUT_OWNED kth_u32_list_mut_t* out_indices,
+    KTH_OUT_OWNED kth_payment_address_list_mut_t* out_addresses,
+    KTH_OUT_OWNED kth_u64_list_mut_t* out_amounts) {
+    KTH_PRECONDITION(available_utxos != nullptr);
+    KTH_PRECONDITION(destination_address != nullptr);
+    KTH_PRECONDITION(change_addresses != nullptr);
+    KTH_PRECONDITION(change_ratios != nullptr);
+    KTH_PRECONDITION(out_tx != nullptr);
+    KTH_PRECONDITION(*out_tx == nullptr);
+    KTH_PRECONDITION(out_indices != nullptr);
+    KTH_PRECONDITION(*out_indices == nullptr);
+    KTH_PRECONDITION(out_addresses != nullptr);
+    KTH_PRECONDITION(*out_addresses == nullptr);
+    KTH_PRECONDITION(out_amounts != nullptr);
+    KTH_PRECONDITION(*out_amounts == nullptr);
+    auto available_utxos_cpp = kth::cpp_ref<std::vector<kth::domain::chain::utxo>>(available_utxos);
+    auto const& destination_cpp = kth::cpp_ref<kth::domain::wallet::payment_address>(destination_address);
+    auto const& change_addresses_cpp = kth::cpp_ref<std::vector<kth::domain::wallet::payment_address>>(change_addresses);
+    auto const& change_ratios_cpp = kth::cpp_ref<std::vector<double>>(change_ratios);
+    auto const algo_cpp = kth::coin_selection_algorithm_to_cpp(selection_algo);
+    return emit_tx_template_result(
+        kth::domain::wallet::create_tx_template(std::move(available_utxos_cpp), amount_to_send, destination_cpp, change_addresses_cpp, change_ratios_cpp, algo_cpp),
+        out_tx, out_indices, out_addresses, out_amounts);
+}
+
+kth_error_code_t kth_wallet_coin_selection_create_tx_template_default_ratios(
+    kth_utxo_list_const_t available_utxos,
+    uint64_t amount_to_send,
+    kth_payment_address_const_t destination_address,
+    kth_payment_address_list_const_t change_addresses,
+    kth_coin_selection_algorithm_t selection_algo,
+    KTH_OUT_OWNED kth_transaction_mut_t* out_tx,
+    KTH_OUT_OWNED kth_u32_list_mut_t* out_indices,
+    KTH_OUT_OWNED kth_payment_address_list_mut_t* out_addresses,
+    KTH_OUT_OWNED kth_u64_list_mut_t* out_amounts) {
+    KTH_PRECONDITION(available_utxos != nullptr);
+    KTH_PRECONDITION(destination_address != nullptr);
+    KTH_PRECONDITION(change_addresses != nullptr);
+    KTH_PRECONDITION(out_tx != nullptr);
+    KTH_PRECONDITION(*out_tx == nullptr);
+    KTH_PRECONDITION(out_indices != nullptr);
+    KTH_PRECONDITION(*out_indices == nullptr);
+    KTH_PRECONDITION(out_addresses != nullptr);
+    KTH_PRECONDITION(*out_addresses == nullptr);
+    KTH_PRECONDITION(out_amounts != nullptr);
+    KTH_PRECONDITION(*out_amounts == nullptr);
+    auto available_utxos_cpp = kth::cpp_ref<std::vector<kth::domain::chain::utxo>>(available_utxos);
+    auto const& destination_cpp = kth::cpp_ref<kth::domain::wallet::payment_address>(destination_address);
+    auto const& change_addresses_cpp = kth::cpp_ref<std::vector<kth::domain::wallet::payment_address>>(change_addresses);
+    auto const algo_cpp = kth::coin_selection_algorithm_to_cpp(selection_algo);
+    return emit_tx_template_result(
+        kth::domain::wallet::create_tx_template(std::move(available_utxos_cpp), amount_to_send, destination_cpp, change_addresses_cpp, algo_cpp),
+        out_tx, out_indices, out_addresses, out_amounts);
+}
+
+kth_error_code_t kth_wallet_coin_selection_create_token_split_tx_template(
+    kth_output_point_list_const_t outpoints_to_split,
+    kth_utxo_list_const_t available_utxos,
+    kth_payment_address_const_t destination_address,
+    KTH_OUT_OWNED kth_transaction_mut_t* out_tx,
+    KTH_OUT_OWNED kth_payment_address_list_mut_t* out_addresses,
+    KTH_OUT_OWNED kth_u64_list_mut_t* out_amounts) {
+    KTH_PRECONDITION(outpoints_to_split != nullptr);
+    KTH_PRECONDITION(available_utxos != nullptr);
+    KTH_PRECONDITION(destination_address != nullptr);
+    KTH_PRECONDITION(out_tx != nullptr);
+    KTH_PRECONDITION(*out_tx == nullptr);
+    KTH_PRECONDITION(out_addresses != nullptr);
+    KTH_PRECONDITION(*out_addresses == nullptr);
+    KTH_PRECONDITION(out_amounts != nullptr);
+    KTH_PRECONDITION(*out_amounts == nullptr);
+    auto const& outpoints_cpp = kth::cpp_ref<std::vector<kth::domain::chain::output_point>>(outpoints_to_split);
+    auto const& available_utxos_cpp = kth::cpp_ref<std::vector<kth::domain::chain::utxo>>(available_utxos);
+    auto const& destination_cpp = kth::cpp_ref<kth::domain::wallet::payment_address>(destination_address);
+    auto result = kth::domain::wallet::create_token_split_tx_template(outpoints_cpp, available_utxos_cpp, destination_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out_tx        = kth::leak(std::move(std::get<0>(*result)));
+    *out_addresses = kth::leak(std::move(std::get<1>(*result)));
+    *out_amounts   = kth::leak(std::move(std::get<2>(*result)));
+    return kth_ec_success;
 }
 
 } // extern "C"

--- a/src/c-api/test/wallet/coin_selection.cpp
+++ b/src/c-api/test/wallet/coin_selection.cpp
@@ -13,15 +13,22 @@
 #include <stdint.h>
 
 #include <kth/capi/chain/output_point.h>
+#include <kth/capi/chain/output_point_list.h>
 #include <kth/capi/chain/token_data.h>
+#include <kth/capi/chain/transaction.h>
 #include <kth/capi/chain/utxo.h>
 #include <kth/capi/chain/utxo_list.h>
 #include <kth/capi/double_list.h>
 #include <kth/capi/hash.h>
 #include <kth/capi/primitives.h>
+#include <kth/capi/u32_list.h>
+#include <kth/capi/u64_list.h>
 #include <kth/capi/wallet/coin_selection.h>
+#include <kth/capi/wallet/coin_selection_algorithm.h>
 #include <kth/capi/wallet/coin_selection_result.h>
 #include <kth/capi/wallet/coin_selection_strategy.h>
+#include <kth/capi/wallet/payment_address.h>
+#include <kth/capi/wallet/payment_address_list.h>
 
 #include "../test_helpers.hpp"
 
@@ -228,4 +235,184 @@ TEST_CASE("C-API wallet::coin_selection - select_utxos(NULL out) aborts",
         utxos, 1u, 1u, &kBchCategory,
         kth_coin_selection_strategy_clean, NULL));
     kth_chain_utxo_list_destruct(utxos);
+}
+
+// ---------------------------------------------------------------------------
+// create_tx_template — happy path + preconditions
+// ---------------------------------------------------------------------------
+
+// Real, parse-able mainnet P2PKH addresses. Default-constructed
+// payment_address objects are rejected by the domain layer, so tests
+// must use addresses that round-trip through the legacy CashAddr
+// decoder.
+static char const* const kAddrDest =
+    "bitcoincash:qpzz8n7jp6847yyx8t33matrgcsdx6c0cvmtevrfgz";
+static char const* const kAddrChange1 =
+    "bitcoincash:qrhea03074073ff3zv9whh0nggxc7k03ssh8jv9mkx";
+static char const* const kAddrChange2 =
+    "bitcoincash:qz4t90ackhtsdcz5e7sf6sszphpv2t5ucslvfvkavn";
+
+TEST_CASE("C-API wallet::coin_selection - create_tx_template builds a tx with explicit ratios",
+          "[C-API WalletCoinSelection][create_tx_template]") {
+    uint64_t const amounts[] = { 100000u, 200000u, 300000u };
+    kth_utxo_list_mut_t utxos = make_bch_utxos(amounts, 3);
+
+    kth_payment_address_mut_t dest    = kth_wallet_payment_address_construct_from_address(kAddrDest);
+    kth_payment_address_mut_t change1 = kth_wallet_payment_address_construct_from_address(kAddrChange1);
+    kth_payment_address_mut_t change2 = kth_wallet_payment_address_construct_from_address(kAddrChange2);
+    kth_payment_address_list_mut_t change_addrs = kth_wallet_payment_address_list_construct_default();
+    kth_wallet_payment_address_list_push_back(change_addrs, change1);
+    kth_wallet_payment_address_list_push_back(change_addrs, change2);
+
+    kth_double_list_mut_t ratios = kth_core_double_list_construct_default();
+    kth_core_double_list_push_back(ratios, 0.4);
+    kth_core_double_list_push_back(ratios, 0.6);
+
+    kth_transaction_mut_t          out_tx        = NULL;
+    kth_u32_list_mut_t             out_indices   = NULL;
+    kth_payment_address_list_mut_t out_addresses = NULL;
+    kth_u64_list_mut_t             out_amounts   = NULL;
+
+    kth_error_code_t ec = kth_wallet_coin_selection_create_tx_template(
+        utxos, 50000u, dest, change_addrs, ratios,
+        kth_coin_selection_algorithm_largest_first,
+        &out_tx, &out_indices, &out_addresses, &out_amounts);
+
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(out_tx != NULL);
+    REQUIRE(out_indices != NULL);
+    REQUIRE(out_addresses != NULL);
+    REQUIRE(out_amounts != NULL);
+    // One destination output + two change outputs = 3.
+    REQUIRE(kth_wallet_payment_address_list_count(out_addresses) == 3u);
+    REQUIRE(kth_core_u64_list_count(out_amounts) == 3u);
+    // At least one input was selected to cover the 50000 sat target.
+    REQUIRE(kth_core_u32_list_count(out_indices) >= 1u);
+
+    kth_chain_transaction_destruct(out_tx);
+    kth_core_u32_list_destruct(out_indices);
+    kth_wallet_payment_address_list_destruct(out_addresses);
+    kth_core_u64_list_destruct(out_amounts);
+
+    kth_core_double_list_destruct(ratios);
+    kth_wallet_payment_address_list_destruct(change_addrs);
+    kth_wallet_payment_address_destruct(change2);
+    kth_wallet_payment_address_destruct(change1);
+    kth_wallet_payment_address_destruct(dest);
+    kth_chain_utxo_list_destruct(utxos);
+}
+
+TEST_CASE("C-API wallet::coin_selection - create_tx_template_default_ratios builds a tx",
+          "[C-API WalletCoinSelection][create_tx_template]") {
+    uint64_t const amounts[] = { 100000u, 200000u, 300000u };
+    kth_utxo_list_mut_t utxos = make_bch_utxos(amounts, 3);
+
+    kth_payment_address_mut_t dest    = kth_wallet_payment_address_construct_from_address(kAddrDest);
+    kth_payment_address_mut_t change1 = kth_wallet_payment_address_construct_from_address(kAddrChange1);
+    kth_payment_address_list_mut_t change_addrs = kth_wallet_payment_address_list_construct_default();
+    kth_wallet_payment_address_list_push_back(change_addrs, change1);
+
+    kth_transaction_mut_t          out_tx        = NULL;
+    kth_u32_list_mut_t             out_indices   = NULL;
+    kth_payment_address_list_mut_t out_addresses = NULL;
+    kth_u64_list_mut_t             out_amounts   = NULL;
+
+    kth_error_code_t ec = kth_wallet_coin_selection_create_tx_template_default_ratios(
+        utxos, 50000u, dest, change_addrs,
+        kth_coin_selection_algorithm_largest_first,
+        &out_tx, &out_indices, &out_addresses, &out_amounts);
+
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(out_tx != NULL);
+    REQUIRE(out_indices != NULL);
+    REQUIRE(out_addresses != NULL);
+    REQUIRE(out_amounts != NULL);
+
+    kth_chain_transaction_destruct(out_tx);
+    kth_core_u32_list_destruct(out_indices);
+    kth_wallet_payment_address_list_destruct(out_addresses);
+    kth_core_u64_list_destruct(out_amounts);
+
+    kth_wallet_payment_address_list_destruct(change_addrs);
+    kth_wallet_payment_address_destruct(change1);
+    kth_wallet_payment_address_destruct(dest);
+    kth_chain_utxo_list_destruct(utxos);
+}
+
+TEST_CASE("C-API wallet::coin_selection - create_tx_template(NULL utxos) aborts",
+          "[C-API WalletCoinSelection][precondition]") {
+    kth_payment_address_mut_t dest = kth_wallet_payment_address_construct_from_address(kAddrDest);
+    kth_payment_address_list_mut_t change_addrs = kth_wallet_payment_address_list_construct_default();
+    kth_double_list_mut_t ratios = kth_core_double_list_construct_default();
+    kth_transaction_mut_t          out_tx        = NULL;
+    kth_u32_list_mut_t             out_indices   = NULL;
+    kth_payment_address_list_mut_t out_addresses = NULL;
+    kth_u64_list_mut_t             out_amounts   = NULL;
+    KTH_EXPECT_ABORT(kth_wallet_coin_selection_create_tx_template(
+        NULL, 1u, dest, change_addrs, ratios,
+        kth_coin_selection_algorithm_smallest_first,
+        &out_tx, &out_indices, &out_addresses, &out_amounts));
+    kth_core_double_list_destruct(ratios);
+    kth_wallet_payment_address_list_destruct(change_addrs);
+    kth_wallet_payment_address_destruct(dest);
+}
+
+TEST_CASE("C-API wallet::coin_selection - create_tx_template(NULL out_tx) aborts",
+          "[C-API WalletCoinSelection][precondition]") {
+    uint64_t const amounts[] = { 100000u };
+    kth_utxo_list_mut_t utxos = make_bch_utxos(amounts, 1);
+    kth_payment_address_mut_t dest = kth_wallet_payment_address_construct_from_address(kAddrDest);
+    kth_payment_address_list_mut_t change_addrs = kth_wallet_payment_address_list_construct_default();
+    kth_double_list_mut_t ratios = kth_core_double_list_construct_default();
+    kth_u32_list_mut_t             out_indices   = NULL;
+    kth_payment_address_list_mut_t out_addresses = NULL;
+    kth_u64_list_mut_t             out_amounts   = NULL;
+    KTH_EXPECT_ABORT(kth_wallet_coin_selection_create_tx_template(
+        utxos, 1u, dest, change_addrs, ratios,
+        kth_coin_selection_algorithm_smallest_first,
+        NULL, &out_indices, &out_addresses, &out_amounts));
+    kth_core_double_list_destruct(ratios);
+    kth_wallet_payment_address_list_destruct(change_addrs);
+    kth_wallet_payment_address_destruct(dest);
+    kth_chain_utxo_list_destruct(utxos);
+}
+
+// ---------------------------------------------------------------------------
+// create_token_split_tx_template — preconditions
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::coin_selection - create_token_split_tx_template(NULL outpoints) aborts",
+          "[C-API WalletCoinSelection][precondition]") {
+    kth_utxo_list_mut_t utxos = kth_chain_utxo_list_construct_default();
+    kth_payment_address_mut_t dest = kth_wallet_payment_address_construct_from_address(kAddrDest);
+    kth_transaction_mut_t          out_tx        = NULL;
+    kth_payment_address_list_mut_t out_addresses = NULL;
+    kth_u64_list_mut_t             out_amounts   = NULL;
+    KTH_EXPECT_ABORT(kth_wallet_coin_selection_create_token_split_tx_template(
+        NULL, utxos, dest, &out_tx, &out_addresses, &out_amounts));
+    kth_wallet_payment_address_destruct(dest);
+    kth_chain_utxo_list_destruct(utxos);
+}
+
+TEST_CASE("C-API wallet::coin_selection - create_token_split_tx_template(empty outpoints) returns error",
+          "[C-API WalletCoinSelection][create_token_split]") {
+    kth_output_point_list_mut_t outpoints = kth_chain_output_point_list_construct_default();
+    kth_utxo_list_mut_t utxos = kth_chain_utxo_list_construct_default();
+    kth_payment_address_mut_t dest = kth_wallet_payment_address_construct_from_address(kAddrDest);
+    kth_transaction_mut_t          out_tx        = NULL;
+    kth_payment_address_list_mut_t out_addresses = NULL;
+    kth_u64_list_mut_t             out_amounts   = NULL;
+
+    kth_error_code_t ec = kth_wallet_coin_selection_create_token_split_tx_template(
+        outpoints, utxos, dest, &out_tx, &out_addresses, &out_amounts);
+
+    // Empty outpoint list is an error condition; out params untouched.
+    REQUIRE(ec != kth_ec_success);
+    REQUIRE(out_tx == NULL);
+    REQUIRE(out_addresses == NULL);
+    REQUIRE(out_amounts == NULL);
+
+    kth_wallet_payment_address_destruct(dest);
+    kth_chain_utxo_list_destruct(utxos);
+    kth_chain_output_point_list_destruct(outpoints);
 }


### PR DESCRIPTION
Closes #205.

PR #201 moved coin selection from `chain::transaction` static methods to a `wallet::coin_selection` module. The selection primitives (`select_utxos` / `_send_all` / `_both`) shipped in PR #312, but the higher-level template builders — the ones consumers actually call to assemble unsigned transactions — were still missing on the C surface. This PR closes that gap and the issue.

## What's new

Three functions under `kth_wallet_coin_selection_*`:

- **`create_tx_template`** — runs UTXO selection and emits an unsigned BCH transaction, distributing change across N addresses by explicit ratios. Returns `(tx, selected_indices, output_addresses, output_amounts)` via four `KTH_OUT_OWNED` slots.
- **`create_tx_template_default_ratios`** — overload that synthesises random ratios internally; mirrors the C++ overload.
- **`create_token_split_tx_template`** — splits "dirty" token UTXOs (token + non-dust BCH in the same output) into a clean token output plus a separate BCH output, so wallets that can't spend mixed outputs can recover the trapped BCH. Returns `(tx, output_addresses, output_amounts)`.

`expected<tuple<...>, error_code>` is unpacked into separate out-params following the same convention as `kth_vm_program_pop_ternary`, so consumers don't have to learn a new return shape.

## Cleanup bundled in

`kth_coin_selection_algorithm_t` moves from `capi/chain/coin_selection_algorithm.h` to `capi/wallet/coin_selection_algorithm.h`. The chain/ location was a leftover from when coin selection lived on `chain::transaction`; putting it next to the rest of the coin_selection surface makes the include graph match the namespace. `capi.h`, `helpers.hpp`, and `CMakeLists.txt` are updated to follow the move. No compat shim — there are no in-tree consumers of the old path beyond `capi.h` itself.

## Tests

- Happy path for both `create_tx_template` overloads (verifies output count = 1 destination + N change, indices count >= 1, all four out handles non-NULL).
- Empty-outpoint error path for `create_token_split_tx_template` (verifies `out_*` stay NULL on error).
- NULL preconditions for `utxos`, `out_tx`, and the `outpoints` arg of the split variant.

## Test plan
- [ ] CI green on Linux + macOS sanitizers.
- [ ] Coverage report still produces (no new gcovr regression on the added TUs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transaction template creation with configurable coin selection algorithms
  * Support for multi-address change distribution with custom or default ratios
  * Added token split template builder for fungible token transactions

* **Tests**
  * Added comprehensive test coverage for transaction template creation and token splitting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new C-API entry points that construct unsigned transactions and manipulate UTXO selection outputs; correctness issues could lead to malformed templates or incorrect change/token handling. Changes are localized but touch wallet transaction-building surfaces and public headers.
> 
> **Overview**
> Adds new C-API functions in `wallet/coin_selection` to build unsigned transaction templates: `kth_wallet_coin_selection_create_tx_template` (explicit change ratios), `kth_wallet_coin_selection_create_tx_template_default_ratios`, and `kth_wallet_coin_selection_create_token_split_tx_template` (split mixed token/BCH UTXOs), returning owned handles via out-params.
> 
> Moves `kth_coin_selection_algorithm_t`’s public header from `chain/` to `wallet/` and updates `CMakeLists.txt`, `capi.h`, and `helpers.hpp` includes accordingly. Extends `test/wallet/coin_selection.cpp` with happy-path coverage for both template builders plus precondition/error-path checks (including empty outpoints leaving out-params untouched).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0bd09f192965e98af841780b07c02d2158dee83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->