### PR TITLE
ci: serialize full-node smoke tests + cap ctest parallelism

### DIFF
--- a/.github/workflows/build-with-container.yml
+++ b/.github/workflows/build-with-container.yml
@@ -328,7 +328,21 @@ jobs:
           if [ "${{ inputs.enable-asan }}" = "true" ] || [ "${{ inputs.enable-ubsan }}" = "true" ] || [ "$TSAN_ENABLED_FOR_TESTS" = "true" ]; then
             timeout 1800 ctest --output-on-failure --parallel 2 || echo "Some tests may have failed or timed out with sanitizers"
           else
-            ctest --output-on-failure --parallel 4 || echo "Some tests may have failed, but continuing..."
+            # `ctest --parallel 4` was OK until ~2026-05-03, when the
+            # post-merge master CI started dying inside the test step
+            # with "runner lost communication with the server" — GHA's
+            # report when the runner process gets OS-killed (memory
+            # SIGKILL). The trigger was `readme_c_runtime` /
+            # `readme_cpp_runtime` (added in PR #325): both spin up a
+            # full node with LMDB databases and network threads, and
+            # when ctest scheduled them in parallel with three other
+            # tests the peak memory exceeded the hosted runner's
+            # 7 GB ceiling. Capping parallelism at 2 keeps the heavy
+            # tests from pairing up with each other or with other
+            # memory-hungry tests; the wall-clock cost is ~50 % more
+            # in the worst case but the build was already test-bound,
+            # not CPU-bound.
+            ctest --output-on-failure --parallel 2 || echo "Some tests may have failed, but continuing..."
           fi
 
       - name: ⏭️ Skip tests info

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -290,7 +290,7 @@ jobs:
       compiler-version: ${{ matrix.config.version }}
       build-version: "${{ needs.setup.outputs.build-version }}"
       enable-asan: false   # Always enabled (sanitizer builds)
-      enable-ubsan: false  # Always enabled (sanitizer builds) 
+      enable-ubsan: false  # Always enabled (sanitizer builds)
       enable-tsan: false   # Always enabled (sanitizer builds)
       skip-tests: false
     secrets:

--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -642,7 +642,18 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     target_link_libraries(kth_readme_c_runtime PRIVATE ${PROJECT_NAME})
     target_link_libraries(kth_readme_c_runtime PRIVATE Threads::Threads)
     add_test(NAME kth_readme_c_runtime COMMAND kth_readme_c_runtime)
-    set_tests_properties(kth_readme_c_runtime PROPERTIES TIMEOUT 60)
+    # Spins up a full `kth_node_*` instance with an LMDB chain database
+    # and a network thread pool — peak memory is large enough that
+    # ctest scheduling it concurrently with other tests on the GHA
+    # hosted runner (7 GB ceiling) tipped the post-merge master CI
+    # into runner-OOM kills since 2026-05-03. PROCESSORS 4 reserves
+    # the full CPU slot count, so ctest serialises this against every
+    # other test on a 4-core runner without forcing the rest of the
+    # suite to run serially.
+    set_tests_properties(kth_readme_c_runtime PROPERTIES
+        TIMEOUT 60
+        PROCESSORS 4
+        RUN_SERIAL TRUE)
 endif()
 
 

--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -311,7 +311,18 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
   add_executable(kth_readme_cpp_runtime test/readme_cpp_runtime.cpp)
   target_link_libraries(kth_readme_cpp_runtime PRIVATE ${PROJECT_NAME})
   add_test(NAME kth_readme_cpp_runtime COMMAND kth_readme_cpp_runtime)
-  set_tests_properties(kth_readme_cpp_runtime PROPERTIES TIMEOUT 60)
+  # Spins up a full `kth::node::full_node` instance with an LMDB
+  # chain database and a network thread pool — peak memory is
+  # large enough that ctest scheduling it concurrently with other
+  # tests on the GHA hosted runner (7 GB ceiling) tipped the
+  # post-merge master CI into runner-OOM kills since 2026-05-03.
+  # PROCESSORS 4 reserves the full CPU slot count, so ctest
+  # serialises this against every other test on a 4-core runner
+  # without forcing the rest of the suite to run serially.
+  set_tests_properties(kth_readme_cpp_runtime PROPERTIES
+      TIMEOUT 60
+      PROCESSORS 4
+      RUN_SERIAL TRUE)
 endif()
 
 


### PR DESCRIPTION
## Summary

Master CI has been red since 2026-05-03 because the post-merge
\"Sanitizers\" job (sanitizers disabled — input flags are all
\`false\`) dies inside the test step with \"hosted runner lost
communication with the server\" — GHA's report when the runner
process gets OS-killed (memory SIGKILL).

The trigger is the full-node smoke tests added in PR #325
(\`readme_c_runtime\` / \`readme_cpp_runtime\`). Each spins up a
real \`kth_node_*\` / \`kth::node::full_node\` instance with an
LMDB chain database and a network thread pool — peak memory is
large enough that ctest scheduling either of them concurrently
with other tests on the 7 GB hosted runner pushed peak memory
past the OOM threshold.

## Diff

* **\`src/c-api/CMakeLists.txt\`, \`src/node/CMakeLists.txt\`** —
  add \`PROCESSORS 4\` + \`RUN_SERIAL TRUE\` to the two heavy
  full-node tests. ctest treats either property as \"this test
  needs all the runner's slots\", so nothing else runs while a
  heavy test is running. Other tests parallelise normally
  between runs.

* **\`build-with-container.yml\`** — drop ctest \`--parallel 4\`
  to \`--parallel 2\` on the non-sanitizer path. The sanitizer
  path was already capped at 2. Belt and suspenders against any
  future memory-hungry test the CMake property doesn't cover.

(An earlier revision marked the Sanitizers matrix
\`continue-on-error: true\` as a safety net, but GitHub Actions
disallows that key on jobs that call a reusable workflow — the
validation rejected the workflow before any job ran. Removed.
The CMake serialization is the actual fix; the parallelism
cap is the safety net.)

## What's unchanged

Every existing matrix job still runs. The release matrix
(\`build-with-container-release\`,
\`build-without-container-release\`) skips tests via
\`if: \${{ inputs.skip-tests != true && inputs.upload != true }}\`
and remains required.

## Test plan

- [ ] CI runs on this PR — Sanitizers matrix entries
      complete inside the runner memory budget.
- [ ] After merge, the next master build's Sanitizers
      entries go green.
- [ ] Cut a release branch and confirm the release matrix
      runs to completion with uploads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI stability by reducing test parallelism and tightening test execution constraints to avoid runner OOM and scheduling issues.
  * Added clearer CI diagnostics and comments to aid failure investigation and maintain consistent sanitizer/non-sanitizer behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/k-nuth/kth/pull/331)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->