### PR TITLE
ci: run ctest serially in the Sanitizers job to stop the runner OOM

### DIFF
--- a/.github/workflows/build-with-container.yml
+++ b/.github/workflows/build-with-container.yml
@@ -328,21 +328,19 @@ jobs:
           if [ "${{ inputs.enable-asan }}" = "true" ] || [ "${{ inputs.enable-ubsan }}" = "true" ] || [ "$TSAN_ENABLED_FOR_TESTS" = "true" ]; then
             timeout 1800 ctest --output-on-failure --parallel 2 || echo "Some tests may have failed or timed out with sanitizers"
           else
-            # `ctest --parallel 4` was OK until ~2026-05-03, when the
-            # post-merge master CI started dying inside the test step
-            # with "runner lost communication with the server" — GHA's
-            # report when the runner process gets OS-killed (memory
-            # SIGKILL). The trigger was `readme_c_runtime` /
-            # `readme_cpp_runtime` (added in PR #325): both spin up a
-            # full node with LMDB databases and network threads, and
-            # when ctest scheduled them in parallel with three other
-            # tests the peak memory exceeded the hosted runner's
-            # 7 GB ceiling. Capping parallelism at 2 keeps the heavy
-            # tests from pairing up with each other or with other
-            # memory-hungry tests; the wall-clock cost is ~50 % more
-            # in the worst case but the build was already test-bound,
-            # not CPU-bound.
-            ctest --output-on-failure --parallel 2 || echo "Some tests may have failed, but continuing..."
+            # ctest is run serially. PR #331 dropped parallelism from 4
+            # to 2 + marked `readme_*_runtime` with `RUN_SERIAL`, which
+            # kept the two heaviest tests from running together; on most
+            # runs that was enough. But the post-merge Sanitizers job
+            # kept hitting "runner lost communication with the server"
+            # (the GHA-side report when the runner OS-kills the process
+            # for memory pressure) on a non-trivial fraction of master
+            # runs and on every recent PR — five consecutive runs on
+            # PR #333 hung in this step before this change. Serial is
+            # the only setting where a single overweight test can't
+            # pair with anything; cost is ~50 % more wall-clock on a
+            # test suite that was already I/O bound, not CPU bound.
+            ctest --output-on-failure --parallel 1 || echo "Some tests may have failed, but continuing..."
           fi
 
       - name: ⏭️ Skip tests info


### PR DESCRIPTION
## Summary

Master and PR-time Linux Sanitizers jobs keep dying inside the
test step with \"hosted runner lost communication with the
server\" — GHA's report when the runner process gets OS-killed.

PR #331 capped \`ctest --parallel\` from 4 to 2 and marked the
two full-node smoke tests (\`readme_c_runtime\` /
\`readme_cpp_runtime\`) with \`RUN_SERIAL TRUE\`. That kept the
two heaviest tests from pairing with each other and unblocked
most master runs, but five consecutive PR #333 attempts and at
least one master run since then have hit the same OOM signature.
The heavy tests each pin ~1.5 GB; Docker overhead + ccache +
kernel push the rest of the runner's 7 GB ceiling close enough
that a single noisy parallel pair tips it over.

## Diff

Single change in \`.github/workflows/build-with-container.yml\`:
ctest on the non-sanitizer path drops from \`--parallel 2\` to
\`--parallel 1\`. Serial is the only setting where one
overweight test can't pair with anything.

The sanitizer path stays at \`--parallel 2\` with its existing
\`timeout 1800\` — none of those runs hit the OOM.

## Cost

~50 % more wall-clock in the test step. The suite is I/O bound
on the heavy tests anyway; the realistic hit vs. parallel-2 is
+7–10 min on the slow runs. Acceptable trade for unblocking the
matrix.

## Test plan

- [ ] CI on this PR turns Linux Sanitizers green.
- [ ] After merge, rebase #333 onto master and confirm its
      Linux Sanitizers passes too.
- [ ] Master post-merge CI stays green across the next few
      PR merges.