### PR TITLE
Update maximum network protocol version to 70016

### DIFF
--- a/config/kth-bch-mainnet-pruned-ibd.cfg
+++ b/config/kth-bch-mainnet-pruned-ibd.cfg
@@ -10,7 +10,7 @@ verbose = true
 threads = 1
 hosts_file = /home/fernando/kth-exec/hosts.cache
 
-protocol_maximum = 70013
+protocol_maximum = 70016
 # protocol_maximum = 70015
 protocol_minimum = 31402
 identifier = 3908297187

--- a/src/node/data/bn.cfg
+++ b/src/node/data/bn.cfg
@@ -23,8 +23,8 @@ verbose = false
 [network]
 # The minimum number of threads in the network threadpool, defaults to 0 (physical cores).
 threads = 0
-# The maximum network protocol version, defaults to 70013.
-protocol_maximum = 70013
+# The maximum network protocol version, defaults to 70016.
+protocol_maximum = 70016
 # The minimum network protocol version, defaults to 31402.
 protocol_minimum = 31402
 # The services exposed by network connections, defaults to 1 (9 = full node, witness).


### PR DESCRIPTION
I was hoping the max supported protocol version kth supports is 70016? Is this correct?

We also might want to change some other files then.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network protocol version support to enhance compatibility with the latest network infrastructure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/k-nuth/kth/pull/335)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->