### PR TITLE
fix(c-api): plug ASan-detected leaks in kth_capi_test

### DIFF
--- a/src/c-api/include/kth/capi/string_list.h
+++ b/src/c-api/include/kth/capi/string_list.h
@@ -28,8 +28,8 @@ void kth_core_string_list_destruct(kth_string_list_mut_t list);
 KTH_EXPORT
 kth_size_t kth_core_string_list_count(kth_string_list_const_t list);
 
-/** @return Owned string. Caller must release with `free()`. */
-KTH_EXPORT KTH_OWNED
+/** @return Borrowed `char const*` view into the list element. Do not free; the list retains ownership. Invalidated by any mutation or destruct of the list. */
+KTH_EXPORT
 char const* kth_core_string_list_nth(kth_string_list_const_t list, kth_size_t index);
 
 KTH_EXPORT

--- a/src/c-api/src/string_list.cpp
+++ b/src/c-api/src/string_list.cpp
@@ -39,7 +39,7 @@ char const* kth_core_string_list_nth(kth_string_list_const_t list, kth_size_t in
     KTH_PRECONDITION(list != nullptr);
     auto const& vec = kth::list_ref<cpp_t>(list);
     KTH_PRECONDITION(index < vec.size());
-    return kth::create_c_str(vec[index]);
+    return vec[index].c_str();
 }
 
 void kth_core_string_list_assign_at(kth_string_list_mut_t list, kth_size_t index, char const* elem) {

--- a/src/c-api/test/chain/compact_block.cpp
+++ b/src/c-api/test/chain/compact_block.cpp
@@ -216,11 +216,16 @@ TEST_CASE("C-API CompactBlock - nonce round-trips",
 TEST_CASE("C-API CompactBlock - short_ids getter reflects input",
           "[C-API CompactBlock]") {
     kth_compact_block_mut_t cb = make_fixture();
-    kth_u64_list_const_t view = kth_chain_compact_block_short_ids(cb);
-    REQUIRE(view != NULL);
-    REQUIRE(kth_core_u64_list_count(view) == 2u);
-    REQUIRE(kth_core_u64_list_nth(view, 0) == 0x010203040506ull);
-    REQUIRE(kth_core_u64_list_nth(view, 1) == 0x0a0b0c0d0e0full);
+    // `kth_chain_compact_block_short_ids` returns an owned
+    // `kth_u64_list_mut_t` (the parent doesn't keep it after the call),
+    // so the test owns it and must release with
+    // `kth_core_u64_list_destruct`.
+    kth_u64_list_mut_t ids = kth_chain_compact_block_short_ids(cb);
+    REQUIRE(ids != NULL);
+    REQUIRE(kth_core_u64_list_count(ids) == 2u);
+    REQUIRE(kth_core_u64_list_nth(ids, 0) == 0x010203040506ull);
+    REQUIRE(kth_core_u64_list_nth(ids, 1) == 0x0a0b0c0d0e0full);
+    kth_core_u64_list_destruct(ids);
     kth_chain_compact_block_destruct(cb);
 }
 

--- a/src/c-api/test/wallet/wallet_data.cpp
+++ b/src/c-api/test/wallet/wallet_data.cpp
@@ -41,9 +41,14 @@ TEST_CASE("C-API WalletData - create with English default returns a handle",
     REQUIRE(wd != NULL);
 
     // mnemonics: 24-word BIP39 seed phrase (256-bit entropy default).
-    kth_string_list_const_t mnemonics = kth_wallet_wallet_data_mnemonics(wd);
+    // `kth_wallet_wallet_data_mnemonics` returns an owned
+    // `kth_string_list_mut_t` (the parent doesn't keep it after the call),
+    // so the test owns it and must release with
+    // `kth_core_string_list_destruct`.
+    kth_string_list_mut_t mnemonics = kth_wallet_wallet_data_mnemonics(wd);
     REQUIRE(mnemonics != NULL);
     REQUIRE(kth_core_string_list_count(mnemonics) == 24u);
+    kth_core_string_list_destruct(mnemonics);
 
     // xpub: a non-null borrowed view.
     kth_hd_public_const_t xpub = kth_wallet_wallet_data_xpub(wd);
@@ -72,8 +77,13 @@ TEST_CASE("C-API WalletData - copy preserves mnemonics count and xpub validity",
     REQUIRE(copy != NULL);
     REQUIRE(copy != original);  // different heap allocations
 
-    REQUIRE(kth_core_string_list_count(kth_wallet_wallet_data_mnemonics(copy))
-            == kth_core_string_list_count(kth_wallet_wallet_data_mnemonics(original)));
+    kth_string_list_mut_t copy_mnemonics = kth_wallet_wallet_data_mnemonics(copy);
+    kth_string_list_mut_t orig_mnemonics = kth_wallet_wallet_data_mnemonics(original);
+    REQUIRE(kth_core_string_list_count(copy_mnemonics)
+            == kth_core_string_list_count(orig_mnemonics));
+    kth_core_string_list_destruct(copy_mnemonics);
+    kth_core_string_list_destruct(orig_mnemonics);
+
     REQUIRE(kth_wallet_hd_public_valid(kth_wallet_wallet_data_xpub(copy)) != 0);
 
     kth_wallet_wallet_data_destruct(copy);
@@ -95,7 +105,9 @@ TEST_CASE("C-API WalletData - set_mnemonics replaces the word list",
     kth_core_string_list_push_back(replacement, "word-two");
 
     kth_wallet_wallet_data_set_mnemonics(wd, replacement);
-    REQUIRE(kth_core_string_list_count(kth_wallet_wallet_data_mnemonics(wd)) == 2u);
+    kth_string_list_mut_t mnemonics = kth_wallet_wallet_data_mnemonics(wd);
+    REQUIRE(kth_core_string_list_count(mnemonics) == 2u);
+    kth_core_string_list_destruct(mnemonics);
 
     kth_core_string_list_destruct(replacement);
     kth_wallet_wallet_data_destruct(wd);


### PR DESCRIPTION
## Why
The per-binary gate added in #347 started reporting Sanitizers failures the previous `|| echo` masking was swallowing. The first one is `kth_capi_test` exiting via SIGABRT with a LeakSanitizer summary of **2510 bytes in 11 allocations**.

## What

Two real owned-pointer leaks in the c-api tests, plus one generator-level bug that the ASan run surfaced.

### Owned-pointer leaks in tests

| Site | Leak | Fix |
|---|---|---|
| `test/wallet/wallet_data.cpp` (4× calls) | `kth_wallet_wallet_data_mnemonics()` returns owned `kth_string_list_mut_t` left dangling | Store in `_mut_t` var, release with `kth_core_string_list_destruct` |
| `test/chain/compact_block.cpp` (1× call) | `kth_chain_compact_block_short_ids()` same pattern with `kth_u64_list_mut_t` | Release with `kth_core_u64_list_destruct` |

### Generator anomaly fixed at the source

`kth_core_string_list_nth` was the only value-list `_nth` declared `KTH_OWNED`, alloc'ing a fresh C string per access via `kth::create_c_str(vec[index])`. The header even said *"Caller must release with `free()`."* — but no in-repo caller ever did. The convention everywhere else (`data_stack_nth`, every opaque-handle `_nth`, every light-scalar `_nth`) is **borrowed view** for variable-size elements and **by-value** for light ones. The pointer-element path was a generator anomaly, not intent.

Fixed at the generator (kth-tools [`59004e5`](https://github.com/k-nuth/kth-tools/commit/59004e5)):
- `render_value_list_h`'s `elem_is_pointer=True` branch now emits *"Borrowed view ... do not free"* doc and drops the `KTH_OWNED` marker.
- `STRING_LIST_CONFIG.from_cpp` switched from `'kth::create_c_str({name})'` to `'{name}.c_str()'`, so `_nth` returns a borrowed pointer into the stored `std::string`.

This PR lands the regenerated `string_list.h` and `string_list.cpp` in kth-master. Every other value-list (`hash`, `u32`, `u64`, `double`, `bool`) byte-identical against the kth-master master.

## Test plan
- [x] `kth_capi_test` runs clean locally (2807 assertions in 784 test cases)
- [ ] Sanitizers job on master shows 0-byte LeakSanitizer summary for `kth_capi_test`

## Breaking change note

`kth_core_string_list_nth` switches from owned to borrowed return. **In-repo callers were already treating the return as borrowed (none of them called `free()`), so nothing in this repo breaks.** External SDK consumers who follow the previous header contract literally would double-free; the header doc is now corrected and `KTH_OWNED` is gone.