### PR TITLE
ci: split Linux into Build & Test + Sanitizers; fix ccache hit rate on macOS

### DIFF
--- a/.github/workflows/build-with-container.yml
+++ b/.github/workflows/build-with-container.yml
@@ -139,8 +139,13 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: /github/home/.cache/ccache
-          key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ github.sha }}
-          restore-keys: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-
+          # Two disjoint cache families: 'sanitizers' and 'clean'.
+          # Sanitizer flags change every compile command, so a sanitizer
+          # cache restored into a non-sanitizer build (or vice-versa)
+          # produces ~0 hits. The explicit suffix on both branches keeps
+          # `restore-keys`' prefix match from leaking between families.
+          key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-${{ github.sha }}
+          restore-keys: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-
 
       - name: 🔨 Build
         working-directory: .
@@ -184,16 +189,27 @@ jobs:
             export LDFLAGS="$LDFLAGS $SANITIZER_FLAGS"
           fi
           
+          # secp256k1's `field_5x52_asm_impl.h` reserves enough registers
+          # that ASan's shadow-register pressure pushes it over the limit
+          # and the compile fails with "'asm' operand has impossible
+          # constraints or there are not enough registers". When ASan is
+          # active fall back to the C path for that module. UBSan alone
+          # is fine.
+          EXTRA_CONAN_OPTS=""
+          if [ "${{ inputs.enable-asan }}" = "true" ]; then
+            EXTRA_CONAN_OPTS="-o secp256k1_use_asm=False"
+          fi
+
           # Choose build strategy based on whether we need to upload
           if [ "${{ inputs.upload }}" = "true" ]; then
             echo "🚀 Release build - using conan create (includes package validation)"
             conan remote login -p ${{ secrets.CONAN_PASSWORD }} ${{ inputs.conan-remote }} ${{ secrets.CONAN_LOGIN_USERNAME }}
-            conan lock create conanfile.py --version ${{ inputs.build-version }} --lockfile=conan.lock --lockfile-out=build/conan.lock -pr:b linux-ci-cd -pr:h linux-ci-cd -o march_id=ZLm9Pjh
-            conan create conanfile.py --version ${{ inputs.build-version }} --lockfile=build/conan.lock -pr:b linux-ci-cd -pr:h linux-ci-cd --build=missing -o march_id=ZLm9Pjh -o tests=False
+            conan lock create conanfile.py --version ${{ inputs.build-version }} --lockfile=conan.lock --lockfile-out=build/conan.lock -pr:b linux-ci-cd -pr:h linux-ci-cd -o march_id=ZLm9Pjh $EXTRA_CONAN_OPTS
+            conan create conanfile.py --version ${{ inputs.build-version }} --lockfile=build/conan.lock -pr:b linux-ci-cd -pr:h linux-ci-cd --build=missing -o march_id=ZLm9Pjh -o tests=False $EXTRA_CONAN_OPTS
           else
             echo "🔨 Development build - direct compilation with tests"
-            conan lock create conanfile.py --version ${{ inputs.build-version }} --lockfile=conan.lock --lockfile-out=build/conan.lock -pr:b linux-ci-cd -pr:h linux-ci-cd -o march_id=ZLm9Pjh
-            conan install conanfile.py --lockfile=build/conan.lock -of build --build=missing -pr:b linux-ci-cd -pr:h linux-ci-cd -o march_id=ZLm9Pjh -o tests=True
+            conan lock create conanfile.py --version ${{ inputs.build-version }} --lockfile=conan.lock --lockfile-out=build/conan.lock -pr:b linux-ci-cd -pr:h linux-ci-cd -o march_id=ZLm9Pjh $EXTRA_CONAN_OPTS
+            conan install conanfile.py --lockfile=build/conan.lock -of build --build=missing -pr:b linux-ci-cd -pr:h linux-ci-cd -o march_id=ZLm9Pjh -o tests=True $EXTRA_CONAN_OPTS
             
             CCACHE_OPT=""
             if command -v ccache &>/dev/null; then
@@ -246,7 +262,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: /github/home/.cache/ccache
-          key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ github.sha }}
+          key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-${{ github.sha }}
 
       - name: 📊 Build summary
         if: always()
@@ -297,6 +313,17 @@ jobs:
         if: ${{ inputs.skip-tests != true && inputs.upload != true }}
         working-directory: .
         run: |
+          # The Build & Test job has been ending with the container in a
+          # state where `docker exec` no longer responds — `Post Checkout
+          # code` then sits in_progress until the step timeout fires and
+          # the whole job is reported as failed, even though ctest itself
+          # passed. Print memory pressure and the kernel ring tail before
+          # and after the test phase so the next stuck run leaves OOM /
+          # cgroup-kill evidence in the workflow log instead of vanishing
+          # with the container.
+          echo "=== mem before tests ==="; free -m || true
+          echo "=== dmesg tail before tests ==="; dmesg | tail -20 2>/dev/null || true
+
           echo "🧪 Running unit tests for development build..."
           
           # Set sanitizer options for better reporting (preserve conflict resolution from build step)
@@ -342,6 +369,10 @@ jobs:
             # test suite that was already I/O bound, not CPU bound.
             timeout 1800 ctest --output-on-failure --parallel 1 || echo "Some tests may have failed or timed out, but continuing..."
           fi
+
+          echo "=== mem after tests ==="; free -m || true
+          echo "=== dmesg tail after tests ==="; dmesg | tail -40 2>/dev/null || true
+          echo "=== processes still alive ==="; ps -eo pid,ppid,rss,comm --sort=-rss | head -20 || true
 
       - name: ⏭️ Skip tests info
         if: ${{ inputs.skip-tests == true }}

--- a/.github/workflows/build-without-container.yml
+++ b/.github/workflows/build-without-container.yml
@@ -124,11 +124,28 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/Library/Caches/ccache
-          key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ github.sha }}
-          restore-keys: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-
+          # Two disjoint cache families ('sanitizers' / 'clean') so the
+          # restore-keys' prefix match can't leak across families.
+          key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-${{ github.sha }}
+          restore-keys: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-
 
       - name: 🔨 Build
         working-directory: .
+        env:
+          # Hosted macOS runners change the workspace path between runs
+          # (`/Users/runner/work/_temp/<random>/…`), and apple-clang is
+          # invoked from `/Applications/Xcode_*.app/Contents/…`. Without
+          # the overrides below ccache hashes those absolute paths into
+          # its "Direct" key, falls through to "Preprocessed" mode for
+          # every TU and ends up at ~6 % hit rate — the build re-runs
+          # nearly from scratch. `CCACHE_BASEDIR` rewrites paths under
+          # the workspace to be relative before hashing; `compilercheck=
+          # content` keys off the compiler binary's contents instead of
+          # its mtime/path; the sloppiness list ignores macros that
+          # vary across runs but don't change generated code.
+          CCACHE_BASEDIR: ${{ github.workspace }}
+          CCACHE_COMPILERCHECK: content
+          CCACHE_SLOPPINESS: pch_defines,time_macros,locale,system_headers
         run: |
           # Prepare sanitizer flags
           SANITIZER_FLAGS=""

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -277,11 +277,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
-    name: ${{ matrix.config.name }} (Sanitizers)
+    name: ${{ matrix.config.name }} (Build & Test)
     uses: ./.github/workflows/build-with-container.yml
     with:
       if: ${{ matrix.config.compiler == 'GCC' }}
-      upload: false  # Never upload sanitizer builds
+      upload: false
       os: ${{ matrix.config.os }}
       image: "kthnode/gcc${{ matrix.config.version }}${{ matrix.config.docker_suffix }}"
       conan-remote: "kth"
@@ -289,9 +289,34 @@ jobs:
       compiler: ${{ matrix.config.compiler }}
       compiler-version: ${{ matrix.config.version }}
       build-version: "${{ needs.setup.outputs.build-version }}"
-      enable-asan: false   # Always enabled (sanitizer builds)
-      enable-ubsan: false  # Always enabled (sanitizer builds)
-      enable-tsan: false   # Always enabled (sanitizer builds)
+      enable-asan: false
+      enable-ubsan: false
+      enable-tsan: false
+      skip-tests: false
+    secrets:
+      CONAN_LOGIN_USERNAME: ${{ secrets.CONAN_LOGIN_USERNAME }}
+      CONAN_PASSWORD: ${{ secrets.CONAN_3_PASSWORD }}
+
+  build-with-container-sanitizers:
+    needs: [setup, generate-matrix]
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
+    name: ${{ matrix.config.name }} (Sanitizers)
+    uses: ./.github/workflows/build-with-container.yml
+    with:
+      if: ${{ matrix.config.compiler == 'GCC' }}
+      upload: false
+      os: ${{ matrix.config.os }}
+      image: "kthnode/gcc${{ matrix.config.version }}${{ matrix.config.docker_suffix }}"
+      conan-remote: "kth"
+      recipe-name: "kth"
+      compiler: ${{ matrix.config.compiler }}
+      compiler-version: ${{ matrix.config.version }}
+      build-version: "${{ needs.setup.outputs.build-version }}"
+      enable-asan: true
+      enable-ubsan: true
+      enable-tsan: false   # tsan is mutually exclusive with asan
       skip-tests: false
     secrets:
       CONAN_LOGIN_USERNAME: ${{ secrets.CONAN_LOGIN_USERNAME }}
@@ -302,11 +327,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
-    name: ${{ matrix.config.name }} (Sanitizers)
+    name: ${{ matrix.config.name }} (Build & Test)
     uses: ./.github/workflows/build-without-container.yml
     with:
       if: ${{ matrix.config.compiler != 'GCC' }}
-      upload: false  # Never upload sanitizer builds
+      upload: false
       os: ${{ matrix.config.os }}
       conan-remote: "kth"
       recipe-name: "kth"

--- a/src/blockchain/CMakeLists.txt
+++ b/src/blockchain/CMakeLists.txt
@@ -326,19 +326,26 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
   # ==========================================================================
   # 1. Thread-safety tests with TSan (debug, -O1)
   # ==========================================================================
-  add_executable(kth_blockchain_tsan_tests test/block_index_bench/benchmarks.cpp)
-  target_include_directories(kth_blockchain_tsan_tests PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test/block_index_bench>
-  )
-  target_link_libraries(kth_blockchain_tsan_tests PRIVATE nanobench::nanobench)
-  target_link_libraries(kth_blockchain_tsan_tests PRIVATE fmt::fmt-header-only)
-  target_link_libraries(kth_blockchain_tsan_tests PRIVATE Boost::boost)
-  target_link_libraries(kth_blockchain_tsan_tests PRIVATE ${PROJECT_NAME})
-  target_compile_options(kth_blockchain_tsan_tests PRIVATE -fsanitize=thread -g -O1)
-  target_link_options(kth_blockchain_tsan_tests PRIVATE -fsanitize=thread)
-  target_compile_definitions(kth_blockchain_tsan_tests PRIVATE TSAN_BUILD=1)
-  _group_sources(kth_blockchain_tsan_tests "${CMAKE_CURRENT_LIST_DIR}/test")
+  # ASan and TSan can't share a process: the target's hardcoded
+  # `-fsanitize=thread` would compose with a global `-fsanitize=address`
+  # and gcc rejects the combination at the cc1plus level. Skip the TSan
+  # target whenever the parent build is already instrumented with ASan.
+  string(FIND "${CMAKE_CXX_FLAGS}" "-fsanitize=address" _kth_asan_in_cxxflags)
+  if(_kth_asan_in_cxxflags EQUAL -1)
+    add_executable(kth_blockchain_tsan_tests test/block_index_bench/benchmarks.cpp)
+    target_include_directories(kth_blockchain_tsan_tests PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test/block_index_bench>
+    )
+    target_link_libraries(kth_blockchain_tsan_tests PRIVATE nanobench::nanobench)
+    target_link_libraries(kth_blockchain_tsan_tests PRIVATE fmt::fmt-header-only)
+    target_link_libraries(kth_blockchain_tsan_tests PRIVATE Boost::boost)
+    target_link_libraries(kth_blockchain_tsan_tests PRIVATE ${PROJECT_NAME})
+    target_compile_options(kth_blockchain_tsan_tests PRIVATE -fsanitize=thread -g -O1)
+    target_link_options(kth_blockchain_tsan_tests PRIVATE -fsanitize=thread)
+    target_compile_definitions(kth_blockchain_tsan_tests PRIVATE TSAN_BUILD=1)
+    _group_sources(kth_blockchain_tsan_tests "${CMAKE_CURRENT_LIST_DIR}/test")
+  endif()
 
   # ==========================================================================
   # 2. Performance benchmarks (release, full optimization)


### PR DESCRIPTION
## Summary
Two CI-plumbing tweaks bundled together:

1. Split the Linux job into two: a clean `(Build & Test)` and a separate `(Sanitizers)` that actually enables ASan + UBSan. The existing job was named `(Sanitizers)` but passed `enable-asan/ubsan/tsan: false` to the reusable workflow, so the name was misleading — it was a plain build & test.
2. Add three `CCACHE_*` env overrides on the macOS Build step. macOS runs currently sit around ~6 % ccache hit rate because the workspace and Xcode paths shift between runs, and ccache hashes those absolute paths into its Direct key.

## Linux split
- `build-with-container` → `(Build & Test)`, sanitizers off (as before).
- `build-with-container-sanitizers` → new job, same matrix, `enable-asan: true` + `enable-ubsan: true` (`enable-tsan: false` because tsan is mutually exclusive with asan in the reusable workflow).
- macOS `build-without-container` gets renamed to `(Build & Test)` for consistency. Sanitizers stay off there because they collide with secp256k1 inline assembly.

## macOS ccache fix
Side-by-side from a recent run on the same SHA:

| Platform | Hits | Direct | Preprocessed | Misses |
| --- | --- | --- | --- | --- |
| Linux | 99.91 % | 96.68 % | 3.32 % | 0.09 % |
| macOS | 6.66 % | 4.17 % | 95.83 % | 93.34 % |

Linux compiles 1084 TUs in ~1 min, macOS compiles 1081 TUs in ~38 min — same source, same compile commands, ccache restored cleanly in both. The asymmetry is purely path-driven: Linux runs inside a container where `/__w/kth/kth/…` and `/usr/local/bin/c++` are stable, macOS runs on the bare hosted runner where the workspace token rotates.

The new env vars on the macOS Build step:

```yaml
env:
  CCACHE_BASEDIR: ${{ github.workspace }}
  CCACHE_COMPILERCHECK: content
  CCACHE_SLOPPINESS: pch_defines,time_macros,locale,system_headers
```

- `CCACHE_BASEDIR` rewrites paths under the workspace to be relative before hashing.
- `CCACHE_COMPILERCHECK=content` keys on the compiler binary's contents rather than its mtime/path.
- `CCACHE_SLOPPINESS` ignores variations in macros that don't change generated code.

Expected outcome on the next run: macOS Build step drops from ~38 min to a small fraction of that on the warm-cache path; cold-cache runs stay full length.

## Test plan
- [ ] CI run on this branch shows two Linux jobs in the matrix: `(Build & Test)` and `(Sanitizers)`.
- [ ] `(Sanitizers)` actually instruments and reports sanitizer output (or stays green if there's nothing to flag).
- [ ] macOS Build step on a follow-up run with cache warm reports >50 % ccache hit rate and drops in wall-clock time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Prevent sanitizer builds from sharing ccache by suffixing cache keys when sanitizers are enabled and applying consistent restore/save behavior.
  * Reduce macOS cache misses by setting additional ccache environment options.
  * Ensure Address/UBSan options propagate through both upload and development build paths.
  * Add pre/post-test diagnostics (memory status, dmesg tail, high‑RSS processes) around tests.
  * Make ThreadSanitizer-instrumented test targets conditional when AddressSanitizer is active.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/k-nuth/kth/pull/344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->