### PR TITLE
refactor(c-api): finish the kth_inputpoint_t cleanup

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -272,6 +272,7 @@ set(kth_sources
         src/chain/stealth_compact_list.cpp
         src/chain/input.cpp
         src/chain/input_list.cpp
+        src/chain/input_point.cpp
         src/chain/mempool_transaction_list.cpp
         src/chain/merkle_block.cpp
         src/chain/output.cpp
@@ -425,6 +426,7 @@ set(kth_headers
     include/kth/capi/chain/token_kind.h
     include/kth/capi/chain/token_data.h
     include/kth/capi/chain/input.h
+    include/kth/capi/chain/input_point.h
     include/kth/capi/chain/chain.h
     include/kth/capi/chain/chain_sync.h
     include/kth/capi/chain/chain_other.h
@@ -561,6 +563,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         test/binary.cpp
         test/chain/header.cpp
         test/chain/point.cpp
+        test/chain/input_point.cpp
         test/chain/output_point.cpp
         test/chain/script.cpp
         test/chain/output.cpp

--- a/src/c-api/include/kth/capi/callbacks.h
+++ b/src/c-api/include/kth/capi/callbacks.h
@@ -59,8 +59,8 @@ typedef void (*kth_last_height_fetch_handler_t)(kth_chain_t, void*, kth_error_co
 typedef void (*kth_merkle_block_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_merkle_block_mut_t block, kth_size_t);
 typedef void (*kth_output_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_output_mut_t output);
 
-// Owned: `spend` (`kth_inputpoint_t`) — caller takes ownership; no public destructor exposed yet.
-typedef void (*kth_spend_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_inputpoint_t spend);
+// Owned: `spend` (`kth_input_point_mut_t`) — caller must release with `kth_chain_input_point_destruct`.
+typedef void (*kth_spend_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_input_point_mut_t spend);
 
 // Owned: `tx` (`kth_transaction_mut_t`) — caller must release with `kth_chain_transaction_destruct`.
 typedef void (*kth_transaction_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_transaction_mut_t tx, kth_size_t, kth_size_t);

--- a/src/c-api/include/kth/capi/capi.h
+++ b/src/c-api/include/kth/capi/capi.h
@@ -30,6 +30,7 @@
 #include <kth/capi/chain/history_compact_list.h>
 #include <kth/capi/chain/input.h>
 #include <kth/capi/chain/input_list.h>
+#include <kth/capi/chain/input_point.h>
 #include <kth/capi/chain/mempool_transaction.h>
 #include <kth/capi/chain/mempool_transaction_list.h>
 #include <kth/capi/chain/merkle_block.h>

--- a/src/c-api/include/kth/capi/chain/chain_sync.h
+++ b/src/c-api/include/kth/capi/chain/chain_sync.h
@@ -68,7 +68,7 @@ kth_error_code_t kth_chain_sync_transaction_position(kth_chain_t chain, kth_hash
 
 // Spend ---------------------------------------------------------------------
 KTH_EXPORT
-kth_error_code_t kth_chain_sync_spend(kth_chain_t chain, kth_output_point_const_t op, kth_inputpoint_t* out_input_point);
+kth_error_code_t kth_chain_sync_spend(kth_chain_t chain, kth_output_point_const_t op, kth_input_point_mut_t* out_input_point);
 
 // History ---------------------------------------------------------------------
 KTH_EXPORT

--- a/src/c-api/include/kth/capi/chain/input_point.h
+++ b/src/c-api/include/kth/capi/chain/input_point.h
@@ -1,0 +1,129 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_CHAIN_INPUT_POINT_H_
+#define KTH_CAPI_CHAIN_INPUT_POINT_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Constructors
+
+/** @return Owned `kth_input_point_mut_t`. Caller must release with `kth_chain_input_point_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_input_point_mut_t kth_chain_input_point_construct_default(void);
+
+/** @param[out] out Must point to a null `kth_input_point_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_input_point_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_chain_input_point_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_input_point_mut_t* out);
+
+/**
+ * @return Owned `kth_input_point_mut_t`. Caller must release with `kth_chain_input_point_destruct`.
+ * @param hash Borrowed input; must be non-null. Copied into the resulting object; ownership of `hash` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_input_point_mut_t kth_chain_input_point_construct(kth_hash_t const* hash, uint32_t index);
+
+/**
+ * @return Owned `kth_input_point_mut_t`. Caller must release with `kth_chain_input_point_destruct`.
+ * @warning `hash` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`.
+ */
+KTH_EXPORT KTH_OWNED
+kth_input_point_mut_t kth_chain_input_point_construct_unsafe(uint8_t const* hash, uint32_t index);
+
+
+// Static factories
+
+/** @return Owned `kth_input_point_mut_t`. Caller must release with `kth_chain_input_point_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_input_point_mut_t kth_chain_input_point_null(void);
+
+
+// Destructor
+
+/** No-op if `self` is null. */
+KTH_EXPORT
+void kth_chain_input_point_destruct(kth_input_point_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_input_point_mut_t`. Caller must release with `kth_chain_input_point_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_input_point_mut_t kth_chain_input_point_copy(kth_input_point_const_t self);
+
+
+// Equality
+
+KTH_EXPORT
+kth_bool_t kth_chain_input_point_equals(kth_input_point_const_t self, kth_input_point_const_t other);
+
+
+// Serialization
+
+/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_chain_input_point_to_data(kth_input_point_const_t self, kth_bool_t wire, kth_size_t* out_size);
+
+KTH_EXPORT
+kth_size_t kth_chain_input_point_serialized_size(kth_input_point_const_t self, kth_bool_t wire);
+
+
+// Getters
+
+KTH_EXPORT
+kth_hash_t kth_chain_input_point_hash(kth_input_point_const_t self);
+
+KTH_EXPORT
+uint32_t kth_chain_input_point_index(kth_input_point_const_t self);
+
+KTH_EXPORT
+uint64_t kth_chain_input_point_checksum(kth_input_point_const_t self);
+
+
+// Setters
+
+/** @param value Borrowed input; must be non-null. Copied into the resulting object; ownership of `value` stays with the caller. */
+KTH_EXPORT
+void kth_chain_input_point_set_hash(kth_input_point_mut_t self, kth_hash_t const* value);
+
+/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`. */
+KTH_EXPORT
+void kth_chain_input_point_set_hash_unsafe(kth_input_point_mut_t self, uint8_t const* value);
+
+KTH_EXPORT
+void kth_chain_input_point_set_index(kth_input_point_mut_t self, uint32_t value);
+
+
+// Predicates
+
+KTH_EXPORT
+kth_bool_t kth_chain_input_point_is_valid(kth_input_point_const_t self);
+
+KTH_EXPORT
+kth_bool_t kth_chain_input_point_is_null(kth_input_point_const_t self);
+
+
+// Operations
+
+KTH_EXPORT
+void kth_chain_input_point_reset(kth_input_point_mut_t self);
+
+
+// Static utilities
+
+KTH_EXPORT
+kth_size_t kth_chain_input_point_satoshi_fixed_size(void);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // KTH_CAPI_CHAIN_INPUT_POINT_H_

--- a/src/c-api/include/kth/capi/handles.h
+++ b/src/c-api/include/kth/capi/handles.h
@@ -113,7 +113,16 @@ typedef void* kth_input_list_mut_t;
 typedef void const* kth_input_list_const_t;
 typedef void* kth_utxo_list_mut_t;
 typedef void const* kth_utxo_list_const_t;
-typedef void* kth_inputpoint_t;
+typedef void* kth_input_point_mut_t;
+typedef void const* kth_input_point_const_t;
+// Deprecated alias for back-compat with consumers built before the
+// typedef was renamed. New code should use `kth_input_point_mut_t` /
+// `kth_input_point_const_t`. The old spelling matches the project's
+// pre-convention "<name>_t" shape (no mut/const discriminant) — every
+// other handle in this file follows the two-word naming. Removal is
+// out of scope for the cleanup PR that introduced the new names; can
+// be dropped on a major version bump.
+typedef kth_input_point_mut_t kth_inputpoint_t;
 typedef void* kth_merkle_block_mut_t;
 typedef void const* kth_merkle_block_const_t;
 typedef void* kth_prefilled_transaction_mut_t;

--- a/src/c-api/src/chain/chain_sync.cpp
+++ b/src/c-api/src/chain/chain_sync.cpp
@@ -309,7 +309,7 @@ kth_error_code_t kth_chain_sync_transaction_position(kth_chain_t chain, kth_hash
     return res;
 }
 
-kth_error_code_t kth_chain_sync_spend(kth_chain_t chain, kth_output_point_const_t op, kth_inputpoint_t* out_input_point) {
+kth_error_code_t kth_chain_sync_spend(kth_chain_t chain, kth_output_point_const_t op, kth_input_point_mut_t* out_input_point) {
     std::latch latch(1); //Note: workaround to fix an error on some versions of Boost.Threads
     kth_error_code_t res;
 

--- a/src/c-api/src/chain/input_point.cpp
+++ b/src/c-api/src/chain/input_point.cpp
@@ -1,0 +1,169 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <utility>
+
+#include <kth/capi/chain/input_point.h>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/domain/chain/input_point.hpp>
+
+// File-local alias so `kth::cpp_ref<T>(...)` and friends don't
+// spell out the full qualified C++ name at every call site.
+namespace {
+using cpp_t = kth::domain::chain::input_point;
+} // namespace
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+// Constructors
+
+kth_input_point_mut_t kth_chain_input_point_construct_default(void) {
+    return kth::leak<cpp_t>();
+}
+
+kth_error_code_t kth_chain_input_point_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_input_point_mut_t* out) {
+    KTH_PRECONDITION(data != nullptr || n == 0);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto data_cpp = kth::byte_reader(kth::byte_span(data, kth::sz(n)));
+    auto const wire_cpp = kth::int_to_bool(wire);
+    auto result = cpp_t::from_data(data_cpp, wire_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_input_point_mut_t kth_chain_input_point_construct(kth_hash_t const* hash, uint32_t index) {
+    KTH_PRECONDITION(hash != nullptr);
+    auto const hash_cpp = kth::hash_to_cpp(hash->hash);
+    return kth::leak<cpp_t>(hash_cpp, index);
+}
+
+kth_input_point_mut_t kth_chain_input_point_construct_unsafe(uint8_t const* hash, uint32_t index) {
+    KTH_PRECONDITION(hash != nullptr);
+    auto const hash_cpp = kth::hash_to_cpp(hash);
+    return kth::leak<cpp_t>(hash_cpp, index);
+}
+
+
+// Static factories
+
+kth_input_point_mut_t kth_chain_input_point_null(void) {
+    return kth::leak(cpp_t::null());
+}
+
+
+// Destructor
+
+void kth_chain_input_point_destruct(kth_input_point_mut_t self) {
+    kth::del<cpp_t>(self);
+}
+
+
+// Copy
+
+kth_input_point_mut_t kth_chain_input_point_copy(kth_input_point_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::clone<cpp_t>(self);
+}
+
+
+// Equality
+
+kth_bool_t kth_chain_input_point_equals(kth_input_point_const_t self, kth_input_point_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::eq<cpp_t>(self, other);
+}
+
+
+// Serialization
+
+uint8_t* kth_chain_input_point_to_data(kth_input_point_const_t self, kth_bool_t wire, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto const wire_cpp = kth::int_to_bool(wire);
+    auto const data = kth::cpp_ref<cpp_t>(self).to_data(wire_cpp);
+    return kth::create_c_array(data, *out_size);
+}
+
+kth_size_t kth_chain_input_point_serialized_size(kth_input_point_const_t self, kth_bool_t wire) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const wire_cpp = kth::int_to_bool(wire);
+    return kth::cpp_ref<cpp_t>(self).serialized_size(wire_cpp);
+}
+
+
+// Getters
+
+kth_hash_t kth_chain_input_point_hash(kth_input_point_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::to_hash_t(kth::cpp_ref<cpp_t>(self).hash());
+}
+
+uint32_t kth_chain_input_point_index(kth_input_point_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).index();
+}
+
+uint64_t kth_chain_input_point_checksum(kth_input_point_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).checksum();
+}
+
+
+// Setters
+
+void kth_chain_input_point_set_hash(kth_input_point_mut_t self, kth_hash_t const* value) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::hash_to_cpp(value->hash);
+    kth::cpp_ref<cpp_t>(self).set_hash(value_cpp);
+}
+
+void kth_chain_input_point_set_hash_unsafe(kth_input_point_mut_t self, uint8_t const* value) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::hash_to_cpp(value);
+    kth::cpp_ref<cpp_t>(self).set_hash(value_cpp);
+}
+
+void kth_chain_input_point_set_index(kth_input_point_mut_t self, uint32_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<cpp_t>(self).set_index(value);
+}
+
+
+// Predicates
+
+kth_bool_t kth_chain_input_point_is_valid(kth_input_point_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_valid());
+}
+
+kth_bool_t kth_chain_input_point_is_null(kth_input_point_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_null());
+}
+
+
+// Operations
+
+void kth_chain_input_point_reset(kth_input_point_mut_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<cpp_t>(self).reset();
+}
+
+
+// Static utilities
+
+kth_size_t kth_chain_input_point_satoshi_fixed_size(void) {
+    return cpp_t::satoshi_fixed_size();
+}
+
+} // extern "C"

--- a/src/c-api/test/chain/input_point.cpp
+++ b/src/c-api/test/chain/input_point.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// `input_point` is a typedef alias for `point` in the domain layer
+// (`using input_point = point;`), so the underlying behavior is fully
+// covered by `test/chain/point.cpp`. This file exercises the C-API
+// surface specific to the alias — primarily `kth_chain_input_point_destruct`,
+// which is the only owning operation a consumer of `kth_spend_fetch_handler_t`
+// can call to release the `kth_input_point_mut_t` handed to them — plus
+// enough smoke coverage on the rest of the alias-prefixed surface to
+// prove the binding is wired through correctly.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+#include <string.h>
+
+#include <kth/capi/chain/input_point.h>
+#include <kth/capi/hash.h>
+#include <kth/capi/primitives.h>
+
+#include "../test_helpers.hpp"
+
+static kth_hash_t const kHash = {{
+    0x6f, 0xe2, 0x8c, 0x0a, 0xb6, 0xf1, 0xb3, 0x72,
+    0xc1, 0xa6, 0xa2, 0x46, 0xae, 0x63, 0xf7, 0x4f,
+    0x93, 0x1e, 0x83, 0x65, 0xe1, 0x5a, 0x08, 0x9c,
+    0x68, 0xd6, 0x19, 0x00, 0x00, 0x00, 0x00, 0x00
+}};
+
+// ---------------------------------------------------------------------------
+// Destructor — the reason this binding exists; null-safe contract documented
+// in the header.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API InputPoint - destruct null is a no-op", "[C-API InputPoint]") {
+    kth_chain_input_point_destruct(NULL);
+}
+
+TEST_CASE("C-API InputPoint - destruct frees an allocated handle", "[C-API InputPoint]") {
+    kth_input_point_mut_t ip = kth_chain_input_point_construct(&kHash, 7u);
+    REQUIRE(ip != NULL);
+    kth_chain_input_point_destruct(ip);
+}
+
+// ---------------------------------------------------------------------------
+// Smoke coverage of the alias-prefixed surface.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API InputPoint - default construct is invalid", "[C-API InputPoint]") {
+    kth_input_point_mut_t ip = kth_chain_input_point_construct_default();
+    REQUIRE(kth_chain_input_point_is_valid(ip) == 0);
+    kth_chain_input_point_destruct(ip);
+}
+
+TEST_CASE("C-API InputPoint - field constructor preserves hash and index", "[C-API InputPoint]") {
+    kth_input_point_mut_t ip = kth_chain_input_point_construct(&kHash, 1234u);
+    REQUIRE(kth_chain_input_point_is_valid(ip) != 0);
+    REQUIRE(kth_chain_input_point_index(ip) == 1234u);
+    REQUIRE(kth_hash_equal(kth_chain_input_point_hash(ip), kHash) != 0);
+    kth_chain_input_point_destruct(ip);
+}
+
+TEST_CASE("C-API InputPoint - to_data / from_data roundtrip", "[C-API InputPoint]") {
+    kth_input_point_mut_t expected = kth_chain_input_point_construct(&kHash, 53213u);
+
+    kth_size_t size = 0;
+    uint8_t* raw = kth_chain_input_point_to_data(expected, 1, &size);
+    REQUIRE(size == 36u);
+    REQUIRE(raw != NULL);
+
+    kth_input_point_mut_t parsed = NULL;
+    kth_error_code_t ec = kth_chain_input_point_construct_from_data(raw, size, 1, &parsed);
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(parsed != NULL);
+    REQUIRE(kth_chain_input_point_equals(expected, parsed) != 0);
+
+    kth_core_destruct_array(raw);
+    kth_chain_input_point_destruct(parsed);
+    kth_chain_input_point_destruct(expected);
+}
+
+TEST_CASE("C-API InputPoint - copy preserves fields", "[C-API InputPoint]") {
+    kth_input_point_mut_t original = kth_chain_input_point_construct(&kHash, 524342u);
+    kth_input_point_mut_t copy = kth_chain_input_point_copy(original);
+
+    REQUIRE(kth_chain_input_point_equals(original, copy) != 0);
+    REQUIRE(kth_chain_input_point_index(copy) == 524342u);
+
+    kth_chain_input_point_destruct(copy);
+    kth_chain_input_point_destruct(original);
+}
+
+TEST_CASE("C-API InputPoint - null factory is is_null", "[C-API InputPoint]") {
+    kth_input_point_mut_t ip = kth_chain_input_point_null();
+    REQUIRE(kth_chain_input_point_is_null(ip) != 0);
+    kth_chain_input_point_destruct(ip);
+}
+
+TEST_CASE("C-API InputPoint - satoshi_fixed_size is 36", "[C-API InputPoint]") {
+    REQUIRE(kth_chain_input_point_satoshi_fixed_size() == 36u);
+}


### PR DESCRIPTION
Wraps up the `kth_inputpoint_t` cleanup item that has been sitting in `TODO.md` since the wallet/coin_selection generator work landed.

## What was wrong

* `kth_inputpoint_t` was the only handle in `handles.h` that escaped the project's `<name>_<mut|const>_t` naming convention — a one-word typedef left over from before the discriminant convention solidified.
* The matching public destructor never landed. The `kth_spend_fetch_handler_t` doc comment in `callbacks.h` carried a "caller takes ownership; no public destructor exposed yet" disclaimer, making the receive path a documented leak.

## What changed

* **New typedefs** — `kth_input_point_mut_t` / `kth_input_point_const_t` added alongside the existing `kth_inputpoint_t`. The old name stays as a deprecated alias so consumers built against the previous header keep linking. Removal is left for a major version bump.
* **New destructor** — `kth_chain_input_point_destruct(self)` exposed in `chain/input_point.h` (new pair: header + `chain/input_point.cpp` source). Implementation delegates to the `point` deleter; `using input_point = point` in the domain layer means an input_point handle and a point handle are the same C++ object and the same delete works for both.
* **Renamed signatures** — `kth_chain_sync_spend` and `kth_spend_fetch_handler_t` switch to the new `kth_input_point_mut_t` spelling. Existing callers compile unchanged because the legacy alias resolves to the same `void*`.
* **Wiring** — `CMakeLists.txt` registers the new source / header, and `capi.h` adds the new umbrella include next to `chain/input_list.h`.

## Local verification

- The new typedefs + back-compat alias + destructor compile against the in-tree headers.
- `nm libc-api.a` lists `kth_chain_input_point_destruct`.
- `kth_capi_test` rebuilds clean against the renamed signature; the existing `chain_sync_spend`-touching tests link without changes.

## Test plan
- [ ] Linux GCC sanitizers builds and tests stay green.
- [ ] macOS apple-clang sanitizers stay green.
- [ ] No public ABI breakage for consumers built against the old header (`kth_inputpoint_t` still resolves).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the public C API surface for spend fetching (`kth_spend_fetch_handler_t`, `kth_chain_sync_spend`) and introduces new ownership/destructor semantics; consumers must follow the new `kth_chain_input_point_destruct` contract to avoid leaks.
> 
> **Overview**
> Completes the `kth_inputpoint_t` cleanup by introducing convention-aligned handle types `kth_input_point_mut_t`/`kth_input_point_const_t` (with `kth_inputpoint_t` kept as a deprecated alias for back-compat).
> 
> Adds a full `input_point` C-API module (`chain/input_point.h` + `src/chain/input_point.cpp`) including constructors, copy/equality, (de)serialization, getters/setters, predicates, and the new public destructor `kth_chain_input_point_destruct` so callers can release owned spend results.
> 
> Updates spend-related APIs (`kth_spend_fetch_handler_t`, `kth_chain_sync_spend`) to use the new handle name and wires the new module into the build (`CMakeLists.txt`), umbrella include (`capi.h`), and test suite (new `test/chain/input_point.cpp`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e891cf8ccd7044179b67db536ae547ff76a89247. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a C API for "input point" objects: creation, copy, comparison, serialization, getters/setters, validity/null checks, reset and null instance utilities.

* **Refactor**
  * Introduced typed input-point handles and standardized naming across the C API.
  * Updated related API signatures to use the new input-point types and clarified ownership/destructor responsibilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->