### PR TITLE
fix(domain): activate new feature bits for MTP-gated upgrades in chain_state

### DIFF
--- a/src/domain/src/chain/chain_state.cpp
+++ b/src/domain/src/chain/chain_state.cpp
@@ -584,13 +584,11 @@ chain_state::activations chain_state::activation(data const& values, script_flag
 
     auto const mtp = median_time_past(values);
     if (is_mtp_activated(mtp, std::to_underlying(leibniz_activation_time))) {
-        //Note(Fernando): Move this to the next fork rules
-        result.flags |= (to_flags(upgrade::bch_leibniz) & flags);
+        result.flags |= to_flags(upgrade::bch_leibniz);
     }
 
     if (is_mtp_activated(mtp, std::to_underlying(cantor_activation_time))) {
-        //Note(Fernando): Move this to the next fork rules
-        result.flags |= (to_flags(upgrade::bch_cantor) & flags);
+        result.flags |= to_flags(upgrade::bch_cantor);
     }
 
     // Old rules with Replay Protection


### PR DESCRIPTION
## Summary
Drop the `& flags` mask from the MTP-gated branches in `chain_state::activation()`. The MTP gate already serves as the authoritative activation signal for these branches; the intersection against the settings-derived mask is a leftover from the previous two-mask layout (separate `forks` for upgrade names and `flags` for feature bits) and no longer matches the merged-flags semantics.

## Test plan
- [ ] `kth_domain_test` and `kth_blockchain_test` stay green in CI.