### PR TITLE
fix(wallet): restore base58 sentinel for default-constructed payment_address

### DIFF
--- a/src/domain/src/wallet/payment_address.cpp
+++ b/src/domain/src/wallet/payment_address.cpp
@@ -322,7 +322,13 @@ std::string payment_address::encoded_legacy() const {
     // can detect "no legacy form available" instead of acting on
     // wrong-but-plausible output. CashAddr (`encoded_cashaddr` /
     // `encoded_token`) is the right encoder for 32-byte hashes.
-    if (hash_size_ != short_hash_size) {
+    //
+    // Default-constructed addresses have hash_size_ == 0; they must
+    // keep returning the historical zero-hash sentinel (the all-1's
+    // base58 string "1111…oLvT2") that callers and existing tests
+    // rely on, so the guard only triggers for the genuinely oversized
+    // 32-byte case.
+    if (hash_size_ > short_hash_size) {
         return {};
     }
     return encode_base58(wrap(version_, hash20()));


### PR DESCRIPTION
## Summary
Narrow the 32-byte guard in `payment_address::encoded_legacy()` from `!= short_hash_size` to `> short_hash_size`, so default-constructed (and otherwise empty) addresses keep returning the historical all-1's base58 sentinel.

## Why
PR #332 widened the guard in `encoded_legacy()` to bail out whenever `hash_size_ != short_hash_size`, with the intent of preventing silent 32-byte truncation under `pay_script_hash_32`. The widening also caught the `hash_size_ == 0` case of a default-constructed address, breaking the long-standing contract that an invalid address still serialises to `"1111111111111111111114oLvT2"`.

The two `payment_address` construction tests have been failing on `master` since #332 landed (the ctest summary slipped through CI as a fleet-of-99% "green"):

```
99% tests passed, 2 tests failed out of 5149
  2978 - payment_address construct string invalid invalid (Failed)
  4207 - payment_address construct default invalid       (Failed)
```

Switching to `> short_hash_size` keeps the 32-byte hash path returning the empty sentinel (intent of #332) while leaving the 0-byte default and the 20-byte short hash on the original base58 encoder path. `hash20()` and `to_payment()` keep their `!= short_hash_size` checks: for `hash_size_ == 0` they already produce `null_short_hash` / `payment{}`, which is the right sentinel for those accessors.

## Test plan
- [ ] Tests 2978 and 4207 pass locally + in CI.
- [ ] Full domain test suite stays green.