### PR TITLE
fix(domain): tolerate trailing bytes in version message for forward compat

### DIFF
--- a/src/domain/src/message/version.cpp
+++ b/src/domain/src/message/version.cpp
@@ -113,6 +113,13 @@ expect<message::version> version::from_data(byte_reader& reader, uint32_t versio
         reader.is_exhausted() ||
         (self_bip37 && reader.read_byte().value_or(0) != 0);
 
+    // Newer peers (e.g. BCHN/ABC at protocol >= 70016) append additional
+    // optional fields to `version`. Bitcoin's wire format is forward-compatible
+    // by design — receivers must ignore unknown trailing data instead of
+    // dropping the connection. Drain whatever the peer added so the channel
+    // proxy's exhaustion check does not classify the message as malformed.
+    reader.skip_remaining();
+
     return message::version {
         *value,
         *services,

--- a/src/domain/test/message/version.cpp
+++ b/src/domain/test/message/version.cpp
@@ -345,7 +345,32 @@ TEST_CASE("version from data valid input  success", "[version]") {
     REQUIRE(expected == result);
 }
 
+// Newer peers append unknown trailing fields to the version message. The
+// receiver must accept the message and leave the reader exhausted; otherwise
+// the channel proxy classifies the payload as malformed and drops the
+// connection, isolating the node from any peer running a newer protocol.
+TEST_CASE("version from data tolerates trailing bytes  success", "[version]") {
+    const message::version expected{
+        70017u, 1515u, 979797u,
+        {734678u, 5357534u,
+         {{0x47, 0x81, 0x6a, 0x40, 0xbb, 0x92, 0xbd, 0xb4,
+           0xe0, 0xb8, 0x25, 0x68, 0x61, 0xf9, 0x6a, 0x55}},
+         123u},
+        {46324u, 1515u,
+         {{0xab, 0xcd, 0x6a, 0x40, 0x33, 0x92, 0x77, 0xb4,
+           0xe0, 0xb8, 0xda, 0x43, 0x61, 0x66, 0x6a, 0x88}},
+         351u},
+        13626u, "my agent", 100u, true};
 
+    auto data = expected.to_data(version_maximum);
+    data.insert(data.end(), {0xde, 0xad, 0xbe, 0xef, 0x00, 0x01, 0x02, 0x03});
+
+    byte_reader reader(data);
+    auto const result_exp = message::version::from_data(reader, version_maximum);
+    REQUIRE(result_exp);
+    REQUIRE(reader.is_exhausted());
+    REQUIRE(*result_exp == expected);
+}
 
 TEST_CASE("version  value accessor  returns initialized value", "[version]") {
     uint32_t const expected = 210u;


### PR DESCRIPTION
## Summary
- Drain remaining bytes inside `version::from_data` after parsing the optional `relay` field, so unknown trailing data appended by newer peers does not surface as a malformed payload up the channel proxy.
- New unit test exercises a `version` payload with extra bytes appended and asserts the reader is exhausted on return.

## Why
Bitcoin's wire format is forward-compatible: receivers are expected to ignore unknown fields appended to a message. The channel proxy enforces strict exhaustion and stops the channel with `bad_stream` if any bytes remain after parsing, so a `version` message that carries optional trailing data trips `Invalid version payload from [...] trailing bytes.` and aborts the handshake.

Peers running newer protocol versions append additional trailing fields to the `version` payload. kth currently rejects those as malformed and falls back to peers on older protocol versions — fine on a healthy network, but a peer-isolation cascade once the surrounding network advances. Observed on the production fleet, stuck at height 951146 while peers running newer protocols make further progress.

## Test plan
- [x] `version from data tolerates trailing bytes  success` covers the new path.
- [ ] `kth_domain_test` stays green in CI.
- [ ] After deploy, the production fleet completes handshake against newer peers and resumes block sync past 951146.