### PR TITLE
consensus(bch): switch Leibniz (2026-May) to height-based activation

### DIFF
--- a/src/blockchain/include/kth/blockchain/settings.hpp
+++ b/src/blockchain/include/kth/blockchain/settings.hpp
@@ -61,57 +61,57 @@ struct KB_API settings {
     bool bch_descartes = true;       // 2023-May
     bool bch_lobachevski = true;     // 2024-May
     bool bch_galois = true;          // 2025-May
+    bool bch_leibniz = true;         // 2026-May
 
     // Those are post-upgrade constants, change them to true when the time comes
-    // bool bch_leibniz = false;     // 2026-May
     // bool bch_cantor = false;      // 2027-May
     // bool bch_unnamed = false;     // ????-May
 
-    ////2017-Aug-01 hard fork, defaults to 478559 (Mainnet)
+    ////2017-Aug-01 network upgrade, defaults to 478559 (Mainnet)
     // size_t uahf_height = 478559;
 
-    ////2017-Nov-13 hard fork, defaults to 504031 (Mainnet)
+    ////2017-Nov-13 network upgrade, defaults to 504031 (Mainnet)
     // size_t daa_height = 504031;
 
-    ////2018-May-15 hard fork, defaults to 1526400000
+    ////2018-May-15 network upgrade, defaults to 1526400000
     // uint64_t pythagoras_activation_time = bch_pythagoras_activation_time;
 
-    ////2018-Nov-15 hard fork, defaults to 1542300000
+    ////2018-Nov-15 network upgrade, defaults to 1542300000
     // uint64_t euclid_activation_time = bch_euclid_activation_time;
 
-    // //2019-May-15 hard fork, defaults to 1557921600: Wed, 15 May 2019 12:00:00 UTC protocol upgrade
+    // //2019-May-15 network upgrade, defaults to 1557921600: Wed, 15 May 2019 12:00:00 UTC protocol upgrade
     // uint64_t pisano_activation_time = bch_pisano_activation_time;
 
-    // //2019-May-15 hard fork, defaults to 1573819200: Nov 15, 2019 12:00:00 UTC protocol upgrade
+    // //2019-May-15 network upgrade, defaults to 1573819200: Nov 15, 2019 12:00:00 UTC protocol upgrade
     // uint64_t mersenne_activation_time = bch_mersenne_activation_time;
 
-    // //2020-May-15 hard fork, defaults to 1589544000: May 15, 2020 12:00:00 UTC protocol upgrade
+    // //2020-May-15 network upgrade, defaults to 1589544000: May 15, 2020 12:00:00 UTC protocol upgrade
     // uint64_t fermat_activation_time = std::to_underlying(bch_fermat_activation_time);
 
-    // //2020-Nov-15 hard fork, defaults to 1605441600: Nov 15, 2020 12:00:00 UTC protocol upgrade
+    // //2020-Nov-15 network upgrade, defaults to 1605441600: Nov 15, 2020 12:00:00 UTC protocol upgrade
     // uint64_t euler_activation_time = std::to_underlying(bch_euler_activation_time);
 
-    // 2021-May-15: No hard fork on May 15, 2021.
+    // 2021-May-15: No network upgrade on May 15, 2021.
 
-    // //2022-May-15 hard fork, defaults to 1652616000: May 15, 2022 12:00:00 UTC protocol upgrade
+    // //2022-May-15 network upgrade, defaults to 1652616000: May 15, 2022 12:00:00 UTC protocol upgrade
     // uint64_t gauss_activation_time = std::to_underlying(bch_gauss_activation_time);
 
-    // //2023-May-15 hard fork, defaults to 1684152000: May 15, 2023 12:00:00 UTC protocol upgrade
+    // //2023-May-15 network upgrade, defaults to 1684152000: May 15, 2023 12:00:00 UTC protocol upgrade
     // uint64_t descartes_activation_time = std::to_underlying(bch_descartes_activation_time);
 
-    // //2024-May-15 hard fork, defaults to 1715774400: May 15, 2024 12:00:00 UTC protocol upgrade
+    // //2024-May-15 network upgrade, defaults to 1715774400: May 15, 2024 12:00:00 UTC protocol upgrade
     // uint64_t lobachevski_activation_time = std::to_underlying(bch_lobachevski_activation_time);
 
-    // // 2025-May-15 hard fork, defaults to 1747310400: May 15, 2025 12:00:00 UTC protocol upgrade
+    // // 2025-May-15 network upgrade, defaults to 1747310400: May 15, 2025 12:00:00 UTC protocol upgrade
     // uint64_t galois_activation_time = std::to_underlying(bch_galois_activation_time);
 
-    // 2026-May-15 hard fork, defaults to 1778846400: May 15, 2026 12:00:00 UTC protocol upgrade
+    // 2026-May-15 network upgrade, defaults to 1778846400: May 15, 2026 12:00:00 UTC protocol upgrade
     uint64_t leibniz_activation_time = std::to_underlying(bch_leibniz_activation_time);
 
-    // 2027-May-15 hard fork, defaults to xxxxxxxxxx: May 15, 2027 12:00:00 UTC protocol upgrade
+    // 2027-May-15 network upgrade, defaults to xxxxxxxxxx: May 15, 2027 12:00:00 UTC protocol upgrade
     uint64_t cantor_activation_time = std::to_underlying(bch_cantor_activation_time);
 
-    // //????-???-?? hard fork, defaults to 9999999999: ??? ??, ???? 12:00:00 UTC protocol upgrade
+    // //????-???-?? network upgrade, defaults to 9999999999: ??? ??, ???? 12:00:00 UTC protocol upgrade
     // uint64_t unnamed_activation_time = std::to_underlying(bch_unnamed_activation_time);
 
     // The half life for the ASERTi3-2d DAA. For every (asert_half_life) seconds behind schedule the blockchain gets, difficulty is cut in half.

--- a/src/blockchain/src/populate/populate_block.cpp
+++ b/src/blockchain/src/populate/populate_block.cpp
@@ -105,7 +105,7 @@ void populate_block::populate_coinbase(branch::const_ptr branch, block_const_ptr
 
     //*************************************************************************
     // CONSENSUS: Satoshi implemented allow collisions in Nov 2015. This is a
-    // hard fork that destroys unspent outputs in case of hash collision.
+    // network upgrade that destroys unspent outputs in case of hash collision.
     // The tx duplicate check must apply to coinbase txs, handled here.
     //*************************************************************************
     if ( ! state->is_enabled(domain::machine::script_flags::allow_collisions)) {
@@ -187,7 +187,7 @@ void populate_block::populate_transactions(branch::const_ptr branch, size_t buck
 
         //*********************************************************************
         // CONSENSUS: Satoshi implemented allow collisions in Nov 2015. This is
-        // a hard fork that destroys unspent outputs in case of hash collision.
+        // a network upgrade that destroys unspent outputs in case of hash collision.
         //*********************************************************************
         //Knuth: we are not validating tx duplicates.
         // if ( ! collide) {

--- a/src/blockchain/src/populate/populate_chain_state.cpp
+++ b/src/blockchain/src/populate/populate_chain_state.cpp
@@ -291,7 +291,7 @@ chain_state::ptr populate_chain_state::populate() const {
         // , descartes_t(settings_.descartes_activation_time)
         // , lobachevski_t(settings_.lobachevski_activation_time)
         // , galois_t(settings_.galois_activation_time)
-        , leibniz_t(settings_.leibniz_activation_time)
+        // , leibniz_t(settings_.leibniz_activation_time)
         , cantor_t(settings_.cantor_activation_time)
 #endif //KTH_CURRENCY_BCH
     );
@@ -355,7 +355,7 @@ chain_state::ptr populate_chain_state::populate(chain_state::ptr pool, branch::c
         // , descartes_t(settings_.descartes_activation_time)
         // , lobachevski_t(settings_.lobachevski_activation_time)
         // , galois_t(settings_.galois_activation_time)
-        , leibniz_t(settings_.leibniz_activation_time)
+        // , leibniz_t(settings_.leibniz_activation_time)
         , cantor_t(settings_.cantor_activation_time)
 #endif //KTH_CURRENCY_BCH
     );

--- a/src/blockchain/src/settings.cpp
+++ b/src/blockchain/src/settings.cpp
@@ -103,7 +103,7 @@ domain::script_flags_t settings::enabled_flags() const {
     flags |= (bch_descartes   ? to_flags(upgrade::bch_descartes)   : 0);
     flags |= (bch_lobachevski ? to_flags(upgrade::bch_lobachevski) : 0);
     flags |= (bch_galois      ? to_flags(upgrade::bch_galois)      : 0);
-    // flags |= (bch_leibniz     ? to_flags(upgrade::bch_leibniz)     : 0);
+    flags |= (bch_leibniz     ? to_flags(upgrade::bch_leibniz)     : 0);
     // flags |= (bch_cantor     ? to_flags(upgrade::bch_cantor)     : 0);
     // flags |= (bch_unnamed     ? to_flags(upgrade::bch_unnamed)     : 0);
 #else

--- a/src/blockchain/src/validate/validate_input.cpp
+++ b/src/blockchain/src/validate/validate_input.cpp
@@ -106,7 +106,7 @@ uint32_t validate_input::convert_flags(script_flags_t active_flags) {
         flags |= verify_flags_enable_may2026;
     }
 
-    // // We make sure this node will have replay protection during the next hard fork.
+    // // We make sure this node will have replay protection during the next network upgrade.
     // if (script::is_enabled(active_flags, domain::machine::script_flags::bch_replay_protection)) {
     //     flags |= verify_flags_enable_replay_protection;
     // }

--- a/src/blockchain/test/transaction_entry.cpp
+++ b/src/blockchain/test/transaction_entry.cpp
@@ -42,7 +42,6 @@ transaction_const_ptr make_tx() {
             domain::chain::chain_state::assert_anchor_block_info_t{}, 
             0, 
             abla::config{},
-            kth::leibniz_t(0),
             kth::cantor_t(0)
         });
 #else

--- a/src/domain/include/kth/domain/chain/chain_state.hpp
+++ b/src/domain/include/kth/domain/chain/chain_state.hpp
@@ -143,7 +143,7 @@ struct KD_API chain_state {
                 // , descartes_t descartes_activation_time
                 // , lobachevski_t lobachevski_activation_time
                 // , galois_t galois_activation_time
-                , leibniz_t leibniz_activation_time
+                // , leibniz_t leibniz_activation_time
                 , cantor_t cantor_activation_time
 #endif  //KTH_CURRENCY_BCH
     );
@@ -227,8 +227,8 @@ struct KD_API chain_state {
     // [[nodiscard]]
     // galois_t galois_activation_time() const;
 
-    [[nodiscard]]
-    leibniz_t leibniz_activation_time() const;
+    // [[nodiscard]]
+    // leibniz_t leibniz_activation_time() const;
 
     [[nodiscard]]
     cantor_t cantor_activation_time() const;
@@ -327,7 +327,7 @@ protected:
             // , descartes_t descartes_activation_time
             // , lobachevski_t lobachevski_activation_time
             // , galois_t galois_activation_time
-            , leibniz_t leibniz_activation_time
+            // , leibniz_t leibniz_activation_time
             , cantor_t cantor_activation_time
 #endif  //KTH_CURRENCY_BCH
     );
@@ -340,7 +340,7 @@ protected:
                             // , descartes_t descartes_activation_time
                             // , lobachevski_t lobachevski_activation_time
                             // , galois_t galois_activation_time
-                            , leibniz_t leibniz_activation_time
+                            // , leibniz_t leibniz_activation_time
                             , cantor_t cantor_activation_time
                             , assert_anchor_block_info_t const& assert_anchor_block_info
                             , uint32_t asert_half_life
@@ -428,8 +428,8 @@ public:
     static
     bool is_galois_enabled(size_t height, config::network network);
 
-    // static
-    // bool is_leibniz_enabled(size_t height, config::network network);
+    static
+    bool is_leibniz_enabled(size_t height, config::network network);
 
     // static
     // bool is_cantor_enabled(size_t height, config::network network);
@@ -520,7 +520,7 @@ private:
     // descartes_t const descartes_activation_time_;
     // lobachevski_t const lobachevski_activation_time_;
     // galois_t const galois_activation_time_;
-    leibniz_t const leibniz_activation_time_;
+    // leibniz_t const leibniz_activation_time_;
     cantor_t const cantor_activation_time_;
 #endif  //KTH_CURRENCY_BCH
 };

--- a/src/domain/include/kth/domain/config/parser.hpp
+++ b/src/domain/include/kth/domain/config/parser.hpp
@@ -49,7 +49,7 @@ kth::infrastructure::config::checkpoint::list default_checkpoints(config::networ
 //TODO(fernando): Set Litecoin checkpoints
 #if defined(KTH_CURRENCY_BCH)
     if (network == domain::config::network::testnet) {
-        checkpoints.reserve(38);
+        checkpoints.reserve(42);
         checkpoints.emplace_back("000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943", 0);
         checkpoints.emplace_back("00000000009e2958c15ff9290d571bf9459e93b19765c6801ddeccadbb160a1e", 100000);
         checkpoints.emplace_back("0000000000287bffd321963ef05feab753ebe274e1d78b2fd4e2bfe9ad3aa6f2", 200000);
@@ -111,18 +111,11 @@ kth::infrastructure::config::checkpoint::list default_checkpoints(config::networ
         checkpoints.emplace_back("00000000062c7f32591d883c99fc89ebe74a83287c0f2b7ffeef72e62217d40b", 1421481);  //mediantime: 1605442008. New rules activated in the next block.
         checkpoints.emplace_back("0000000023e0680a8a062b3cc289a4a341124ce7fcb6340ede207e194d73b60a", 1421482);  //mediantime: 1605443209. New rules activated in this block.
 
-        // //2021-May Upgrade - gauss - (1652616000)
-        // checkpoints.emplace_back("", 9999999);  //mediantime: 9999999999
-        // checkpoints.emplace_back("", 9999999);  //mediantime: 9999999999. New rules activated in the next block.
-        // checkpoints.emplace_back("", 9999999);  //mediantime: 9999999999. New rules activated in this block.
-
-        // //2021-Nov Upgrade - unnamed - (9999999999)
-        // checkpoints.emplace_back("", 9999999);  //mediantime: 9999999999
-        // checkpoints.emplace_back("", 9999999);  //mediantime: 9999999999. New rules activated in the next block.
-        // checkpoints.emplace_back("", 9999999);  //mediantime: 9999999999. New rules activated in this block.
+        // 2026-May Upgrade - leibniz - (1778846400)
+        checkpoints.emplace_back("00000000078fe0c74ffa0c5221081c34774aa7d17a3c14c36f952f829463f120", 1710483);
 
     } else if (network == domain::config::network::testnet4) {
-        checkpoints.reserve(18);
+        checkpoints.reserve(21);
         checkpoints.emplace_back("000000001dd410c49a788668ce26751718cc797474d3152a5fc073dd44fd9f7b", 0);
 
         checkpoints.emplace_back("000000001d4ea1368ef790f94fd0f267814701d7ec0f5a5711d7dfe9b1f57ad6", 4);
@@ -148,6 +141,11 @@ kth::infrastructure::config::checkpoint::list default_checkpoints(config::networ
         checkpoints.emplace_back("000000008bdc7862ad9368f78a952ec754f68db569b5e4620bf35d480d238155", 16843);  //mediantime: 1605436827
         checkpoints.emplace_back("00000000602570ee2b66c1d3f75d404c234f8aacdcc784da97e65838a2daf0fc", 16844);  //mediantime: 1605442049. New rules activated in the next block.
         checkpoints.emplace_back("00000000fb325b8f34fe80c96a5f708a08699a68bbab82dba4474d86bd743077", 16845);  //mediantime: 1605445733. New rules activated in this block.
+
+        // 2026-May Upgrade - leibniz - (1778846400)
+        checkpoints.emplace_back("00000000c45de7decceacab29002b82e454841dccf0a71db13b0572081d3cc8c", 305847);
+        checkpoints.emplace_back("00000000601bf68f9927154cf55557b1c08245b4d415658d1cbcd1eb4502dabc", 305848);
+        checkpoints.emplace_back("000000002da8249454eb69ea7f38fb455305a51d34224494ecd533ab36a489e6", 305849);
     } else if (network == domain::config::network::scalenet) {
         checkpoints.reserve(19);
         checkpoints.emplace_back("00000000e6453dc2dfe1ffa19023f86002eb11dbb8e87d0291a4599f0430be52", 0);
@@ -178,7 +176,7 @@ kth::infrastructure::config::checkpoint::list default_checkpoints(config::networ
         checkpoints.emplace_back("00000000e4627a1a0bf9aaae007af5cea32720fb54cf2ccf0aa20b02a18392ab", 16869);  //mediantime: 1605444236. New rules activated in this block.
 
     } else if (network == domain::config::network::chipnet) {
-        checkpoints.reserve(17);
+        checkpoints.reserve(20);
 
         checkpoints.emplace_back("000000001dd410c49a788668ce26751718cc797474d3152a5fc073dd44fd9f7b", 0);
 
@@ -214,8 +212,13 @@ kth::infrastructure::config::checkpoint::list default_checkpoints(config::networ
         checkpoints.emplace_back("00000000144b00db5736b33bd572b3a3a52aa9b4c26ba59fc212aeb68a9b7a20", 228000);
         checkpoints.emplace_back("0000000017d92f88ed2c81885c57f999184860a042250510be06b3edd12e0dc5", 232000);
 
+        // 2026-May Upgrade - leibniz - (1778846400)
+        checkpoints.emplace_back("00000000261a64ba18da8edee2562957bad84c4d2405e5e4f044c5306fd3e195", 279791);
+        checkpoints.emplace_back("0000000019fdedee4233df4236800ec8bbe8ce45185ff531f43b307db12122b4", 279792);
+        checkpoints.emplace_back("00000000292db830fbd551b9b6ccf2a0e562acb6daf5b45d56588ec742d0ef1d", 279793);
+
     } else if (network == domain::config::network::mainnet) {
-        checkpoints.reserve(60);
+        checkpoints.reserve(92);
         checkpoints.emplace_back("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",       0);
         checkpoints.emplace_back("0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d",  11'111);
         checkpoints.emplace_back("000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6",  33'333);
@@ -340,10 +343,15 @@ kth::infrastructure::config::checkpoint::list default_checkpoints(config::networ
         checkpoints.emplace_back("00000000000000000157a0a3dcdc80f1acd809648d238c1e893b26247091b3b4", 898'374);
         checkpoints.emplace_back("0000000000000000007e2e7dd49323c90d16fd76a521804d709f0d5a442fd42a", 898'375);
 
-        // //2026-May Upgrade - leibniz - (1778846400)
-        // checkpoints.emplace_back("", 0);
-        // checkpoints.emplace_back("", 0);
-        // checkpoints.emplace_back("", 0);
+        checkpoints.emplace_back("000000000000000001fb491cce2c6d44f628e812519a2bc420bbc774cdc2d647", 905'000);
+        checkpoints.emplace_back("0000000000000000016a9d52a9c0a7d7fd3cf1a7cea538565674613a65341186", 920'000);
+        checkpoints.emplace_back("00000000000000000099a0c2d63cfa812992761580d7a8995fe699ee6a9c848e", 935'000);
+        checkpoints.emplace_back("00000000000000000046655be4cd21fd8ee3c59cf9218f3b349c5ea78538fabf", 950'000);
+
+        // 2026-May Upgrade - leibniz - (1778846400)
+        checkpoints.emplace_back("0000000000000000009647b105551f1776362ef92f08aa0312311ff0e9fdad3f", 951'144);
+        checkpoints.emplace_back("000000000000000000f64dbed68370486f945097ba90b17e30d7bf5c43df7a60", 951'145);
+        checkpoints.emplace_back("0000000000000000005cc515e90a5f37ea3029d1e2741d8a00e863edb55f3d1d", 951'146);
 
         // //2027-May Upgrade - cantor - (1810382400)
         // checkpoints.emplace_back("", 0);

--- a/src/domain/include/kth/domain/constants/bch.hpp
+++ b/src/domain/include/kth/domain/constants/bch.hpp
@@ -120,56 +120,56 @@ constexpr size_t testnet4_csv_activation_height = 6;
 constexpr size_t scalenet_csv_activation_height = 6;
 constexpr size_t chipnet_csv_activation_height = 6;
 
-//2017-August-01 hard fork
+//2017-August-01 network upgrade
 constexpr size_t mainnet_uahf_activation_height = 478559;
 constexpr size_t testnet_uahf_activation_height = 1155876;
 constexpr size_t testnet4_uahf_activation_height = 6;
 constexpr size_t scalenet_uahf_activation_height = 6;
 constexpr size_t chipnet_uahf_activation_height = 6;
 
-//2017-November-13 hard fork
+//2017-November-13 network upgrade
 constexpr size_t mainnet_daa_cw144_activation_height = 504032;
 constexpr size_t testnet_daa_cw144_activation_height = 1188698;
 constexpr size_t testnet4_daa_cw144_activation_height = 3001;
 constexpr size_t scalenet_daa_cw144_activation_height = 3001;
 constexpr size_t chipnet_daa_cw144_activation_height = 3001;
 
-//2018-May hard fork
+//2018-May network upgrade
 constexpr size_t mainnet_pythagoras_activation_height = 530356;  // Bitcoin Cash Node checkpoint: 530359, due to a historical inaccuracy in the Bitcoin ABC code: https://github.com/bitcoin-cash-node/bitcoin-cash-node/commit/97c32f461a1a6d6ca71c5958d67047a1c06d83fd#diff-ff53e63501a5e89fd650b378c9708274df8ad5d38fcffa6c64be417c4d438b6d
 constexpr size_t testnet_pythagoras_activation_height = 1233070; // Bitcoin Cash Node checkpoint: 1233078
 constexpr size_t testnet4_pythagoras_activation_height = 0;      // TODO(fernando): testnet4
 constexpr size_t scalenet_pythagoras_activation_height = 0;      // TODO(fernando): scalenet
 constexpr size_t chipnet_pythagoras_activation_height = 0;       // TODO(fernando): chipnet
 
-//2018-November hard fork
+//2018-November network upgrade
 constexpr size_t mainnet_euclid_activation_height = 556767;
 constexpr size_t testnet_euclid_activation_height = 1267997;
 constexpr size_t testnet4_euclid_activation_height = 4001;
 constexpr size_t scalenet_euclid_activation_height = 4001;
 constexpr size_t chipnet_euclid_activation_height = 4001;
 
-//2019-May hard fork
+//2019-May network upgrade
 constexpr size_t mainnet_pisano_activation_height = 582680;
 constexpr size_t testnet_pisano_activation_height = 1303885;
 constexpr size_t testnet4_pisano_activation_height = 0; //TODO(fernando): testnet4
 constexpr size_t scalenet_pisano_activation_height = 0; //TODO(fernando): scalenet
 constexpr size_t chipnet_pisano_activation_height = 0;  //TODO(fernando): chipnet
 
-//2019-Nov hard fork
+//2019-Nov network upgrade
 constexpr size_t mainnet_mersenne_activation_height = 609136;
 constexpr size_t testnet_mersenne_activation_height = 1341712;
 constexpr size_t testnet4_mersenne_activation_height = 5001;
 constexpr size_t scalenet_mersenne_activation_height = 5001;
 constexpr size_t chipnet_mersenne_activation_height = 5001;
 
-//2020-May hard fork
+//2020-May network upgrade
 constexpr size_t mainnet_fermat_activation_height = 635259;
 constexpr size_t testnet_fermat_activation_height = 1378461;
 constexpr size_t testnet4_fermat_activation_height = 0;         //Note: https://gitlab.com/bitcoin-cash-node/bitcoin-cash-node/-/blame/master/src/chainparams.cpp#L594
 constexpr size_t scalenet_fermat_activation_height = 0;         //Note: https://gitlab.com/bitcoin-cash-node/bitcoin-cash-node/-/blame/master/src/chainparams.cpp#L594
 constexpr size_t chipnet_fermat_activation_height = 0;          //Note: https://gitlab.com/bitcoin-cash-node/bitcoin-cash-node/-/blame/master/src/chainparams.cpp#L594
 
-// //2020-Nov hard fork, ASERT Anchor block lock up
+// //2020-Nov network upgrade, ASERT Anchor block lock up
 // //Will be removed once Euler(2020-Nov) update is activated
 // constexpr size_t mainnet_asert_anchor_lock_up_height = 652500;  // 000000000000000001655f282a3684de3e422290dca55a7ff84753871073c37e
 // constexpr size_t testnet_asert_anchor_lock_up_height = 1408990; // 0000000000069a8d053a2f34739137cd86722bde2516f03759d9349a0c04fd2e
@@ -177,7 +177,7 @@ constexpr size_t chipnet_fermat_activation_height = 0;          //Note: https://
 // constexpr size_t scalenet_asert_anchor_lock_up_height = 0;      // Genesis: 00000000e6453dc2dfe1ffa19023f86002eb11dbb8e87d0291a4599f0430be52
 // constexpr size_t chipnet_asert_anchor_lock_up_height = 0;       // Genesis: 00000000e6453dc2dfe1ffa19023f86002eb11dbb8e87d0291a4599f0430be52
 
-//2020-Nov hard fork, ASERT Anchor/Reference block
+//2020-Nov network upgrade, ASERT Anchor/Reference block
 constexpr size_t mainnet_asert_anchor_block_height = 661647;        // 00000000000000000083ed4b7a780d59e3983513215518ad75654bb02deee62f
 constexpr uint32_t mainnet_asert_anchor_block_bits = 0x1804dafe;
 constexpr size_t mainnet_asert_anchor_block_ancestor_time = 1605447844;
@@ -198,51 +198,51 @@ constexpr size_t chipnet_asert_anchor_block_height = 16844;        // 0000000060
 constexpr uint32_t chipnet_asert_anchor_block_bits = 0x1d00ffff;
 constexpr size_t chipnet_asert_anchor_block_ancestor_time = 1605451779;
 
-//2020-Nov hard fork
+//2020-Nov network upgrade
 constexpr size_t mainnet_euler_activation_height = 661648;
 constexpr size_t testnet_euler_activation_height = 1421482;
 constexpr size_t testnet4_euler_activation_height = 16845;
 constexpr size_t scalenet_euler_activation_height = 16869;
 constexpr size_t chipnet_euler_activation_height = 16845;
 
-//2021-May hard fork - There was no hard fork in May 2021
+//2021-May network upgrade - There was no network upgrade in May 2021
 
-//2022-May hard fork
+//2022-May network upgrade
 constexpr size_t mainnet_gauss_activation_height = 740'238;
 constexpr size_t testnet_gauss_activation_height = 1'500'206;
 constexpr size_t testnet4_gauss_activation_height = 95'465;
 constexpr size_t scalenet_gauss_activation_height = 10'007;
 constexpr size_t chipnet_gauss_activation_height = 95'465;
 
-//2023-May hard fork
+//2023-May network upgrade
 constexpr size_t mainnet_descartes_activation_height = 792'773;
 constexpr size_t testnet_descartes_activation_height = 1'552'788;
 constexpr size_t testnet4_descartes_activation_height = 148'044;
 constexpr size_t scalenet_descartes_activation_height = 10'007;
 constexpr size_t chipnet_descartes_activation_height = 121'957;
 
-//2024-May hard fork
+//2024-May network upgrade
 constexpr size_t mainnet_lobachevski_activation_height = 845'891;
 constexpr size_t testnet_lobachevski_activation_height = 1'605'521;
 constexpr size_t testnet4_lobachevski_activation_height = 200'741;
 constexpr size_t scalenet_lobachevski_activation_height = 10'007;
 constexpr size_t chipnet_lobachevski_activation_height = 174'520;
 
-//2025-May hard fork
+//2025-May network upgrade
 constexpr size_t mainnet_galois_activation_height = 898'374;
 constexpr size_t testnet_galois_activation_height = 1'658'050;
 constexpr size_t testnet4_galois_activation_height = 253'319;
 constexpr size_t scalenet_galois_activation_height = 10'007;
 constexpr size_t chipnet_galois_activation_height = 227'229;
 
-// //2026-May hard fork
-// constexpr size_t mainnet_leibniz_activation_height = ???;
-// constexpr size_t testnet_leibniz_activation_height = ???;
-// constexpr size_t testnet4_leibniz_activation_height = ???;
-// constexpr size_t scalenet_leibniz_activation_height = ???;
-// constexpr size_t chipnet_leibniz_activation_height = ???;
+//2026-May network upgrade
+constexpr size_t mainnet_leibniz_activation_height = 951'145;
+constexpr size_t testnet_leibniz_activation_height = 1'710'483;
+constexpr size_t testnet4_leibniz_activation_height = 305'848;
+constexpr size_t scalenet_leibniz_activation_height = 10'007;
+constexpr size_t chipnet_leibniz_activation_height = 279'792;
 
-// //2027-May hard fork
+// //2027-May network upgrade
 // constexpr size_t mainnet_cantor_activation_height = ???;
 // constexpr size_t testnet_cantor_activation_height = ???;
 // constexpr size_t testnet4_cantor_activation_height = ???;

--- a/src/domain/include/kth/domain/machine/script_flags.hpp
+++ b/src/domain/include/kth/domain/machine/script_flags.hpp
@@ -38,13 +38,13 @@ namespace machine {
 enum script_flags : script_flags_t {
     no_rules = 0,
 
-    /// Allow minimum difficulty blocks (hard fork, testnet).
+    /// Allow minimum difficulty blocks (network upgrade, testnet).
     easy_blocks = 1ULL << 0,
 
     /// Pay-to-script-hash enabled (soft fork, feature).
     bip16_rule = 1ULL << 1,
 
-    /// No duplicated unspent transaction ids (hard fork, security).
+    /// No duplicated unspent transaction ids (network upgrade, security).
     bip30_rule = 1ULL << 2,
 
     /// Coinbase must include height (soft fork, security).
@@ -56,10 +56,10 @@ enum script_flags : script_flags_t {
     /// Operation nop2 becomes check locktime verify (soft fork, feature).
     bip65_rule = 1ULL << 5,
 
-    /// Hard code bip34-based activation heights (hard fork, optimization).
+    /// Hard code bip34-based activation heights (network upgrade, optimization).
     bip90_rule = 1ULL << 6,
 
-    /// Assume hash collisions cannot happen (hard fork, optimization).
+    /// Assume hash collisions cannot happen (network upgrade, optimization).
     allow_collisions = 1ULL << 7,
 
     /// Enforce relative locktime (soft fork, feature).
@@ -114,7 +114,7 @@ enum script_flags : script_flags_t {
     bip147_rule = 1ULL << 13,
 #endif //KTH_CURRENCY_BCH
 
-    /// Perform difficulty retargeting (hard fork, regtest).
+    /// Perform difficulty retargeting (network upgrade, regtest).
     retarget = 1ULL << 62,
 
     /// Sentinel bit to indicate tx has not been validated.

--- a/src/domain/src/chain/chain_state.cpp
+++ b/src/domain/src/chain/chain_state.cpp
@@ -39,7 +39,7 @@ using namespace boost::adaptors;
 // Constructors.
 //-----------------------------------------------------------------------------
 
-// The allow_collisions hard fork is always activated (not configurable).
+// The allow_collisions network upgrade is always activated (not configurable).
 chain_state::chain_state(data&& values, script_flags_t flags, checkpoints const& checkpoints
     , domain::config::network network
 #if defined(KTH_CURRENCY_BCH)
@@ -55,7 +55,7 @@ chain_state::chain_state(data&& values, script_flags_t flags, checkpoints const&
     // , descartes_t descartes_activation_time
     // , lobachevski_t lobachevski_activation_time
     // , galois_t galois_activation_time
-    , leibniz_t leibniz_activation_time
+    // , leibniz_t leibniz_activation_time
     , cantor_t cantor_activation_time
 #endif  //KTH_CURRENCY_BCH
 )
@@ -77,7 +77,7 @@ chain_state::chain_state(data&& values, script_flags_t flags, checkpoints const&
         // , descartes_activation_time
         // , lobachevski_activation_time
         // , galois_activation_time
-        , leibniz_activation_time
+        // , leibniz_activation_time
         , cantor_activation_time
 #endif  //KTH_CURRENCY_BCH
         ))
@@ -89,7 +89,7 @@ chain_state::chain_state(data&& values, script_flags_t flags, checkpoints const&
             // , descartes_activation_time
             // , lobachevski_activation_time
             // , galois_activation_time
-            , leibniz_activation_time
+            // , leibniz_activation_time
             , cantor_activation_time
             , assert_anchor_block_info_
             , asert_half_life
@@ -107,7 +107,7 @@ chain_state::chain_state(data&& values, script_flags_t flags, checkpoints const&
     // , descartes_activation_time_(descartes_activation_time)
     // , lobachevski_activation_time_(lobachevski_activation_time)
     // , galois_activation_time_(galois_activation_time)
-    , leibniz_activation_time_(leibniz_activation_time)
+    // , leibniz_activation_time_(leibniz_activation_time)
     , cantor_activation_time_(cantor_activation_time)
 #endif  //KTH_CURRENCY_BCH
 {}
@@ -138,7 +138,7 @@ std::shared_ptr<chain_state> chain_state::from_pool_ptr(chain_state const& pool,
         // , pool.descartes_activation_time_
         // , pool.lobachevski_activation_time_
         // , pool.galois_activation_time_
-        , pool.leibniz_activation_time_
+        // , pool.leibniz_activation_time_
         , pool.cantor_activation_time_
 #endif  //KTH_CURRENCY_BCH
     );
@@ -339,7 +339,7 @@ bool chain_state::is_euler_enabled() const {
     return is_euler_enabled(height(), network());
 }
 
-// 2021-May: There were no hard forks in 2021
+// 2021-May: There were no network upgrades in 2021
 
 // 2022-May
 bool chain_state::is_gauss_enabled() const {
@@ -363,9 +363,7 @@ bool chain_state::is_galois_enabled() const {
 
 // 2026-May
 bool chain_state::is_leibniz_enabled() const {
-   //TODO(fernando): this was activated, change to the other method
-    return is_mtp_activated(median_time_past(), std::to_underlying(leibniz_activation_time()));
-    // return is_leibniz_enabled(height(), network());
+    return is_leibniz_enabled(height(), network());
 }
 
 // 2027-May
@@ -401,7 +399,7 @@ chain_state::activations chain_state::activation(data const& values, script_flag
         // , descartes_t descartes_activation_time
         // , lobachevski_t lobachevski_activation_time
         // , galois_t galois_activation_time
-        , leibniz_t leibniz_activation_time
+        // , leibniz_t leibniz_activation_time
         , cantor_t cantor_activation_time
 #endif  //KTH_CURRENCY_BCH
 ) {
@@ -436,13 +434,13 @@ chain_state::activations chain_state::activation(data const& values, script_flag
     // Initialize activation results with genesis values.
     activations result{script_flags::no_rules, first_version};
 
-    // retarget is only activated via configuration (hard fork).
+    // retarget is only activated via configuration (network upgrade).
     result.flags |= (script_flags::retarget & flags);
 
-    // testnet is activated based on configuration alone (hard fork).
+    // testnet is activated based on configuration alone (network upgrade).
     result.flags |= (script_flags::easy_blocks & flags);
 
-    // bip90 is activated based on configuration alone (hard fork).
+    // bip90 is activated based on configuration alone (network upgrade).
     result.flags |= (script_flags::bip90_rule & flags);
 
     // bip16 is activated with a one-time test on mainnet/testnet (~55% rule).
@@ -582,11 +580,11 @@ chain_state::activations chain_state::activation(data const& values, script_flag
         result.flags |= (to_flags(upgrade::bch_galois) & flags);
     }
 
-    auto const mtp = median_time_past(values);
-    if (is_mtp_activated(mtp, std::to_underlying(leibniz_activation_time))) {
-        result.flags |= to_flags(upgrade::bch_leibniz);
+    if (is_leibniz_enabled(values.height, network)) {
+        result.flags |= (to_flags(upgrade::bch_leibniz) & flags);
     }
 
+    auto const mtp = median_time_past(values);
     if (is_mtp_activated(mtp, std::to_underlying(cantor_activation_time))) {
         result.flags |= to_flags(upgrade::bch_cantor);
     }
@@ -723,7 +721,7 @@ bool chain_state::is_csv_enabled(size_t height, config::network network) {
     return res;
 }
 
-//2017-August-01 hard fork
+//2017-August-01 network upgrade
 bool chain_state::is_uahf_enabled(size_t height, config::network network) {
     auto res = is_rule_enabled(height, network
         , mainnet_uahf_activation_height
@@ -736,7 +734,7 @@ bool chain_state::is_uahf_enabled(size_t height, config::network network) {
     return res;
 }
 
-//2017-November-13 hard fork
+//2017-November-13 network upgrade
 bool chain_state::is_daa_cw144_enabled(size_t height, config::network network) {
     return is_rule_enabled(height, network
         , mainnet_daa_cw144_activation_height
@@ -747,7 +745,7 @@ bool chain_state::is_daa_cw144_enabled(size_t height, config::network network) {
         );
 }
 
-//2018-May hard fork
+//2018-May network upgrade
 bool chain_state::is_pythagoras_enabled(size_t height, config::network network) {
     return is_rule_enabled(height, network
         , mainnet_pythagoras_activation_height
@@ -758,7 +756,7 @@ bool chain_state::is_pythagoras_enabled(size_t height, config::network network) 
         );
 }
 
-//2018-Nov hard fork
+//2018-Nov network upgrade
 bool chain_state::is_euclid_enabled(size_t height, config::network network) {
     return is_rule_enabled(height, network
         , mainnet_euclid_activation_height
@@ -769,7 +767,7 @@ bool chain_state::is_euclid_enabled(size_t height, config::network network) {
         );
 }
 
-//2019-May hard fork
+//2019-May network upgrade
 bool chain_state::is_pisano_enabled(size_t height, config::network network) {
     return is_rule_enabled(height, network
         , mainnet_pisano_activation_height
@@ -780,7 +778,7 @@ bool chain_state::is_pisano_enabled(size_t height, config::network network) {
         );
 }
 
-//2019-Nov hard fork
+//2019-Nov network upgrade
 bool chain_state::is_mersenne_enabled(size_t height, config::network network) {
     return is_rule_enabled(height, network
         , mainnet_mersenne_activation_height
@@ -791,7 +789,7 @@ bool chain_state::is_mersenne_enabled(size_t height, config::network network) {
         );
 }
 
-//2020-May hard fork
+//2020-May network upgrade
 bool chain_state::is_fermat_enabled(size_t height, config::network network) {
     return is_rule_enabled(height, network
         , mainnet_fermat_activation_height
@@ -802,7 +800,7 @@ bool chain_state::is_fermat_enabled(size_t height, config::network network) {
         );
 }
 
-//2020-Nov hard fork
+//2020-Nov network upgrade
 bool chain_state::is_euler_enabled(size_t height, config::network network) {
     return is_rule_enabled(height, network
         , mainnet_euler_activation_height
@@ -813,7 +811,7 @@ bool chain_state::is_euler_enabled(size_t height, config::network network) {
      );
 }
 
-//2022-May hard fork
+//2022-May network upgrade
 bool chain_state::is_gauss_enabled(size_t height, config::network network) {
     return is_rule_enabled(height, network
         , mainnet_gauss_activation_height
@@ -824,7 +822,7 @@ bool chain_state::is_gauss_enabled(size_t height, config::network network) {
      );
 }
 
-//2023-May hard fork
+//2023-May network upgrade
 bool chain_state::is_descartes_enabled(size_t height, config::network network) {
     return is_rule_enabled(height, network
         , mainnet_descartes_activation_height
@@ -835,7 +833,7 @@ bool chain_state::is_descartes_enabled(size_t height, config::network network) {
      );
 }
 
-// 2024-May hard fork
+// 2024-May network upgrade
 bool chain_state::is_lobachevski_enabled(size_t height, config::network network) {
     return is_rule_enabled(height, network
         , mainnet_lobachevski_activation_height
@@ -846,7 +844,7 @@ bool chain_state::is_lobachevski_enabled(size_t height, config::network network)
      );
 }
 
-// 2025-May hard fork
+// 2025-May network upgrade
 bool chain_state::is_galois_enabled(size_t height, config::network network) {
     return is_rule_enabled(height, network
         , mainnet_galois_activation_height
@@ -857,20 +855,19 @@ bool chain_state::is_galois_enabled(size_t height, config::network network) {
      );
 }
 
-//2026-May hard fork
-// Complete after the hard fork
-// bool chain_state::is_leibniz_enabled(size_t height, config::network network) {
-//     return is_rule_enabled(height, network
-//         , mainnet_leibniz_activation_height
-//         , testnet_leibniz_activation_height
-//         , testnet4_leibniz_activation_height
-//         , scalenet_leibniz_activation_height
-//         , chipnet_leibniz_activation_height
-//      );
-// }
+// 2026-May network upgrade
+bool chain_state::is_leibniz_enabled(size_t height, config::network network) {
+    return is_rule_enabled(height, network
+        , mainnet_leibniz_activation_height
+        , testnet_leibniz_activation_height
+        , testnet4_leibniz_activation_height
+        , scalenet_leibniz_activation_height
+        , chipnet_leibniz_activation_height
+     );
+}
 
-//2027-May hard fork
-// Complete after the hard fork
+//2027-May network upgrade
+// Complete after the network upgrade
 // bool chain_state::is_cantor_enabled(size_t height, config::network network) {
 //     return is_rule_enabled(height, network
 //         , mainnet_cantor_activation_height
@@ -881,8 +878,8 @@ bool chain_state::is_galois_enabled(size_t height, config::network network) {
 //      );
 // }
 
-//20xx-May hard fork
-// Complete after the hard fork
+//20xx-May network upgrade
+// Complete after the network upgrade
 // bool chain_state::is_unnamed_enabled(size_t height, config::network network) {
 //     return is_rule_enabled(height, network
 //         , mainnet_unnamed_activation_height
@@ -1036,7 +1033,7 @@ uint32_t chain_state::work_required(data const& values, config::network network,
                                     // , descartes_t descartes_activation_time
                                     // , lobachevski_t lobachevski_activation_time
                                     // , galois_t galois_activation_time
-                                    , leibniz_t leibniz_activation_time
+                                    // , leibniz_t leibniz_activation_time
                                     , cantor_t cantor_activation_time
                                     , assert_anchor_block_info_t const& assert_anchor_block_info
                                     , uint32_t asert_half_life
@@ -1451,9 +1448,9 @@ uint64_t chain_state::dynamic_max_block_sigchecks() const {
 //     return galois_activation_time_;
 // }
 
-leibniz_t chain_state::leibniz_activation_time() const {
-    return leibniz_activation_time_;
-}
+// leibniz_t chain_state::leibniz_activation_time() const {
+//     return leibniz_activation_time_;
+// }
 
 cantor_t chain_state::cantor_activation_time() const {
     return cantor_activation_time_;
@@ -1490,7 +1487,7 @@ uint32_t chain_state::get_next_work_required(uint32_t time_now) {
                             // , descartes_activation_time()
                             // , lobachevski_activation_time()
                             // , galois_activation_time()
-                            , leibniz_activation_time()
+                            // , leibniz_activation_time()
                             , cantor_activation_time()
                             , assert_anchor_block_info_
                             , asert_half_life()

--- a/src/node/src/parser.cpp
+++ b/src/node/src/parser.cpp
@@ -404,7 +404,7 @@ options_metadata parser::load_settings() {
     )(
         "fork.bip90",
         value<bool>(&configured.chain.bip90),
-        "Assume bip34, bip65, and bip66 activation if enabled, defaults to true (hard fork)."
+        "Assume bip34, bip65, and bip66 activation if enabled, defaults to true (network upgrade)."
     )(
         "fork.bip68",
         value<bool>(&configured.chain.bip68),
@@ -424,42 +424,42 @@ options_metadata parser::load_settings() {
     // (
     //     "fork.uahf_height",
     //     value<size_t>(&configured.chain.uahf_height),
-    //     "Height of the 2017-Aug-01 hard fork (UAHF), defaults to 478559 (Mainnet)."
+    //     "Height of the 2017-Aug-01 network upgrade (UAHF), defaults to 478559 (Mainnet)."
     // )
     // (
     //     "fork.daa_height",
     //     value<size_t>(&configured.chain.daa_height),
-    //     "Height of the 2017-Nov-13 hard fork (DAA), defaults to 504031 (Mainnet)."
+    //     "Height of the 2017-Nov-13 network upgrade (DAA), defaults to 504031 (Mainnet)."
     // )
     // (
     //     "fork.pythagoras_activation_time",
     //     value<uint64_t>(&configured.chain.pythagoras_activation_time),
-    //     "Unix time used for MTP activation of 2018-May-15 hard fork, defaults to 1526400000."
+    //     "Unix time used for MTP activation of 2018-May-15 network upgrade, defaults to 1526400000."
     // )
     // (
     //     "fork.euclid_activation_time",
     //     value<uint64_t>(&configured.chain.euclid_activation_time),
-    //     "Unix time used for MTP activation of 2018-Nov-15 hard fork, defaults to 1542300000."
+    //     "Unix time used for MTP activation of 2018-Nov-15 network upgrade, defaults to 1542300000."
     // )
     // (
     //     "fork.pisano_activation_time",
     //     value<uint64_t>(&configured.chain.pisano_activation_time),
-    //     "Unix time used for MTP activation of 2019-May-15 hard fork, defaults to 1557921600."
+    //     "Unix time used for MTP activation of 2019-May-15 network upgrade, defaults to 1557921600."
     // )
     // (
     //     "fork.mersenne_activation_time",
     //     value<uint64_t>(&configured.chain.mersenne_activation_time),
-    //     "Unix time used for MTP activation of 2019-Nov-15 hard fork, defaults to 1573819200."
+    //     "Unix time used for MTP activation of 2019-Nov-15 network upgrade, defaults to 1573819200."
     // )
     // (
     //     "fork.fermat_activation_time",
     //     value<uint64_t>(&configured.chain.fermat_activation_time),
-    //     "Unix time used for MTP activation of 2020-May-15 hard fork, defaults to 1589544000."
+    //     "Unix time used for MTP activation of 2020-May-15 network upgrade, defaults to 1589544000."
     // )
     // (
     //     "fork.euler_activation_time",
     //     value<uint64_t>(&configured.chain.euler_activation_time),
-    //     "Unix time used for MTP activation of 2020-Nov-15 hard fork, defaults to 1605441600."
+    //     "Unix time used for MTP activation of 2020-Nov-15 network upgrade, defaults to 1605441600."
     // )
 
     // No HF for 2021-May-15
@@ -467,37 +467,37 @@ options_metadata parser::load_settings() {
     // (
     //     "fork.gauss_activation_time",
     //     value<uint64_t>(&configured.chain.gauss_activation_time),
-    //     "Unix time used for MTP activation of 2022-May-15 hard fork, defaults to 1652616000."
+    //     "Unix time used for MTP activation of 2022-May-15 network upgrade, defaults to 1652616000."
     // )
     // (
     //     "fork.descartes_activation_time",
     //     value<uint64_t>(&configured.chain.descartes_activation_time),
-    //     "Unix time used for MTP activation of 2023-May-15 hard fork, defaults to 1684152000."
+    //     "Unix time used for MTP activation of 2023-May-15 network upgrade, defaults to 1684152000."
     // )
     // (
     //     "fork.lobachevski_activation_time",
     //     value<uint64_t>(&configured.chain.lobachevski_activation_time),
-    //     "Unix time used for MTP activation of 2024-May-15 hard fork, defaults to 1715774400."
+    //     "Unix time used for MTP activation of 2024-May-15 network upgrade, defaults to 1715774400."
     // )
     // (
     //     "fork.galois_activation_time",
     //     value<uint64_t>(&configured.chain.galois_activation_time),
-    //     "Unix time used for MTP activation of 2025-May-15 hard fork, defaults to 1747310400."
+    //     "Unix time used for MTP activation of 2025-May-15 network upgrade, defaults to 1747310400."
     // )
     (
         "fork.leibniz_activation_time",
         value<uint64_t>(&configured.chain.leibniz_activation_time),
-        "Unix time used for MTP activation of 2026-May-15 hard fork, defaults to 1778846400."
+        "Unix time used for MTP activation of 2026-May-15 network upgrade, defaults to 1778846400."
     )
     (
         "fork.cantor_activation_time",
         value<uint64_t>(&configured.chain.cantor_activation_time),
-        "Unix time used for MTP activation of 2027-May-15 hard fork, defaults to xxxxxxxxx."
+        "Unix time used for MTP activation of 2027-May-15 network upgrade, defaults to xxxxxxxxx."
     )
     // (
     //     "fork.unnamed_activation_time",
     //     value<uint64_t>(&configured.chain.unnamed_activation_time),
-    //     "Unix time used for MTP activation of ????-???-?? hard fork, defaults to 9999999999."
+    //     "Unix time used for MTP activation of ????-???-?? network upgrade, defaults to 9999999999."
     // )
     (
         "fork.asert_half_life",


### PR DESCRIPTION
Sets the 2026-May (Leibniz) upgrade activation heights and switches the gate from MTP to height.

## Summary
- mainnet 951'145 / testnet 1'710'483 / testnet4 305'848 / scalenet 10'007 / chipnet 279'792
- `chain_state::activation()` and `is_leibniz_enabled()` now go through the static height-based overload
- `bch_leibniz` flag defaults to `true`; `leibniz_activation_time` plumbing is commented out following the Galois post-upgrade pattern

## Test plan
- [x] domain + blockchain + tests build clean
- [x] `kth_domain_test` green (1011110 assertions, 3867 cases)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for the 2026-May Leibniz network upgrade on BCH networks

* **Improvements**
  * Updated network upgrade checkpoints for BCH mainnet, testnet, testnet4, and chipnet
  * Changed network upgrade activation validation from time-based to height-based checks

* **Documentation**
  * Updated terminology from "hard fork" to "network upgrade" throughout documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->