### PR TITLE
ci(macos): chase ccache hit rate + add gate and ccache log artifact

### DIFF
--- a/.github/workflows/build-without-container.yml
+++ b/.github/workflows/build-without-container.yml
@@ -143,9 +143,17 @@ jobs:
           # content` keys off the compiler binary's contents instead of
           # its mtime/path; the sloppiness list ignores macros that
           # vary across runs but don't change generated code.
+          #
+          # Even with those, the previous fix attempt only got us to
+          # ~6 % hits. Adding `CCACHE_NOHASHDIR=true` so the working
+          # directory isn't part of the hash (it changes between runs
+          # on macOS-hosted runners regardless of BASEDIR), and
+          # `CCACHE_LOGFILE` so we can post-mortem when hits stay low.
           CCACHE_BASEDIR: ${{ github.workspace }}
           CCACHE_COMPILERCHECK: content
-          CCACHE_SLOPPINESS: pch_defines,time_macros,locale,system_headers
+          CCACHE_NOHASHDIR: "true"
+          CCACHE_SLOPPINESS: pch_defines,time_macros,locale,system_headers,include_file_mtime,include_file_ctime
+          CCACHE_LOGFILE: ${{ github.workspace }}/ccache.log
         run: |
           # Prepare sanitizer flags
           SANITIZER_FLAGS=""
@@ -266,38 +274,71 @@ jobs:
         working-directory: .
         run: |
           echo "🧪 Running unit tests for development build..."
-          
+
           # Set sanitizer options for better reporting (preserve conflict resolution from build step)
           TSAN_ENABLED_FOR_TESTS="${{ inputs.enable-tsan }}"
           if [ "${{ inputs.enable-asan }}" = "true" ] && [ "${{ inputs.enable-tsan }}" = "true" ]; then
             TSAN_ENABLED_FOR_TESTS=false
           fi
-          
+
           if [ "${{ inputs.enable-asan }}" = "true" ] || [ "${{ inputs.enable-ubsan }}" = "true" ] || [ "$TSAN_ENABLED_FOR_TESTS" = "true" ]; then
             echo "🧪 Running tests with sanitizers enabled..."
             echo "⚠️ Tests may run slower due to sanitizer overhead"
-            
+
             if [ "${{ inputs.enable-asan }}" = "true" ]; then
               export ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:print_stats=1"
             fi
-            
+
             if [ "${{ inputs.enable-ubsan }}" = "true" ]; then
               export UBSAN_OPTIONS="print_stacktrace=1:abort_on_error=1"
             fi
-            
+
             if [ "$TSAN_ENABLED_FOR_TESTS" = "true" ]; then
               export TSAN_OPTIONS="halt_on_error=1:abort_on_error=1"
             fi
           fi
-          
-          # Run unit tests (project was already built with tests in previous step)
+
+          # Run unit tests (project was already built with tests in previous step).
+          # Capture rc instead of swallowing it with `|| echo`; the step itself
+          # still exits 0 so the rest of the workflow can run, but a non-zero
+          # rc is recorded in $GITHUB_ENV and the gate step below fails the
+          # job. Mirrors the pattern in build-with-container.yml.
           cd build/build/Release
-          
+          rc=0
           if [ "${{ inputs.enable-asan }}" = "true" ] || [ "${{ inputs.enable-ubsan }}" = "true" ] || [ "$TSAN_ENABLED_FOR_TESTS" = "true" ]; then
-            timeout 1800 ctest --output-on-failure --parallel 2 || echo "Some tests may have failed or timed out with sanitizers"
+            timeout 1800 ctest --output-on-failure --parallel 2 || rc=$?
           else
-            ctest --output-on-failure --parallel 4 || echo "Some tests may have failed, but continuing..."
+            ctest --output-on-failure --parallel 4 || rc=$?
           fi
+          if [ "$rc" != 0 ]; then
+            echo "::error::ctest failed or timed out (exit=$rc)"
+            echo 'TESTS_FAILED=1' >> "$GITHUB_ENV"
+          fi
+
+      # Gate that turns the recorded test failure into a job failure.
+      # Runs unconditionally (`always()`) so it fires even when an earlier
+      # step ended in failure for an unrelated reason.
+      - name: 🧪 Test results gate
+        if: ${{ always() && inputs.skip-tests != true && inputs.upload != true }}
+        run: |
+          if [ "${TESTS_FAILED:-0}" = "1" ]; then
+            echo "::error::ctest failed or timed out (see annotations above)"
+            exit 1
+          fi
+          echo "All tests passed"
+
+      # ccache log helps diagnose hit-rate problems on macOS-hosted
+      # runners — upload it as an artifact so we can post-mortem the
+      # next time hits stay low. Cheap when ccache.log doesn't exist.
+      - name: 📤 Upload ccache log
+        if: ${{ always() && inputs.upload != true }}
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: ccache-log-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}
+          path: ${{ github.workspace }}/ccache.log
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: ⏭️ Skip tests info
         if: ${{ inputs.skip-tests == true }}


### PR DESCRIPTION
## Why
macOS Build & Test has been taking ~40 min per run because ccache hits stay at **~6 %** (vs **~95 %** on Linux). The previous attempt — #344 — set `CCACHE_BASEDIR`, `CCACHE_COMPILERCHECK=content`, and a sloppiness list, but the actual numbers we see in CI haven't moved.

## What

Two changes in this PR:

### 1. Chase the ccache hit rate

Two more knobs on top of the existing settings:

- **`CCACHE_NOHASHDIR=true`** — hosted macOS runners place the workspace under a randomised `_temp` path each run. `CCACHE_BASEDIR` only rewrites paths *under* the basedir before hashing, but the working directory itself still leaks into the cache key. Disabling that bit of the hash lets TUs from different runs share entries.
- **Sloppiness += `include_file_mtime,include_file_ctime`** — conan and brew touch system headers between runs without changing their contents.

If hits stay low after this, **`CCACHE_LOGFILE` + artifact upload** gives us per-TU evidence (manifest key, included files, miss reason) instead of having to guess. Log gets uploaded as `ccache-log-macOS-…` artifact, 7-day retention.

### 2. Apply the rc-capture + gate pattern to the mac test step

Same pattern as #347 in `build-with-container.yml`: capture `rc` from `ctest` instead of swallowing it with `|| echo`, surface the failure via `::error::` annotation + `TESTS_FAILED=1` in `$GITHUB_ENV`, and a final `Test results gate` step turns the recorded failure into a job failure. The step itself still exits 0 so the ccache-log upload step runs even on test failure.

## Test plan
- [ ] macOS Build & Test green
- [ ] First run will still be a full rebuild (cold cache key for `__CCACHE_NOHASHDIR=true__` + new sloppiness). The **second** run is what to look at.
- [ ] If hits remain low, download `ccache-log-macOS-*` artifact and inspect to identify what's busting the key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **CI/CD Improvements**
  - Enhanced macOS build caching behavior to improve cache reuse across runs.
- **Test Reporting**
  - Improved how sanitizer-related test failures and timeouts are captured and propagated to the workflow result.
  - Added a dedicated test-results gate to ensure test failures are reflected in the final job status.
- **Artifacts**
  - Uploads the build cache log as an artifact to aid diagnostics when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->