### PR TITLE
test: build + run README C++ and C snippets in CI

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -616,6 +616,30 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     include(CTest)
     include(Catch)
     catch_discover_tests(kth_capi_test)
+
+    # README C snippet — compile-only check. Verbatim copy of the
+    # README's "Using the C API" snippet. Builds, but is not
+    # registered as a runtime test: the snippet ends in
+    # `kth_node_init_run_and_wait_for_signal`, which blocks until
+    # SIGINT/SIGTERM. The compile is enough to fail the build if any
+    # public symbol the snippet references drifts.
+    add_executable(kth_readme_c_compile_check test/readme_c_compile_check.c)
+    target_link_libraries(kth_readme_c_compile_check PRIVATE ${PROJECT_NAME})
+
+    # README C snippet — runtime smoke. Same flow as the README but
+    # adapted for CI: regtest network, fresh temp data dir, 16 MiB DB
+    # cap, no network threads. A pthread issues the async height query
+    # once the chain's dispatcher is up, and the result handler calls
+    # `kth_node_signal_stop`, which unblocks
+    # `kth_node_init_run_and_wait_for_signal` so the test can exit
+    # without an external SIGINT. Asserts the freshly initialised
+    # regtest reports height 0.
+    find_package(Threads REQUIRED)
+    add_executable(kth_readme_c_runtime test/readme_c_runtime.c)
+    target_link_libraries(kth_readme_c_runtime PRIVATE ${PROJECT_NAME})
+    target_link_libraries(kth_readme_c_runtime PRIVATE Threads::Threads)
+    add_test(NAME kth_readme_c_runtime COMMAND kth_readme_c_runtime)
+    set_tests_properties(kth_readme_c_runtime PROPERTIES TIMEOUT 60)
 endif()
 
 

--- a/src/c-api/test/readme_c_compile_check.c
+++ b/src/c-api/test/readme_c_compile_check.c
@@ -1,0 +1,52 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Verbatim copy of the C snippet in `README.md`'s "Using the C API"
+// section. Compiled — but not executed — under `ENABLE_TEST=ON`. Its
+// purpose is purely to fail the build if the public surface the README
+// example relies on (`kth_settings` layout, `kth_chain_async_last_height`,
+// `kth_last_height_fetch_handler_t`, `kth_node_init_run_and_wait_for_signal`,
+// `kth_start_modules_all`) drifts.
+//
+// The runtime smoke for the same flow lives in `readme_c_runtime.c`,
+// which exercises the APIs end-to-end on a regtest temp DB.
+//
+// Keep this file byte-identical to the README's `int main()` body
+// minus the includes header.
+
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <kth/capi.h>
+
+// Fires once the chain has resolved the request.
+static void on_height(kth_chain_t chain, void* ctx, kth_error_code_t ec, kth_size_t height) {
+    (void)chain; (void)ctx;
+    if (ec == kth_ec_success) {
+        printf("Current height: %" PRIu64 "\n", (uint64_t)height);
+    }
+}
+
+int main(void) {
+    // Mainnet defaults.
+    kth_settings settings = kth_config_settings_default(kth_network_mainnet);
+
+    // Override individual settings if you need to, e.g.:
+    //   settings.database.directory = "/var/lib/kth";
+    //   settings.network.threads    = 8;
+
+    kth_node_t node = kth_node_construct(&settings, /*stdout_enabled=*/1);
+
+    // Submit the height query asynchronously; on_height fires once the chain
+    // can answer it.
+    kth_chain_t chain = kth_node_get_chain(node);
+    kth_chain_async_last_height(chain, /*ctx=*/NULL, on_height);
+
+    // Bring the node up and block until SIGINT/SIGTERM. The async query
+    // resolves while the node is running.
+    kth_node_init_run_and_wait_for_signal(node, NULL, kth_start_modules_all, NULL);
+
+    kth_node_destruct(node);
+    return 0;
+}

--- a/src/c-api/test/readme_c_runtime.c
+++ b/src/c-api/test/readme_c_runtime.c
@@ -1,0 +1,185 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Smoke test for the public C surface used by the README's "Using the
+// C API" snippet (`kth_settings` defaults → `kth_node_construct` →
+// `kth_chain_async_last_height` → `kth_node_init_run_and_wait_for_signal`).
+//
+// We can't run the snippet verbatim — the README example uses
+// `kth_network_mainnet` (400 GiB LMDB cap, real network) and only ever
+// returns when the user sends SIGINT. Both are wrong for CI:
+//
+//   * `kth_network_regtest` instead of `mainnet` — same cap defaults
+//     in this tree, but we shrink `db_max_size` to 16 MiB explicitly.
+//   * `settings.database.directory` is a fresh per-run temp parent +
+//     a `chain` subdir; `kth_node_initchain` requires that it create
+//     the leaf itself, so we hand it a path that doesn't exist yet.
+//   * `settings.network.threads = 0` keeps the test offline.
+//
+// Driving the run loop without an external SIGINT is the awkward bit.
+// `kth_chain_async_last_height` issued before `init_run_*` core-dumps
+// (the chain's dispatcher isn't attached to a threadpool yet) and the
+// public C-API has no "node started" hook, so we fall back to a
+// worker thread that delays briefly to let the dispatcher come up,
+// issues the async query, and exits. The result handler calls
+// `kth_node_signal_stop`, which unblocks the main thread's
+// `init_run_and_wait_for_signal` so the test can finish without an
+// external signal. ctest's TIMEOUT property bounds the worst case.
+
+#include <inttypes.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <kth/capi.h>
+
+// `on_height` runs on the chain's internal dispatcher thread, while
+// the assertions at the bottom of `main` read the result on the
+// initial thread. `pthread_join` only synchronises with the querier
+// thread, not the dispatcher, so we hand-roll the cross-thread
+// publish/load with C11 atomics. Sequential consistency (the default
+// memory order) is fine — the test isn't hot enough to care about
+// relaxed orderings.
+static atomic_int        g_fetched = 0;
+static _Atomic kth_size_t g_height  = (kth_size_t)-1;
+
+// Fires once the chain has resolved the request. Stores the result
+// and unblocks the run loop so main can return.
+static void on_height(kth_chain_t chain, void* ctx, kth_error_code_t ec, kth_size_t height) {
+    (void)chain;
+    if (ec == kth_ec_success) {
+        atomic_store(&g_height, height);
+        atomic_store(&g_fetched, 1);
+        printf("Current height: %" PRIu64 "\n", (uint64_t)height);
+    }
+    kth_node_signal_stop((kth_node_t)ctx);
+}
+
+// Sleeps `ms` milliseconds without pulling in platform helpers.
+static void sleep_ms(int ms) {
+    struct timespec ts;
+    ts.tv_sec  = ms / 1000;
+    ts.tv_nsec = (long)(ms % 1000) * 1000000L;
+    while (nanosleep(&ts, &ts) == -1) {} // resume on EINTR
+}
+
+// Worker thread: waits for the chain's dispatcher to come up under
+// `init_run_and_wait_for_signal`, then issues the async height query.
+// 3 seconds is enough on every CI runner we have today (Linux GHC
+// container ~0.05 s, macOS apple-clang ~0.05 s, coverage `-O0` build
+// ~0.5 s); ctest's 60 s test-level TIMEOUT bounds the worst case if
+// a future runner is somehow much slower.
+static void* querier(void* arg) {
+    kth_node_t node = (kth_node_t)arg;
+    sleep_ms(3000);
+    if (kth_node_stopped(node)) return NULL; // shutdown already in flight
+    kth_chain_t chain = kth_node_get_chain(node);
+    kth_chain_async_last_height(chain, /*ctx=*/node, on_height);
+    return NULL;
+}
+
+int main(void) {
+    // `kth_node_initchain` requires that it create the leaf directory
+    // itself — passing an already-existing path makes the underlying
+    // `executor::init_directory` fail with `directory_exists`. So we
+    // claim a unique parent via `mkdtemp` and hand the unbuilt
+    // `chain` subdir inside it to the node.
+    char parent[] = "/tmp/kth_readme_c_runtime_XXXXXX";
+    if (mkdtemp(parent) == NULL) {
+        perror("mkdtemp");
+        return 1;
+    }
+    char chain_dir[512];
+    snprintf(chain_dir, sizeof chain_dir, "%s/chain", parent);
+
+    // Same shape as the README example, but with the CI-safe overrides
+    // described in the file header.
+    kth_settings settings = kth_config_settings_default(kth_network_regtest);
+    // `kth_config_settings_default` heap-allocates `database.directory`
+    // via `path_to_c` (malloc'd), and the matching cleanup is `free()`
+    // in `database_settings_delete`. Pointing the field at our local
+    // `chain_dir` array would leak the original allocation and leave
+    // a stack pointer where a heap pointer is expected. Free the
+    // default and replace it with our own heap copy so the invariant
+    // holds; we free our copy ourselves before the test exits.
+    free(settings.database.directory);
+    settings.database.directory = strdup(chain_dir);
+    if (settings.database.directory == NULL) {
+        perror("strdup");
+        char cmd[512];
+        snprintf(cmd, sizeof cmd, "rm -rf '%s'", parent);
+        (void)system(cmd);
+        return 1;
+    }
+    settings.database.db_max_size = (uint64_t)16ULL << 20; // 16 MiB
+    settings.network.threads = 0;
+
+    kth_node_t node = kth_node_construct(&settings, /*stdout_enabled=*/0);
+    if (node == NULL) {
+        fprintf(stderr, "kth_node_construct returned NULL\n");
+        free(settings.database.directory);
+        char cmd[512];
+        snprintf(cmd, sizeof cmd, "rm -rf '%s'", parent);
+        (void)system(cmd);
+        return 1;
+    }
+
+    // Initialise the chain database so init_run has something to open.
+    if ( ! kth_node_initchain(node)) {
+        kth_node_destruct(node);
+        free(settings.database.directory);
+        char cmd[512];
+        snprintf(cmd, sizeof cmd, "rm -rf '%s'", parent);
+        (void)system(cmd);
+        return 1;
+    }
+
+    pthread_t tid;
+    if (pthread_create(&tid, NULL, querier, node) != 0) {
+        kth_node_destruct(node);
+        free(settings.database.directory);
+        char cmd[512];
+        snprintf(cmd, sizeof cmd, "rm -rf '%s'", parent);
+        (void)system(cmd);
+        return 1;
+    }
+
+    kth_node_init_run_and_wait_for_signal(
+        node, /*ctx=*/NULL, kth_start_modules_just_chain, /*handler=*/NULL);
+
+    pthread_join(tid, NULL);
+    kth_node_destruct(node);
+
+    // Release our heap copy of the chain directory so the test exits
+    // ASAN-clean. (Other inner allocations of `kth_settings` —
+    // `node_settings`, `network_settings`, `blockchain_settings` —
+    // also leak here; `kth_config_settings_destruct` would clean them
+    // up but it also `delete`s the settings pointer itself, which is
+    // wrong for our stack-allocated `kth_settings`. Restoring the
+    // missing per-field cleanup helpers to the public C-API is a
+    // separate fix.)
+    free(settings.database.directory);
+
+    char cmd[512];
+    snprintf(cmd, sizeof cmd, "rm -rf '%s'", parent);
+    (void)system(cmd);
+
+    if ( ! atomic_load(&g_fetched)) {
+        fprintf(stderr, "fetch_last_height did not succeed\n");
+        return 1;
+    }
+    // Freshly initialised regtest = genesis only; height must be 0.
+    kth_size_t const height = atomic_load(&g_height);
+    if (height != 0) {
+        fprintf(stderr, "unexpected height %" PRIu64 "\n", (uint64_t)height);
+        return 1;
+    }
+    return 0;
+}

--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -292,6 +292,26 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     # Fallback to manual test registration
     add_test(NAME kth_node_test COMMAND kth_node_test)
   endif()
+
+  # README C++ snippet — compile-only check. Verbatim copy of the
+  # README's "Using the C++ library" snippet. Builds, but is not
+  # registered as a runtime test: the snippet uses `mainnet` defaults
+  # (400 GiB LMDB cap, real data dir) and assumes a populated chain
+  # database, which CI does not provide. The compile is enough to
+  # fail the build if any public symbol the snippet references drifts.
+  add_executable(kth_readme_cpp_compile_check test/readme_cpp_compile_check.cpp)
+  target_link_libraries(kth_readme_cpp_compile_check PRIVATE ${PROJECT_NAME})
+
+  # README C++ snippet — runtime smoke. Same flow as the README but
+  # adapted for CI: regtest network, fresh temp data dir, 16 MiB DB
+  # cap, no network threads. Initialises the chain via `executor`
+  # then runs the `full_node` + `start_chain` + `chain().fetch_last_height`
+  # + `close` flow the README example shows; asserts the freshly
+  # initialised regtest reports height 0.
+  add_executable(kth_readme_cpp_runtime test/readme_cpp_runtime.cpp)
+  target_link_libraries(kth_readme_cpp_runtime PRIVATE ${PROJECT_NAME})
+  add_test(NAME kth_readme_cpp_runtime COMMAND kth_readme_cpp_runtime)
+  set_tests_properties(kth_readme_cpp_runtime PROPERTIES TIMEOUT 60)
 endif()
 
 

--- a/src/node/test/readme_cpp_compile_check.cpp
+++ b/src/node/test/readme_cpp_compile_check.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Verbatim copy of the C++ snippet in `README.md`'s "Using the C++
+// library" section. Compiled — but not executed — under
+// `ENABLE_TEST=ON`. Its purpose is purely to fail the build if the
+// public surface the README example relies on (configuration ctor,
+// full_node ctor, start_chain / chain() / fetch_last_height / close
+// shapes) drifts.
+//
+// The runtime smoke for the same flow lives in
+// `readme_cpp_runtime.cpp`, which exercises the APIs end-to-end on
+// a regtest temp DB.
+//
+// Keep this file byte-identical to the README's `int main()` body
+// minus the includes header.
+
+#include <latch>
+#include <print>
+#include <system_error>
+
+#include <kth/node.hpp>
+
+int main() {
+    // Mainnet defaults — equivalent to what the node-exe ships with.
+    kth::node::configuration cfg{kth::domain::config::network::mainnet};
+
+    // Override individual settings if you need to, e.g.:
+    //   cfg.database.directory = "/var/lib/kth";
+    //   cfg.network.threads    = 8;
+
+    kth::node::full_node node{cfg};
+
+    std::latch done{1};
+    node.start_chain([&](std::error_code const& ec) {
+        if (ec) { done.count_down(); return; }
+        node.chain().fetch_last_height([&](std::error_code const& fec, std::size_t height) {
+            if ( ! fec) std::println("Current height: {}", height);
+            done.count_down();
+        });
+    });
+    done.wait();
+    node.close();
+}

--- a/src/node/test/readme_cpp_runtime.cpp
+++ b/src/node/test/readme_cpp_runtime.cpp
@@ -1,0 +1,181 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Smoke test for the public C++ surface used by the README's
+// "Using the C++ library" snippet (configuration → full_node →
+// start_chain → chain().fetch_last_height → close).
+//
+// We don't run the snippet verbatim — the README example uses
+// `network::mainnet`, whose default LMDB cap is 400 GiB and whose
+// data dir is the user's chosen path. Both are wrong for CI:
+//
+//   * `regtest` instead of `mainnet` — same DB cap defaults in the
+//     current tree, but we shrink `db_max_size` to 16 MiB explicitly
+//     so the sparse map file stays bounded on every filesystem.
+//   * `cfg.database.directory` is a fresh per-run temp dir, removed
+//     on exit.
+//   * `cfg.network.threads = 0` keeps the test offline.
+//
+// The point isn't to copy-paste the README at byte level — it's to
+// exercise every public symbol the README example touches:
+//   - `kth::node::configuration{network}`
+//   - `cfg.database.directory`, `cfg.database.db_max_size`,
+//     `cfg.network.threads`
+//   - `kth::node::executor::do_initchain` (initialises the DB so
+//     `start_chain` has something to open)
+//   - `kth::node::full_node{cfg}`
+//   - `node.start_chain(handler)`
+//   - `node.chain().fetch_last_height(handler)`
+//   - `node.close()`
+//
+// If any of those drifts, this binary stops compiling or returns
+// non-zero, and CI flags the README as out of date.
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <expected>
+#include <filesystem>
+#include <latch>
+#include <print>
+#include <random>
+#include <string>
+#include <system_error>
+#include <thread>
+
+#include <kth/node.hpp>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+struct chain_dirs {
+    fs::path parent;
+    fs::path chain;
+};
+
+// Returns paths whose `chain` leaf does NOT exist yet.
+// `executor::do_initchain` requires that it be the one to create
+// the leaf directory — if the path is already present
+// `init_directory` fails with `directory_exists` and
+// `do_initchain` returns false. So we claim a unique parent dir
+// (retrying on collision so a stale artifact from a crashed prior
+// run doesn't make us silently share it) and hand the unbuilt
+// `chain` subdir to `executor`.
+//
+// `fs::create_directories` returns `true` only when it actually
+// created the directory; if the path already exists it returns
+// `false` (and `ec` stays clear), which is the collision case we
+// retry past with a fresh random suffix.
+//
+// Failure modes (filesystem error, exhausted retries) are
+// reported via `std::expected` instead of an exception so the
+// test top-level can pattern-match with the rest of the
+// `error_code` handling in the snippet.
+std::expected<chain_dirs, std::string> make_chain_dirs() {
+    auto base = fs::temp_directory_path();
+    std::random_device rd;
+    for (int attempt = 0; attempt < 100; ++attempt) {
+        auto name = std::string{"kth_readme_cpp_runtime_"} + std::to_string(rd());
+        auto candidate = base / name;
+        std::error_code ec;
+        if (fs::create_directories(candidate, ec)) {
+            return chain_dirs{candidate, candidate / "chain"};
+        }
+        if (ec) {
+            return std::unexpected{
+                "fs::create_directories failed: " + ec.message()};
+        }
+        // Path exists already (no error, just `false` return); retry.
+    }
+    return std::unexpected{
+        std::string{"could not allocate a unique temp directory after 100 attempts"}};
+}
+
+} // namespace
+
+int main() {
+    auto dirs = make_chain_dirs();
+    if ( ! dirs) {
+        std::println(stderr, "make_chain_dirs failed: {}", dirs.error());
+        return 1;
+    }
+    auto cleanup = [&]() noexcept {
+        std::error_code ec;
+        fs::remove_all(dirs->parent, ec);
+    };
+
+    // Same shape as the README example, but with the CI-safe overrides
+    // described in the file header.
+    kth::node::configuration cfg{kth::domain::config::network::regtest};
+    cfg.database.directory = dirs->chain;
+    cfg.database.db_max_size = 16ULL << 20; // 16 MiB
+    cfg.network.threads = 0;
+
+    // Step 1: create the chain database. The README snippet assumes the
+    // user has already done this (or that the dir is populated); CI starts
+    // from scratch every run so we materialise the DB here.
+    {
+        kth::node::executor exec{cfg, /*stdout_enabled=*/false};
+        if ( ! exec.do_initchain("")) {
+            std::println(stderr, "do_initchain failed");
+            cleanup();
+            return 1;
+        }
+        // exec is destroyed here, releasing the DB for the next phase.
+    }
+
+    // Step 2: the actual snippet flow on a now-initialised DB.
+    bool fetch_ok = false;
+    std::size_t fetched_height = 0;
+    bool close_ok = false;
+    {
+        kth::node::full_node node{cfg};
+
+        std::latch done{1};
+        node.start_chain([&](std::error_code const& ec) {
+            if (ec) {
+                std::println(stderr, "start_chain failed: {}", ec.message());
+                done.count_down();
+                return;
+            }
+            node.chain().fetch_last_height(
+                [&](std::error_code const& fec, std::size_t height) {
+                    if ( ! fec) {
+                        fetched_height = height;
+                        fetch_ok = true;
+                        std::println("Current height: {}", height);
+                    } else {
+                        std::println(stderr, "fetch_last_height failed: {}", fec.message());
+                    }
+                    done.count_down();
+                });
+        });
+        done.wait();
+        // `full_node::close()` reports `false` when shutdown didn't
+        // complete cleanly. The README example doesn't check it
+        // because it's the last thing before `main` returns and a
+        // dirty exit is harmless there; in a smoke test we want a
+        // shutdown regression to fail the test instead of slipping
+        // through.
+        close_ok = node.close();
+    }
+
+    cleanup();
+
+    if ( ! fetch_ok) {
+        std::println(stderr, "fetch_last_height did not succeed");
+        return 1;
+    }
+    // Freshly initialised regtest = genesis only; height must be 0.
+    if (fetched_height != 0) {
+        std::println(stderr, "unexpected height {}", fetched_height);
+        return 1;
+    }
+    if ( ! close_ok) {
+        std::println(stderr, "node.close() reported failure");
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
Adds two test binaries per language under `ENABLE_TEST=ON`:

| Target | Source | Action in CI |
|---|---|---|
| `kth_readme_cpp_compile_check` | verbatim README C++ snippet | builds, does not run |
| `kth_readme_cpp_runtime` | regtest-adapted version of the same flow | builds + `ctest` runs end-to-end (60s TIMEOUT) |
| `kth_readme_c_compile_check` | verbatim README C snippet | builds, does not run |
| `kth_readme_c_runtime` | regtest-adapted version of the same flow | builds + `ctest` runs end-to-end (60s TIMEOUT) |

## Why two files per language

The README examples are written for users running interactively against mainnet — `mainnet` defaults, real data dir, Ctrl-C to exit (C). Running them verbatim under CI is hostile:

- Mainnet's default LMDB cap is **400 GiB**, and `regtest` inherits it in this tree (the switch in `database/src/settings.cpp` falls through to `get_db_max_size_mainnet`).
- The C example ends in `kth_node_init_run_and_wait_for_signal`, which blocks until SIGINT/SIGTERM. There's no external signal in CI.
- The C++ example assumes a populated data directory (`start_chain` fails on an empty `directory`).
- `executor::do_initchain` requires the leaf directory NOT to exist — pre-creating it (the obvious `mkdtemp` shape) makes it fail with `directory_exists`.

So:

- **Compile-only** (`*_compile_check.{cpp,c}`): byte-identical to the README. The compile catches API drift cheaply and gives reviewers a single source of truth to keep in sync.
- **Runtime smoke** (`*_runtime.{cpp,c}`): same APIs, CI-friendly inputs:
  - `regtest` network instead of `mainnet`.
  - `mkdtemp`'d parent + a `chain` subdir handed to `do_initchain` / `kth_node_initchain` so they can create the leaf themselves.
  - `db_max_size = 16 MiB` — explicit small cap.
  - `network.threads = 0` — keep the test offline.
  - C++ runtime calls `executor::do_initchain` first to materialise genesis, then runs the README's `full_node` + `start_chain` + `chain().fetch_last_height` + `close()` flow on the now-populated dir.
  - C runtime spawns a worker thread that delays briefly (3 s) to let the chain's dispatcher come up under `init_run_and_wait_for_signal`, issues `kth_chain_async_last_height`, and the handler calls `kth_node_signal_stop`. (Submitting the async query before `init_run_*` core-dumps because the dispatcher isn't attached to a threadpool yet, and the public C-API has no "node started" hook — this is the cleanest pattern that keeps the test fully event-driven on shutdown.)

The runtime targets assert that the freshly-initialised regtest chain reports height 0. Verified locally on Linux: each target builds, runs end-to-end in 0.06–3 s, prints `Current height: 0`, exits 0. macOS sanitizers CI also reports both runtime targets `Passed`.

## Test plan
- [ ] Linux GCC sanitizers job: all four targets build.
- [ ] Linux GCC sanitizers job: `kth_readme_cpp_runtime` and `kth_readme_c_runtime` pass `ctest`.
- [ ] macOS apple-clang job: same.
- [ ] No state leaks: the temp dirs created by the runtime tests are gone after `ctest`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added compile-only checks and runtime smoke tests that build and run the documented C and C++ README usage flows to verify examples compile and execute end-to-end.

* **Chores**
  * Updated build configuration to include the new validation executables and register runtime smoke tests with a 60s timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to new test executables and CMake test registration; primary risk is CI flakiness/timeouts due to async/threaded runtime smoke tests and filesystem/temp-dir assumptions.
> 
> **Overview**
> Adds **README snippet validation** for both the C API and C++ node library under `ENABLE_TEST=ON`.
> 
> The build now includes *compile-only* targets that mirror the README examples to catch public API drift, plus *runtime smoke tests* (registered with `ctest`, 60s timeout) that run the same flows on `regtest` with a temporary chain directory, a reduced DB max size, and networking disabled; the C runtime test also uses a worker thread + `kth_node_signal_stop` to exit without external signals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1017bc454d683c0cb592d605c9c1691a90a01932. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->