### PR TITLE
test(c-api): fix invalid CashAddr literal in create_tx_template test

### DIFF
--- a/src/c-api/test/wallet/coin_selection.cpp
+++ b/src/c-api/test/wallet/coin_selection.cpp
@@ -244,13 +244,20 @@ TEST_CASE("C-API wallet::coin_selection - select_utxos(NULL out) aborts",
 // Real, parse-able mainnet P2PKH addresses. Default-constructed
 // payment_address objects are rejected by the domain layer, so tests
 // must use addresses that round-trip through the legacy CashAddr
-// decoder.
+// decoder. The previous `kAddrChange2`
+// ("bitcoincash:qz4t90ackhtsdcz5e7sf6sszphpv2t5ucslvfvkavn") had an
+// invalid CashAddr checksum, so
+// `kth_wallet_payment_address_construct_from_address` returned NULL
+// and the subsequent `kth_wallet_payment_address_list_push_back`
+// fired its non-null precondition with SIGABRT — silently masked on
+// Linux by the sanitizer test step's `|| echo` and only surfacing
+// when the macOS sanitizer run flagged it.
 static char const* const kAddrDest =
     "bitcoincash:qpzz8n7jp6847yyx8t33matrgcsdx6c0cvmtevrfgz";
 static char const* const kAddrChange1 =
     "bitcoincash:qrhea03074073ff3zv9whh0nggxc7k03ssh8jv9mkx";
 static char const* const kAddrChange2 =
-    "bitcoincash:qz4t90ackhtsdcz5e7sf6sszphpv2t5ucslvfvkavn";
+    "bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a";
 
 TEST_CASE("C-API wallet::coin_selection - create_tx_template builds a tx with explicit ratios",
           "[C-API WalletCoinSelection][create_tx_template]") {


### PR DESCRIPTION
## What was wrong

The `create_tx_template builds a tx with explicit ratios` test (added in #318) ended in `SIGABRT` on every run. The macOS apple-clang sanitizers job in CI surfaced it as
> `coin_selection.cpp:256: FAILED: due to a fatal error condition: SIGABRT - Abort (abnormal termination) signal`

while the Linux GCC sanitizers job silently swallowed it because the `Run unit tests` shell wraps ctest with `|| echo "Some tests may have failed or timed out with sanitizers"`.

## Root cause

The test's `kAddrChange2` constant —
`bitcoincash:qz4t90ackhtsdcz5e7sf6sszphpv2t5ucslvfvkavn`

— is a syntactically-valid but checksum-invalid CashAddr (the prefix and base32 payload parse fine, but the trailing checksum bits don't match the BCH spec). `kth_wallet_payment_address_construct_from_address` returns `NULL` for such inputs, and the very next line —

```c
kth_wallet_payment_address_list_push_back(change_addrs, change2);
```

— fires its non-null precondition with `abort()`. Catch2 reports the abort at the `TEST_CASE(...)` line, which is why the failure looked like it was happening in unrelated coin-selection logic.

I confirmed the diagnosis by writing a short C program that constructs each of the test's addresses and prints `NULL`/`OK`:

```
[0] bitcoincash:qpzz8n7jp6847yyx8t33matrgcsdx6c0cvmtevrfgz -> OK
[1] bitcoincash:qrhea03074073ff3zv9whh0nggxc7k03ssh8jv9mkx -> OK
[2] bitcoincash:qz4t90ackhtsdcz5e7sf6sszphpv2t5ucslvfvkavn -> NULL
[3] bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a -> OK
```

…and confirmed via `gdb` that the `abort()` frame is `kth_wallet_payment_address_list_push_back[cold]` (the `[cold]` is the precondition path).

## Fix

Replace `kAddrChange2` with `bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a` — a canonical valid mainnet P2PKH CashAddr from the BCH spec. The test passes locally on Linux GCC 15 with `8 assertions in 1 test case`, and the sanitizer-masked `SIGABRT` goes away.

A header note next to the constants now records the trap so a future test author doesn't hand-roll another not-quite-valid CashAddr literal.

## Test plan
- [ ] macOS apple-clang sanitizers no longer reports `1 tests failed out of 5138`.
- [ ] Linux GCC sanitizers `Run unit tests` continues to pass (it already did, just with the failure swallowed).
- [ ] Local: `./kth_capi_test "C-API wallet::coin_selection - create_tx_template builds a tx with explicit ratios"` exits 0 with all assertions passing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change replacing an invalid CashAddr constant and adding clarifying comments; no production wallet/coin-selection logic is modified.
> 
> **Overview**
> Fixes a failing `create_tx_template` C-API coin-selection unit test by replacing the `kAddrChange2` CashAddr literal with a checksum-valid mainnet P2PKH address.
> 
> Adds an in-file note explaining that the previous address constructed a `NULL` payment address and triggered an abort via `kth_wallet_payment_address_list_push_back`, which was masked in some CI sanitizer runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ab6762998136a5b4dd8c4da48001d193d76e8ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->