### PR TITLE
fix(wallet): payment_address accessors return sentinels for 32-byte hashes

### DIFF
--- a/src/domain/include/kth/domain/wallet/payment_address.hpp
+++ b/src/domain/include/kth/domain/wallet/payment_address.hpp
@@ -112,6 +112,12 @@ struct KD_API payment_address {
     bool valid() const;
 
     /// Serializer.
+    /// Legacy base58 encoding (`<version><20-byte hash><checksum>`).
+    /// Only valid for 20-byte addresses (P2KH, P2SH). Returns an
+    /// empty string when the address carries a 32-byte hash
+    /// (`pay_script_hash_32`, BCH 2025 Leibniz) — that hash size
+    /// has no legacy representation; use `encoded_cashaddr()` /
+    /// `encoded_token()` instead.
     [[nodiscard]]
     std::string encoded_legacy() const;
 
@@ -130,6 +136,10 @@ struct KD_API payment_address {
     [[nodiscard]]
     byte_span hash_span() const;
 
+    /// 20-byte hash accessor. Only valid for 20-byte addresses
+    /// (P2KH, P2SH). Returns `null_short_hash` when the address
+    /// carries a 32-byte hash — use `hash32()` for 32-byte payloads
+    /// or `hash_span()` for the size-agnostic path.
     [[nodiscard]]
     short_hash hash20() const;
 
@@ -137,6 +147,10 @@ struct KD_API payment_address {
     hash_digest const& hash32() const;
 
     /// Methods.
+    /// 25-byte `<version><20-byte hash><checksum>` payment layout.
+    /// Only valid for 20-byte addresses. Returns a zero-initialised
+    /// `payment` when the address carries a 32-byte hash — the
+    /// `payment` byte_array has no representation for that size.
     [[nodiscard]]
     payment to_payment() const;
 

--- a/src/domain/src/wallet/payment_address.cpp
+++ b/src/domain/src/wallet/payment_address.cpp
@@ -314,6 +314,17 @@ bool payment_address::valid() const {
 // ----------------------------------------------------------------------------
 
 std::string payment_address::encoded_legacy() const {
+    // Legacy base58 wraps a 20-byte hash; the format has no
+    // representation for the 32-byte hashes that ship under BCH's
+    // `pay_script_hash_32` pattern (2025 Leibniz). Calling this on
+    // such an address would silently truncate to the first 20
+    // bytes — surface that as an empty string sentinel so callers
+    // can detect "no legacy form available" instead of acting on
+    // wrong-but-plausible output. CashAddr (`encoded_cashaddr` /
+    // `encoded_token`) is the right encoder for 32-byte hashes.
+    if (hash_size_ != short_hash_size) {
+        return {};
+    }
     return encode_base58(wrap(version_, hash20()));
 }
 
@@ -425,6 +436,15 @@ kth::byte_span payment_address::hash_span() const {
 }
 
 short_hash payment_address::hash20() const {
+    // `pay_script_hash_32` (BCH 2025 Leibniz) addresses store a
+    // 32-byte hash that doesn't fit in a `short_hash`. Returning
+    // the first 20 bytes would be silent truncation. Surface that
+    // as the zero sentinel so callers can detect "no 20-byte hash
+    // available" — use `hash32()` for 32-byte payloads or
+    // `hash_span()` for the general case.
+    if (hash_size_ != short_hash_size) {
+        return null_short_hash;
+    }
     short_hash hash;
     std::copy_n(hash_data_.begin(), hash.size(), hash.begin());
     return hash;
@@ -438,6 +458,17 @@ hash_digest const& payment_address::hash32() const {
 // ----------------------------------------------------------------------------
 
 payment payment_address::to_payment() const {
+    // `payment` is the fixed 25-byte (`version` + 20-byte hash +
+    // 4-byte checksum) layout. There's no representation for a
+    // 32-byte hash — calling this on a `pay_script_hash_32`
+    // address would silently truncate via `hash20()` and then
+    // checksum-sign the truncated bytes, producing a plausible-
+    // looking but wrong payment. Return the zero sentinel so
+    // callers can detect "no `payment` representation" and route
+    // through CashAddr instead.
+    if (hash_size_ != short_hash_size) {
+        return payment{};
+    }
     return wrap(version_, hash20());
 }
 

--- a/src/domain/test/wallet/payment_address.cpp
+++ b/src/domain/test/wallet/payment_address.cpp
@@ -281,7 +281,51 @@ TEST_CASE("payment_address token address from string", "[payment_address]") {
     REQUIRE(address.valid());
     REQUIRE(address.encoded_cashaddr(false) == "bitcoincash:pvstqkm54dtvnpyqxt5m5n7sjsn4enrlxc526xyxlnjkaycdzfeu69reyzmqx");
     REQUIRE(address.encoded_cashaddr(true) == "bitcoincash:rvstqkm54dtvnpyqxt5m5n7sjsn4enrlxc526xyxlnjkaycdzfeu6hs99m6ed");
-    REQUIRE(address.encoded_legacy() == "34frpCV2v6wtzig9xx4Z9XJ6s4jU3zqwR7");  // In fact a 32-byte address is not representable in legacy encoding.
+    // 32-byte address (`pay_script_hash_32`) — no legacy
+    // representation; `encoded_legacy()` returns an empty string
+    // instead of truncating the hash to 20 bytes and producing a
+    // plausible-looking but incorrect base58 result.
+    REQUIRE(address.encoded_legacy().empty());
+}
+
+// ---------------------------------------------------------------------------
+// 32-byte hash truncation guards (`pay_script_hash_32`, BCH 2025 Leibniz)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("payment_address 32-byte hash20 returns null sentinel", "[payment_address]") {
+    // Build a `payment_address` directly from a 32-byte hash, then
+    // call the 20-byte accessor. Previous behaviour was a silent
+    // copy of the first 20 bytes (truncation); the fix surfaces
+    // that as the all-zeros sentinel so callers can detect it.
+    hash_digest h32;
+    for (size_t i = 0; i < h32.size(); ++i) h32[i] = static_cast<uint8_t>(i + 1);
+    payment_address const address(h32);
+    REQUIRE(address.valid());
+    REQUIRE(address.hash20() == null_short_hash);
+    REQUIRE(address.hash32() == h32);
+}
+
+TEST_CASE("payment_address 32-byte to_payment returns zero sentinel", "[payment_address]") {
+    hash_digest h32;
+    for (size_t i = 0; i < h32.size(); ++i) h32[i] = static_cast<uint8_t>(i + 1);
+    payment_address const address(h32);
+    REQUIRE(address.valid());
+    // `payment` is `byte_array<25>`; zero-initialised compares
+    // equal against any other zero-initialised `payment`.
+    payment const zero_payment{};
+    REQUIRE(address.to_payment() == zero_payment);
+}
+
+TEST_CASE("payment_address 20-byte accessors stay untouched on 20-byte hashes", "[payment_address]") {
+    // Regression: the 32-byte guard must not engage for the
+    // common P2KH / P2SH case.
+    auto const hash = decode_base16<short_hash_size>(compressed_hash);
+    REQUIRE(hash);
+    payment_address const address(*hash);
+    REQUIRE(address.valid());
+    REQUIRE(address.hash20() == *hash);
+    REQUIRE_FALSE(address.encoded_legacy().empty());
+    REQUIRE(address.encoded_legacy() == address_compressed);
 }
 
 #endif


### PR DESCRIPTION
## Summary

Closes #243.

\`payment_address\` can hold either a 20-byte or 32-byte hash. The
32-byte form ships under BCH's \`pay_script_hash_32\` pattern
(2025 Leibniz upgrade). Three accessors were written for the
20-byte shape only and silently truncated when called on a
32-byte address:

* **\`hash20()\`** copied the first 20 bytes of the 32-byte hash
  into a \`short_hash\` and returned that — caller had no way
  to tell the result was truncated.
* **\`encoded_legacy()\`** ran the truncated hash through
  \`wrap(version, hash20())\` + \`encode_base58\`, producing a
  plausible-looking but incorrect legacy address string.
* **\`to_payment()\`** produced the same truncated 25-byte
  \`<version><20-byte hash><checksum>\` payload.

The existing \`payment_address token address from string\` test
even asserted the wrong legacy output verbatim, locking the bug
in place.

## Diff

* \`src/domain/src/wallet/payment_address.cpp\` — add
  \`hash_size_ != short_hash_size\` guard to each of the three
  accessors. Sentinels: \`null_short_hash\` /
  empty \`std::string\` / zero-initialised \`payment\`.
* \`src/domain/include/kth/domain/wallet/payment_address.hpp\` —
  header docs on each affected accessor spell out the contract
  and point at \`hash32()\` / \`hash_span()\` /
  \`encoded_cashaddr()\` for the 32-byte path.
* \`src/domain/test/wallet/payment_address.cpp\` — flip the
  locked-in regression to assert \`encoded_legacy().empty()\`;
  three new TEST_CASEs cover the 32-byte sentinel paths plus
  a 20-byte regression so the guard doesn't engage for the
  common P2KH / P2SH case.

## What's NOT in this PR

* No C-API binding changes. The C-API faithfully exposes the
  new behaviour — \`kth_wallet_payment_address_hash20\` now
  returns a zero \`kth_shorthash_t\`,
  \`kth_wallet_payment_address_encoded_legacy\` returns an
  owned empty C-string, and
  \`kth_wallet_payment_address_to_payment\` returns a zero
  \`kth_payment_t\`. Same FFI, safer behaviour.

## Test plan

- [ ] \`payment_address\` tests pass — new TEST_CASEs cover the
      32-byte path, existing 20-byte tests stay untouched.
- [ ] CI green (Linux + macOS + sanitizers).
- [ ] Spot-check any caller of \`encoded_legacy\` / \`hash20\` /
      \`to_payment\` in the wider tree for assumptions that a
      non-empty result is always valid.