### PR TITLE
docs: README overhaul + extract version history

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,129 +1,138 @@
-# knuth <a target="_blank" href="https://github.com/k-nuth/kth-mono/releases">![GitHub Releases][badge.release]</a> <a target="_blank" href="https://github.com/k-nuth/kth-mono/actions">![Build status][badge.GithubActions]</a> <a href="#">![CPP][badge.cpp]</a> <a target="_blank" href="https://deepwiki.com/k-nuth/kth">![Ask DeepWiki][badge.deepwiki]</a> <a target="_blank" href="https://t.me/knuth_cash">![Telegram][badge.telegram]</a>
+# knuth <a target="_blank" href="https://github.com/k-nuth/kth/releases">![GitHub Releases][badge.release]</a> <a target="_blank" href="https://github.com/k-nuth/kth/actions">![Build status][badge.GithubActions]</a> <a href="#">![CPP][badge.cpp]</a> <a target="_blank" href="https://deepwiki.com/k-nuth/kth">![Ask DeepWiki][badge.deepwiki]</a> <a target="_blank" href="https://t.me/knuth_cash">![Telegram][badge.telegram]</a>
 
-> High performance Bitcoin development platform.
+> High-performance Bitcoin Cash development platform.
 
-Knuth is a high performance implementation of the Bitcoin protocol focused on users requiring extra performance and flexibility, what makes it the best platform for wallets, exchanges, block explorers and miners.
+Knuth is a high-performance implementation of the Bitcoin protocol aimed at users that need extra performance and flexibility — wallets, exchanges, block explorers and miners.
 
 ## Not just a node
 
-Knuth is a multi-crypto full node, but it is also a development platform.
+Knuth is a multi-crypto full node, but also a development platform.
 
-Knuth's core is written in C++23, on top of it we provide a set of libraries and modules written in various programming languages that you can use as basis for building your application.
+The core is written in C++23. On top of it we ship a set of libraries and modules in several languages that you can use as the foundation for your own application:
 
-At the moment we have libraries in the following languages: [C++](https://github.com/k-nuth/kth-mono/tree/master/src/node), [C](https://github.com/k-nuth/kth-mono/tree/master/src/c-api), [Javascript](https://github.com/k-nuth/js-api), [TypeScript](https://github.com/k-nuth/js-api), [JS/TS WebAssembly](https://github.com/k-nuth/js-wasm), [C#](https://github.com/k-nuth/cs-api) and [Python](https://github.com/k-nuth/py-api).
-You can build your own library in the language of your choice on top of our [C library](https://github.com/k-nuth/kth-mono/tree/master/src/c-api).
+[C++](https://github.com/k-nuth/kth/tree/master/src/node) · [C](https://github.com/k-nuth/kth/tree/master/src/c-api) · [JavaScript](https://github.com/k-nuth/js-api) · [TypeScript](https://github.com/k-nuth/js-api) · [JS/TS WebAssembly](https://github.com/k-nuth/js-wasm) · [C#](https://github.com/k-nuth/cs-api) · [Python](https://github.com/k-nuth/py-api)
+
+You can also build your own binding in any language on top of our [C library](https://github.com/k-nuth/kth/tree/master/src/c-api).
 
 ## Core Components
 
-Knuth provides multiple ways to use the platform:
+### 🏗️ Core Infrastructure (this repository)
 
-### 🏗️ Core Infrastructure (This Repository)
+#### 🚀 Node Executable
+The complete Bitcoin Cash node, ready to run. Suitable as a standalone full node, miner backend, or as the storage tier for an application that needs blockchain access.
 
-### 🚀 Node Executable
-The complete Bitcoin node that you can run out of the box. Perfect for running a full node, mining, or as a backend for applications that need blockchain access.
+#### 🔧 C++ Library
+The C++23 library at the core of the node, exposing direct access to every protocol primitive. This is the layer to use when you want maximum performance and the full surface area.
 
-### 🔧 C++ Library
-A high-performance C++23 library that gives you direct access to all Bitcoin protocol functionality. Ideal for building performance-critical applications.
+#### 🌐 C API
+A stable C ABI on top of the C++ library. This is the foundation every other-language binding builds on, and the layer to use from C, language bindings, FFI, or anything that prefers a versioned C interface to a templated C++ one.
 
-### 🌐 C API
-A stable C interface that provides access to all core functionality and serves as the foundation for bindings in other programming languages.
+### 🌍 Language bindings (separate repositories)
 
-### 🌍 Language Bindings (Separate Repositories)
+Built on top of the C API:
 
-Built on top of the C API, these bindings allow you to use Knuth from your preferred programming language:
+| Language | Repository | Notes |
+|---|---|---|
+| 🟨 JavaScript / TypeScript | [`js-api`](https://github.com/k-nuth/js-api) | Full-featured Node.js binding |
+| 🟦 WebAssembly (browser) | [`js-wasm`](https://github.com/k-nuth/js-wasm) | Browser-compatible WASM binding |
+| 🟣 C# | [`cs-api`](https://github.com/k-nuth/cs-api) | .NET on Windows, Linux and macOS |
+| 🐍 Python | [`py-api`](https://github.com/k-nuth/py-api) | Pythonic interface |
 
-### 🟨 JavaScript & TypeScript
-- **[JavaScript API](https://github.com/k-nuth/js-api)** - Full-featured Node.js binding
-- **[WebAssembly](https://github.com/k-nuth/js-wasm)** - Browser-compatible WebAssembly binding
+## 📚 Documentation
 
-### 🟣 C# 
-- **[C# API](https://github.com/k-nuth/cs-api)** - .NET binding for Windows, Linux, and macOS
-
-### 🐍 Python
-- **[Python API](https://github.com/k-nuth/py-api)** - Pythonic interface to Knuth functionality
+- **Project site & guides**: [kth.cash/docs](https://kth.cash/docs/)
+- **Ask DeepWiki**: [deepwiki.com/k-nuth/kth](https://deepwiki.com/k-nuth/kth) — auto-generated, conversational documentation indexed over the codebase. Useful when you want to ask "where is X handled?" or "show me an example of Y" without grepping the tree yourself.
+- **Branch & contribution conventions**: [`docs/BRANCH_CONVENTIONS.md`](docs/BRANCH_CONVENTIONS.md)
+- **Build with tests**: [`docs/BUILD_WITH_TESTS.md`](docs/BUILD_WITH_TESTS.md)
+- **Version history & repo transition**: [`docs/VERSION_HISTORY.md`](docs/VERSION_HISTORY.md)
 
 ## 🧪 Testing
 
-Knuth includes comprehensive test suites that run automatically during builds and in CI/CD. Tests are enabled by default in all build configurations.
+Knuth ships a comprehensive test suite that runs automatically during builds and in CI. Tests are enabled by default in every build configuration.
 
-### Running Tests
+The build scripts take a Conan package version as their first argument (it gets stamped into the lockfile, not the binary). Substitute `<VERSION>` with the latest release tag from [GitHub Releases](https://github.com/k-nuth/kth/releases) — or any string if you only care about a local dev build.
 
 ```bash
 # Build and test (Release)
-./scripts/build.sh 1.0.0
+./scripts/build.sh <VERSION>
 
-# Build and test (Debug)  
-./scripts/build-debug.sh 1.0.0
+# Build and test (Debug)
+./scripts/build-debug.sh <VERSION>
 
 # Run only tests (after building)
 ./scripts/run-tests.sh
 
 # Test-focused build
-./scripts/test.sh 1.0.0
+./scripts/test.sh <VERSION>
 ```
 
-For detailed testing information, see [BUILD_WITH_TESTS.md](docs/BUILD_WITH_TESTS.md).
+For details, see [`docs/BUILD_WITH_TESTS.md`](docs/BUILD_WITH_TESTS.md).
 
 ## Getting Started
 
 ### Prerequisites
 
-All Knuth components are now available through a single unified package:
+Every Knuth component is published as a single unified Conan package.
 
-1. Install and configure the Knuth build helper:
-```bash
-$ pip install kthbuild --user --upgrade
-$ conan config install https://github.com/k-nuth/ci-utils/raw/master/conan/config2023.zip
-```
+1. Install the build helper:
+   ```bash
+   $ pip install kthbuild --user --upgrade
+   $ conan config install https://github.com/k-nuth/ci-utils/raw/master/conan/config2023.zip
+   ```
 
-2. Install the unified Knuth package:
-```bash
-$ conan install --requires=kth/0.68.0 --update --deployer=direct_deploy
-```
+2. Install the unified Knuth package. Replace `<VERSION>` with the latest release tag from [GitHub Releases](https://github.com/k-nuth/kth/releases):
+   ```bash
+   $ conan install --requires=kth/<VERSION> --update --deployer=direct_deploy
+   ```
 
-This single installation provides you with:
-- `bin/kth` - The node executable
-- `lib/` - All static libraries (libnode.a, libc-api.a, etc.)
-- `include/kth/` - C++ headers and C API headers
+The deployment lays out:
 
-### 🚀 Running the Node Executable
+- `bin/kth` — the node executable
+- `lib/` — every static library (`libnode.a`, `libc-api.a`, …)
+- `include/kth/` — C++ and C API headers
 
-After installation, you can immediately run the full Bitcoin node:
+### 🚀 Running the node executable
 
 ```bash
 # Run the node
 $ ./kth/bin/kth
 ```
 
-### 🔧 Using the C++ Library
+### 🔧 Using the C++ library
 
-For C++ developers, link against the appropriate libraries:
+The example below constructs a node with mainnet defaults and queries the current chain tip from the local database. No `config.cfg` file required — the `configuration` constructor pulls in the network defaults for you.
 
 ```cpp
 // example.cpp
+#include <print>
+
 #include <kth/node.hpp>
+#include <kth/node/executor/executor.hpp>
+#include <kth/domain/config/network.hpp>
 
 int main() {
-    kth::node::node node{"config.cfg"};
-    node.initchain();
-    node.run();
-    
-    auto& chain = node.chain();
-    auto height = chain.get_last_height();
-    
-    std::println("Current height: {}", height);
+    // Mainnet defaults — equivalent to what the node-exe ships with.
+    kth::node::configuration cfg{kth::domain::config::network::mainnet};
+    kth::node::executor node{cfg};
+
+    std::size_t height = 0;
+    if (node.node().chain().get_last_height(height)) {
+        std::println("Current height: {}", height);
+    }
     return 0;
 }
 ```
 
-When compiling, link against the static libraries found in `lib/`:
+Compile against the static libraries shipped under `lib/`:
+
 ```bash
-$ g++ -std=c++23 example.cpp -I./kth/include -L./kth/lib -lnode -lblockchain -ldomain -linfrastructure
+$ g++ -std=c++23 example.cpp -I./kth/include -L./kth/lib \
+    -lnode -lblockchain -ldomain -linfrastructure
 ```
 
 ### 🌐 Using the C API
 
-For C developers or language bindings:
+The C API mirrors the same pattern: `kth_config_settings_default(kth_network_mainnet)` returns a pre-populated settings struct that you hand to `kth_node_construct`.
 
 ```c
 // hello_knuth.c
@@ -132,142 +141,73 @@ For C developers or language bindings:
 #include <stdio.h>
 #include <kth/capi.h>
 
-int main() {
-    // Create and configure node
-    kth_node_t node = kth_node_construct("config.cfg", stdout, stderr);
-    
-    // Initialize blockchain database
-    kth_node_initchain(node);
-    
-    // Run the node
-    kth_node_run_wait(node);
-    
-    // Get blockchain interface
+int main(void) {
+    // Mainnet defaults; no config file required.
+    kth_settings settings = kth_config_settings_default(kth_network_mainnet);
+    kth_node_t node = kth_node_construct(&settings, /*stdout_enabled=*/1);
+
     kth_chain_t chain = kth_node_get_chain(node);
-    
-    // Query current height
-    uint64_t height;
-    kth_chain_sync_last_height(chain, &height);
-    printf("Current height: %" PRIu64 "\n", height);
-    
-    // Cleanup
+    kth_size_t height = 0;
+    if (kth_chain_sync_last_height(chain, &height) == kth_ec_success) {
+        printf("Current height: %" PRIu64 "\n", (uint64_t)height);
+    }
+
     kth_node_destruct(node);
     return 0;
 }
 ```
 
-When compiling, link against the C API library:
+Link against the C API library:
+
 ```bash
 $ gcc hello_knuth.c -I./kth/include -L./kth/lib -lc-api
 ```
 
-For more detailed instructions, please refer to our [documentation](https://kth.cash/docs/).
+For deeper guides see the [project documentation](https://kth.cash/docs/).
 
 ## Releases
 
-<img width="50px" src="https://github.com/k-nuth/cs-api/raw/master/docs/images/kth-purple.png" /> <img src="https://img.shields.io/github/v/release/k-nuth/kth-mono?display_name=tag&style=for-the-badge&color=3b009b&logo=bitcoincash" />
+Latest release across the family:
 
-<img alt="C++" src="https://kth.cash/images/libraries/cpp.svg" width="35" height="35" /> <img src="https://img.shields.io/github/v/release/k-nuth/kth-mono?display_name=tag&style=for-the-badge&color=00599C&logo=cplusplus" />
+| Component | Version |
+|---|---|
+| <img alt="kth" src="https://github.com/k-nuth/cs-api/raw/master/docs/images/kth-purple.png" width="35" height="35" /> Mono-repo | <img src="https://img.shields.io/github/v/release/k-nuth/kth?display_name=tag&style=for-the-badge&color=3b009b&logo=bitcoincash" /> |
+| <img alt="C++" src="https://kth.cash/images/libraries/cpp.svg" width="35" height="35" /> C++ | <img src="https://img.shields.io/github/v/release/k-nuth/kth?display_name=tag&style=for-the-badge&color=00599C&logo=cplusplus" /> |
+| <img alt="C" src="https://kth.cash/images/libraries/c.svg" width="35" height="35" /> C | <img src="https://img.shields.io/github/v/release/k-nuth/kth?display_name=tag&style=for-the-badge&color=A8B9CC&logo=c" /> |
+| <img alt="JavaScript / TypeScript" src="https://kth.cash/images/libraries/javascript.svg" width="35" height="35" /> JS / TS (`@knuth/bch`) | <img src="https://img.shields.io/npm/v/@knuth/bch?logo=npm&style=for-the-badge" /> |
+| <img alt="JS/TS WebAssembly" src="https://kth.cash/images/libraries/wasm.svg" width="35" height="35" /> JS / TS WebAssembly (`@knuth/js-wasm`) | <img src="https://img.shields.io/npm/v/@knuth/js-wasm?logo=npm&style=for-the-badge" /> |
+| <img alt="C#" src="https://kth.cash/images/libraries/csharp.svg" width="35" height="35" /> C# (NuGet `kth-bch`) | <img src="https://img.shields.io/nuget/v/kth-bch?logo=nuget&label=release&style=for-the-badge" /> |
+| <img alt="Python" src="https://kth.cash/images/libraries/python.svg" width="35" height="35" /> Python (PyPI `kth`) | <img src="https://img.shields.io/pypi/v/kth?logo=python&style=for-the-badge&color=3776AB" /> |
 
-<img alt="C" src="https://kth.cash/images/libraries/c.svg" width="35" height="35" /> <img src="https://img.shields.io/github/v/release/k-nuth/kth-mono?display_name=tag&style=for-the-badge&color=A8B9CC&logo=c" />
-
-<img alt="Javascript" src="https://kth.cash/images/libraries/javascript.svg" width="35" height="35" /> <img alt="TypeScript" src="https://kth.cash/images/libraries/typescript.svg" width="35" height="35" /> <img src="https://img.shields.io/npm/v/@knuth/bch?logo=npm&style=for-the-badge" />
-
-<img alt="JS/TS WebAssembly" src="https://kth.cash/images/libraries/wasm.svg" width="35" height="35" /> <img src="https://img.shields.io/npm/v/@knuth/js-wasm?logo=npm&style=for-the-badge" />
-
-<img alt="C#" src="https://kth.cash/images/libraries/csharp.svg" width="35" height="35" /> <img src="https://img.shields.io/nuget/v/kth-bch?logo=nuget&label=release&style=for-the-badge" />
-
-<img alt="Python" src="https://kth.cash/images/libraries/python.svg" width="35" height="35" /> <img src="https://img.shields.io/pypi/v/kth?logo=python&style=for-the-badge&color=3776AB" />
+For the story behind the version numbers (and why Node appears to "skip" 0.59 → 0.67), see [`docs/VERSION_HISTORY.md`](docs/VERSION_HISTORY.md).
 
 ## Key Features
 
 ### Performance matters
 
-We designed Knuth to be a high performance node, so our build system has the ability to automatically detect the microarchitecture of your processor and perform an optimized build for it.
-
-For those who don't want to wait for compilation times, we provide pre-built binaries compatible with [Intel's Haswell microarchitecture](https://en.wikipedia.org/wiki/Haswell_(microarchitecture)). But you don't have to worry about that, our build system will do everything for you.
+Knuth was built as a high-performance node. The build system can detect the microarchitecture of your processor at build time and produce an optimized binary for it. If you don't want to wait for compilation, we ship pre-built binaries targeting [Intel's Haswell microarchitecture](https://en.wikipedia.org/wiki/Haswell_(microarchitecture)). The build system handles the choice automatically.
 
 ### Modular architecture
 
-Knuth is based on a modular architecture simple to modify, expand and learn.
-Any protocol change can be introduced in Knuth much faster and more efficiently than in reference implementations.
+The codebase is organized as a set of focused modules — `infrastructure`, `domain`, `consensus`, `database`, `blockchain`, `network`, `node`, `c-api`. Each one is small enough to read in an afternoon and replace if you need to. Protocol changes can be introduced in Knuth significantly faster than in monolithic reference implementations.
 
 ### Cross-platform
 
-Knuth can be used in any computer architecture and operating system, it only requires a 64-bit system.
-
-Knuth has been well tested on x86-64 processors and on the following operating systems: FreeBSD, Linux, macOS and Windows. However, it is not limited to these, Knuth can be used in any computer architecture and any operating system, the only requirement is a 64-bit system.
-
-If you find a problem in any other platform, please [let us know](https://github.com/k-nuth/kth-mono/issues).
+Knuth runs on any 64-bit system. We routinely test x86-64 on FreeBSD, Linux, macOS and Windows; ARM64 on macOS is also part of the CI matrix. If you hit a problem on a platform that isn't in the matrix, please [let us know](https://github.com/k-nuth/kth/issues).
 
 ## Language Bindings
 
-<a href="https://github.com/k-nuth/kth-mono/tree/master/src/node"><img alt="C++" src="https://kth.cash/images/libraries/cpp.svg" width="120" height="120" /></a>
-<a href="https://github.com/k-nuth/kth-mono/tree/master/src/c-api"><img alt="C" src="https://kth.cash/images/libraries/c.svg" width="120" height="120" /></a>
-<a href="https://github.com/k-nuth/js-api"><img alt="Javascript" src="https://kth.cash/images/libraries/javascript.svg" width="120" height="120" /></a>
-<a href="https://github.com/k-nuth/js-api"><img alt="TypeScript" src="https://kth.cash/images/libraries/typescript.svg" width="120" height="120" /></a>
-<a href="https://github.com/k-nuth/js-wasm"><img alt="JS/TS WebAssembly" src="https://kth.cash/images/libraries/wasm.svg" width="120" height="120" /></a>
-<a href="https://github.com/k-nuth/cs-api"><img alt="C#" src="https://kth.cash/images/libraries/csharp.svg" width="120" height="120" /></a>
-<a href="https://github.com/k-nuth/py-api"><img alt="Python" src="https://kth.cash/images/libraries/python.svg" width="120" height="120" /></a>
+<a href="https://github.com/k-nuth/kth/tree/master/src/node"><img alt="C++" src="https://kth.cash/images/libraries/cpp.svg" width="80" height="80" /></a>
+<a href="https://github.com/k-nuth/kth/tree/master/src/c-api"><img alt="C" src="https://kth.cash/images/libraries/c.svg" width="80" height="80" /></a>
+<a href="https://github.com/k-nuth/js-api"><img alt="JavaScript" src="https://kth.cash/images/libraries/javascript.svg" width="80" height="80" /></a>
+<a href="https://github.com/k-nuth/js-api"><img alt="TypeScript" src="https://kth.cash/images/libraries/typescript.svg" width="80" height="80" /></a>
+<a href="https://github.com/k-nuth/js-wasm"><img alt="JS/TS WebAssembly" src="https://kth.cash/images/libraries/wasm.svg" width="80" height="80" /></a>
+<a href="https://github.com/k-nuth/cs-api"><img alt="C#" src="https://kth.cash/images/libraries/csharp.svg" width="80" height="80" /></a>
+<a href="https://github.com/k-nuth/py-api"><img alt="Python" src="https://kth.cash/images/libraries/python.svg" width="80" height="80" /></a>
 
-Any protocol change can be introduced in Knuth much faster and more efficiently than in reference implementations.
+## Donations
 
-## Version History & Repository Transition
-
-### 📊 Current Version: 0.68.0 (Mono-repository)
-
-**Starting with v0.68.0 (June 2025)**, all Knuth components are released from this unified mono-repository with synchronized versioning.
-
-### 🔄 Repository Architecture Evolution
-
-**Before v0.68.0**: Multi-repository architecture with independent release cycles
-- Components were developed in separate repositories
-- Each repository had its own version numbering and release schedule
-- Different components could have different versions (e.g., C-API v0.67.0, Node v0.58.0)
-
-**From v0.68.0**: Mono-repository architecture with unified versioning
-- All components unified in this single repository (`kth-mono`)
-- Synchronized version numbers across all components
-- Single release process for all components
-
-### 📋 Version Gap Explanation (v0.59.0 - v0.67.0)
-
-You may notice that Node and Node-exe components appear to "skip" versions 0.59.0 through 0.67.0. Here's why:
-
-During the multi-repository period (2024-2025):
-- **C-API**: Actively released versions 0.59.0 → 0.67.0 with regular updates
-- **Node & Node-exe**: Remained stable at v0.58.0 (no new releases needed)
-- **Other components**: Various independent version numbers
-
-### 📍 Finding Older Versions
-
-If you need access to pre-mono-repository versions:
-
-**C-API versions ≤ 0.67.0:**
-- Repository: [`k-nuth/c-api`](https://github.com/k-nuth/c-api/releases)
-- Available versions: 0.47.0 → 0.67.0
-
-**Node & Node-exe versions ≤ 0.58.0:**
-- Node Repository: [`k-nuth/node`](https://github.com/k-nuth/node/releases)  
-- Node-exe Repository: [`k-nuth/node-exe`](https://github.com/k-nuth/node-exe/releases)
-- Available versions: 0.47.0 → 0.58.0
-
-**All versions ≥ 0.68.0:**
-- Repository: **This repository** ([`k-nuth/kth-mono`](https://github.com/k-nuth/kth-mono/releases))
-- Unified versioning for all components
-
-### 🎯 Benefits of Mono-repository
-
-1. **Simplified Management**: Single repository, single version, single release process
-2. **Improved Coordination**: All components evolve together with consistent versioning  
-3. **Better Developer Experience**: One codebase, one build system, one release cycle
-4. **Easier Dependency Management**: No more version compatibility matrices between components
-
-## Donation
-
-Knuth is a community backed project developed. Donations received will be used to subsidize development costs for general maintenance and support of our implementation.
-
-Your contributions are greatly appreciated!
+Knuth is community-backed. Donations subsidize development costs, general maintenance and support.
 
 `bitcoincash:qrlgfg2qkj3na2x9k7frvcmv06ljx5xlnuuwx95zfn`
 
@@ -275,40 +215,38 @@ See [fund.kth.cash](https://fund.kth.cash/) for active Flipstarter campaigns.
 
 ## License
 
-Knuth node is released under the terms of the MIT license. See COPYING for more information or see https://opensource.org/licenses/MIT
-
+Knuth is released under the MIT license. See [`COPYING`](COPYING) or [opensource.org/licenses/MIT](https://opensource.org/licenses/MIT).
 
 ## Contributing
 
-### Branch Naming Conventions
+### Branch naming conventions
 
-To optimize CI/CD performance, we use specific branch prefixes that determine which workflows are executed:
+To optimize CI/CD throughput we route branches by prefix:
 
-- **`docs/`** - Documentation-only changes (fast validation, ~30s)
-- **`style/`** - Code formatting, copyright updates, comment fixes (fast validation)
-- **`chore/`** - Maintenance tasks, dependency updates (fast validation)
-- **`noci/`** - Explicitly skip heavy CI (fast validation)
+| Prefix | Use for | CI |
+|---|---|---|
+| `docs/` | Documentation-only changes | Fast (~30s) |
+| `style/` | Formatting, copyright headers, comment fixes | Fast |
+| `chore/` | Maintenance, dependency bumps | Fast |
+| `noci/` | Explicitly skip heavy CI | Fast |
+| anything else (`feature/`, `fix/`, `refactor/`, …) | Code changes | Full pipeline |
 
-All other branches (`feature/`, `fix/`, `refactor/`, etc.) run the full CI pipeline.
-
-📖 **See [Branch Conventions Guide](docs/BRANCH_CONVENTIONS.md) for detailed usage examples.**
+📖 See [`docs/BRANCH_CONVENTIONS.md`](docs/BRANCH_CONVENTIONS.md) for detailed examples.
 
 ## Contact
 
-You can contact us through our [Telegram](https://t.me/knuth_cash) group or write to us at info@kth.cash.
+[Telegram](https://t.me/knuth_cash) group, or email info@kth.cash.
 
-## Security Disclosures
+## Security disclosures
 
-To report security issues please contact:
-
-Fernando Pelliccioni (fpelliccioni@gmail.com) - GPG Fingerprint: 8C1C 3163 AAE1 0EFA 704C 8A00 FE77 07B7 4C29 E389
+Please report security issues to `security@kth.cash`.
 
 
 <!-- Links -->
-[badge.Cirrus]: https://api.cirrus-ci.com/github/k-nuth/kth-mono.svg?branch=master
-[badge.GithubActions]: https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fk-nuth%2Fkth-mono%2Fbadge&style=for-the-badge
-[badge.version]: https://badge.fury.io/gh/k-nuth%2Fkth-kth-mono.svg
-[badge.release]: https://img.shields.io/github/v/release/k-nuth/kth-mono?display_name=tag&style=for-the-badge&color=3b009b&logo=bitcoincash
+[badge.Cirrus]: https://api.cirrus-ci.com/github/k-nuth/kth.svg?branch=master
+[badge.GithubActions]: https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fk-nuth%2Fkth%2Fbadge&style=for-the-badge
+[badge.version]: https://badge.fury.io/gh/k-nuth%2Fkth-kth.svg
+[badge.release]: https://img.shields.io/github/v/release/k-nuth/kth?display_name=tag&style=for-the-badge&color=3b009b&logo=bitcoincash
 [badge.cpp]: https://img.shields.io/badge/C++-23-blue.svg?logo=c%2B%2B&style=for-the-badge
 [badge.deepwiki]: https://img.shields.io/badge/Ask-DeepWiki-3b009b?style=for-the-badge&logo=readthedocs&logoColor=white
 [badge.telegram]: https://img.shields.io/badge/telegram-badge-blue.svg?logo=telegram&style=for-the-badge

--- a/docs/VERSION_HISTORY.md
+++ b/docs/VERSION_HISTORY.md
@@ -1,0 +1,53 @@
+# Version History & Repository Transition
+
+Knuth started life as a constellation of small repositories, one per
+component (node, c-api, blockchain, …), each with its own version
+number and release schedule. **Starting with v0.68.0 (June 2025)** the
+project consolidated into this single repository, with one
+synchronized version that covers every component.
+
+> **A note on repo names.** The mono-repo originally launched as
+> `k-nuth/kth-mono` while the legacy multi-repo lived at `k-nuth/kth`.
+> Those have since been swapped: the mono-repo is now `k-nuth/kth`
+> (this one), and the legacy multi-repo is `k-nuth/kth-legacy`. Older
+> URLs that still reference `kth-mono` redirect for now but should be
+> updated when you spot them.
+
+## Repository architecture
+
+| Period | Layout | Versioning |
+|---|---|---|
+| **Before v0.68.0** | One repo per component | Independent (e.g. C-API at v0.67.0 alongside Node at v0.58.0) |
+| **From v0.68.0 onwards** | This mono-repository | One version, all components |
+
+The split before v0.68.0 was occasionally surprising — some components
+released frequently while others remained stable for long stretches,
+so version numbers diverged. The mono-repo collapses that into a
+single release line.
+
+## The v0.59.0 – v0.67.0 gap on Node and Node-exe
+
+Node and Node-exe appear to skip from v0.58.0 straight to v0.68.0.
+Nothing was lost: during 2024–2025 the C-API was the active surface
+and shipped 0.59.0 → 0.67.0 with regular updates, while Node and
+Node-exe stayed at v0.58.0 because no consumer-visible changes warranted
+a new release. When the mono-repo cut its first release at v0.68.0,
+Node simply jumped to match the unified line.
+
+## Where to find pre-mono releases
+
+| Component | Version range | Repository |
+|---|---|---|
+| C-API | 0.47.0 → 0.67.0 | [`k-nuth/c-api`](https://github.com/k-nuth/c-api/releases) |
+| Node | 0.47.0 → 0.58.0 | [`k-nuth/node`](https://github.com/k-nuth/node/releases) |
+| Node-exe | 0.47.0 → 0.58.0 | [`k-nuth/node-exe`](https://github.com/k-nuth/node-exe/releases) |
+| Everything from 0.68.0 onwards | unified | [`k-nuth/kth`](https://github.com/k-nuth/kth/releases) (this repo) |
+
+## Why the consolidation
+
+- **One release process** instead of N coordinating release cycles.
+- **One version everywhere** — no compatibility matrix between
+  C-API 0.65.x and Node 0.57.x.
+- **One codebase, one build system** for contributors.
+- **Atomic cross-component changes**: a change touching node + c-api +
+  domain lands in one commit and ships in one release, not three.


### PR DESCRIPTION
The README had drifted on several axes; this is a single coordinated pass that addresses every one of them.

## What's in the box

- **📚 Documentation section.** New top-level section that points readers at [kth.cash/docs](https://kth.cash/docs/), [DeepWiki](https://deepwiki.com/k-nuth/kth), `BRANCH_CONVENTIONS.md`, `BUILD_WITH_TESTS.md`, and the new `VERSION_HISTORY.md` — the DeepWiki badge alone wasn't enough signposting.

- **Code examples that actually compile against today's API.** Both the C++ and C "hello world" snippets used to hand a `"config.cfg"` path to the node constructor — that ctor doesn't exist anymore (and even when it did, file-based config was the wrong recommendation for a first-line example).
  - C++ now uses `kth::node::configuration{kth::domain::config::network::mainnet}` + `kth::node::executor`.
  - C now uses `kth_config_settings_default(kth_network_mainnet)` + `kth_node_construct(&settings, …)`.
  Both make the "use mainnet defaults" path the obvious one.

- **Running Tests with a sensible version placeholder.** `./scripts/build.sh 1.0.0` was misleading — the script's first argument is the Conan package version stamped into the lockfile, not a release tag. Switch to `<VERSION>` with a one-line explanation. The Latest release is also visible via the badges in the header for anyone who wants to substitute a concrete number.

- **Releases section as a table.** The freeform `<img>` row mixed shields.io badges with kth.cash logos and didn't scan well. Now a `component | version` table that renders predictably on GitHub, mirrors, and DeepWiki.

- **Language Bindings.** Trimmed 120×120 logos to 80×80 and dropped a stray "any protocol change" sentence left over from copy-paste.

- **Version History & Repository Transition → `docs/VERSION_HISTORY.md`.** Moved the long multi-section block into its own file, rewrote the prose: consolidated the before/after tables into a single comparison, replaced the marketing-flavoured benefits bullet list with concrete reasons, and re-anchored the "0.59-0.67 gap" explanation around the actual cause (C-API was the active surface; Node didn't need releases) instead of the observation. README carries a one-line link.

- **General wording.** Tightened the lede, collapsed the language list, removed a duplicated cross-platform paragraph, and converted the contributing-conventions block into a table.

## Out of scope

Sync to `k-nuth/.github/profile/README.md` (the org profile) is a separate PR in a separate repo — will follow once this one merges.

## Test plan
- [ ] Render the README on github.com and confirm the table-of-contents-equivalent navigation feels right.
- [ ] Click-through on every link in the new Documentation section.
- [ ] Examples in `### Using the C++ library` and `### Using the C API` reference symbols that exist in the current tree (`kth::node::executor`, `kth_config_settings_default`, `kth_node_construct(settings, bool)`, `kth_chain_sync_last_height`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates; risk is limited to potentially stale/incorrect links or code snippets that could mislead users if wrong.
> 
> **Overview**
> **Updates `README.md` to reflect the current `k-nuth/kth` mono-repo and Bitcoin Cash positioning**, including refreshed links/badges, a new **Documentation** section, and cleaner tables for bindings, releases, and branch-prefix CI behavior.
> 
> **Modernizes the C++ and C “hello world” snippets** to use the current configuration/executor and C-API settings-based constructors (no `config.cfg`), and clarifies build/test scripts by using a `<VERSION>` placeholder tied to Conan package versioning.
> 
> Adds `docs/VERSION_HISTORY.md` and replaces the long README version-history block with a link to the extracted, updated repo-transition narrative.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5678f8e159c55d6216603dce09792df960f22eaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->