### PR TITLE
docs: switch the C-API example to the async surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ $ g++ -std=c++23 example.cpp -I./kth/include -L./kth/lib \
 
 ### 🌐 Using the C API
 
-The C API mirrors the same pattern: `kth_config_settings_default(kth_network_mainnet)` returns a pre-populated settings struct that you hand to `kth_node_construct`.
+The C API mirrors the same pattern: `kth_config_settings_default(kth_network_mainnet)` returns a pre-populated settings struct that you hand to `kth_node_construct`. The chain interface comes in two flavours — `kth_chain_sync_*` (blocks the caller) and `kth_chain_async_*` (callback fires when the answer is ready). The example below uses the async surface to mirror the C++ snippet above.
 
 ```c
 // hello_knuth.c
@@ -151,6 +151,14 @@ The C API mirrors the same pattern: `kth_config_settings_default(kth_network_mai
 #include <stdint.h>
 #include <stdio.h>
 #include <kth/capi.h>
+
+// Fires once the chain has resolved the request.
+static void on_height(kth_chain_t chain, void* ctx, kth_error_code_t ec, kth_size_t height) {
+    (void)chain; (void)ctx;
+    if (ec == kth_ec_success) {
+        printf("Current height: %" PRIu64 "\n", (uint64_t)height);
+    }
+}
 
 int main(void) {
     // Mainnet defaults.
@@ -162,11 +170,14 @@ int main(void) {
 
     kth_node_t node = kth_node_construct(&settings, /*stdout_enabled=*/1);
 
+    // Submit the height query asynchronously; on_height fires once the chain
+    // can answer it.
     kth_chain_t chain = kth_node_get_chain(node);
-    kth_size_t height = 0;
-    if (kth_chain_sync_last_height(chain, &height) == kth_ec_success) {
-        printf("Current height: %" PRIu64 "\n", (uint64_t)height);
-    }
+    kth_chain_async_last_height(chain, /*ctx=*/NULL, on_height);
+
+    // Bring the node up and block until SIGINT/SIGTERM. The async query
+    // resolves while the node is running.
+    kth_node_init_run_and_wait_for_signal(node, NULL, kth_start_modules_all, NULL);
 
     kth_node_destruct(node);
     return 0;


### PR DESCRIPTION
The C-API exposes both `kth_chain_sync_*` (blocks the caller) and `kth_chain_async_*` (handler fires when the answer is ready). The README's "Using the C API" snippet used the sync variant, which made the C++ example one block above (built around `fetch_last_height` + lambda) look like the only way to show the async pattern. With both flavours available in C, there's no reason not to mirror the C++ snippet.

What changed:

- `kth_chain_async_last_height(chain, ctx, on_height)` issues the query and returns immediately. The handler signature comes from `kth_last_height_fetch_handler_t` — `(chain, ctx, ec, height)` — so the snippet now also exercises the standard async-handler shape that other `kth_chain_async_*` calls use.
- `kth_node_init_run_and_wait_for_signal(...)` brings the node up and blocks until `SIGINT` / `SIGTERM`. The async query resolves while the node is running and `on_height` prints the result.
- Intro paragraph now points readers at both the sync and async flavours so consumers know `kth_chain_sync_*` still exists when they want a blocking call.

## Test plan
- [ ] Snippet compiles against the current C-API headers (`kth_chain_async_last_height`, `kth_last_height_fetch_handler_t`, `kth_node_init_run_and_wait_for_signal`, `kth_start_modules_all`).
- [ ] On render, the C example mirrors the structure of the C++ example one block up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change updating the README C snippet to use the async chain API and run-loop; no production code paths are modified.
> 
> **Overview**
> Updates the README’s **C API** example to mirror the C++ async pattern by replacing the blocking `kth_chain_sync_last_height` call with `kth_chain_async_last_height` and an `on_height` callback.
> 
> The snippet now starts the node via `kth_node_init_run_and_wait_for_signal(...)` so the async request resolves while the node is running, and the intro text explicitly calls out both `kth_chain_sync_*` and `kth_chain_async_*` variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 238282c9a1fec36eae47b7d46ea74aeecac77a1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->