### PR TITLE
docs: drop the redundant "No config.cfg file required" wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ $ ./kth/bin/kth
 
 ### 🔧 Using the C++ library
 
-The example below constructs a full node with mainnet defaults, opens the chain database and prints the current tip. No `config.cfg` file required — the `configuration` constructor pulls in the network defaults for you. Tweak any field on `cfg` before handing it to `full_node` if you want to override a default.
+The example below constructs a full node with mainnet defaults, opens the chain database and prints the current tip. The `configuration` constructor pulls in the network defaults for you; tweak any field on `cfg` before handing it to `full_node` if you want to override a default.
 
 The chain interface is asynchronous: you call methods on `node.chain()` and your callback fires when the result is ready, so you can interact with the node while it keeps doing its work.
 
@@ -153,7 +153,7 @@ The C API mirrors the same pattern: `kth_config_settings_default(kth_network_mai
 #include <kth/capi.h>
 
 int main(void) {
-    // Mainnet defaults; no config file required.
+    // Mainnet defaults.
     kth_settings settings = kth_config_settings_default(kth_network_mainnet);
 
     // Override individual settings if you need to, e.g.:


### PR DESCRIPTION
The `kth::node::configuration{kth::domain::config::network::mainnet}` and `kth_config_settings_default(kth_network_mainnet)` calls already make it obvious no config file is in play. Calling it out explicitly was leftover noise from when the older snippets passed a literal `"config.cfg"` path; with that pattern gone the disclaimer is just clutter.

Two touch-ups:

- C++ intro paragraph: "No `config.cfg` file required — the `configuration` constructor pulls in the network defaults for you" → "The `configuration` constructor pulls in the network defaults for you" (kept the rest of the sentence; only dropped the negative half).
- C example comment: "// Mainnet defaults; no config file required." → "// Mainnet defaults."

The org-profile README at `k-nuth/.github` will get the same trim in the still-open profile sync PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only wording tweaks in `README.md` with no code or behavior changes.
> 
> **Overview**
> Removes redundant “no config file required” phrasing from the `README.md` C++ and C usage examples, keeping the focus on mainnet-default configuration construction and override guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd24a3918b310f17a439e8b322fb83d1080ed3b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->