### PR TITLE
ci: pin all third-party actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/build-deps-with-container.yml
+++ b/.github/workflows/build-deps-with-container.yml
@@ -44,12 +44,12 @@ jobs:
 
 
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           submodules: true
 
       # - if: ${{ inputs.reference != 'null' && inputs.compiler != 'GCC' }}
-      #   uses: actions/setup-python@v5
+      #   uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       #   with:
       #     python-version: '3.11'
       - name: 🔧 Setup Conan
@@ -63,7 +63,7 @@ jobs:
         run: conan remote login -p ${{ secrets.conan-password }} ${{ inputs.conan-remote }} ${{ secrets.conan-user }}
       - name: 📥 Download artifact
         if: ${{ inputs.reference != 'null' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: conan-lockfile-container
       - name: 🏗️ Build dependencies

--- a/.github/workflows/build-deps-without-container.yml
+++ b/.github/workflows/build-deps-without-container.yml
@@ -52,13 +52,13 @@ jobs:
 
 
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           submodules: true
 
       - name: 🐍 Setup Python
         if: ${{ inputs.reference != 'null' && inputs.compiler != 'GCC' }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.11'
 
@@ -73,7 +73,7 @@ jobs:
         run: conan remote login -p ${{ secrets.conan-password }} ${{ inputs.conan-remote }} ${{ secrets.conan-user }}
       - name: 📥 Download artifact
         if: ${{ inputs.reference != 'null' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: conan-lockfile-no-container
       - name: 🏗️ Build dependencies

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -32,7 +32,7 @@ jobs:
     outputs:
       build-version: ${{ steps.version.outputs.build-version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           submodules: true
           fetch-depth: 0
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           submodules: true
 
@@ -65,7 +65,7 @@ jobs:
           new-version: ${{ needs.setup.outputs.build-version }}
 
       - name: 🐍 Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.11'
 

--- a/.github/workflows/build-with-container.yml
+++ b/.github/workflows/build-with-container.yml
@@ -81,7 +81,7 @@ jobs:
 
 
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           submodules: true
 
@@ -92,18 +92,18 @@ jobs:
       # 18+ min and marking otherwise-green jobs as `failure`.
       - name: 💾 Restore Conan packages
         id: restore-conan
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/.conan/data
           key: ${{ runner.os }}-${{ hashFiles('**/conan.lock') }}
-      # - uses: actions/cache@v5
+      # - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
       #   with:
       #     path: ~/.cache/pip
       #     key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
 
 
       # - if: ${{ inputs.compiler != 'GCC' }}
-      #   uses: actions/setup-python@v5
+      #   uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       #   with:
       #     python-version: '3.11'
 
@@ -136,7 +136,7 @@ jobs:
       - name: 🗄️ Restore ccache
         id: restore-ccache
         if: ${{ inputs.upload != true }}
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: /github/home/.cache/ccache
           # Two disjoint cache families: 'sanitizers' and 'clean'.
@@ -251,7 +251,7 @@ jobs:
       - name: 💾 Save Conan packages
         if: always() && steps.restore-conan.outputs.cache-hit != 'true'
         continue-on-error: true
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/.conan/data
           key: ${{ steps.restore-conan.outputs.cache-primary-key }}
@@ -259,7 +259,7 @@ jobs:
       - name: 🗄️ Save ccache
         if: always() && inputs.upload != true && steps.restore-ccache.outputs.cache-hit != 'true'
         continue-on-error: true
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: /github/home/.cache/ccache
           key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-${{ github.sha }}

--- a/.github/workflows/build-without-container.yml
+++ b/.github/workflows/build-without-container.yml
@@ -76,16 +76,16 @@ jobs:
       # ----------------------------------------------------------------
 
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           submodules: true
 
       - name: 💾 Cache Conan packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/.conan/data
           key: ${{ runner.os }}-${{ hashFiles('**/conan.lock') }}
-      # - uses: actions/cache@v5
+      # - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
       #   with:
       #     path: ~/.cache/pip
       #     key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -93,7 +93,7 @@ jobs:
 
       # - if: ${{ inputs.compiler != 'GCC' }}
       - name: 🐍 Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.11'
 
@@ -102,7 +102,7 @@ jobs:
       - name: 🔧 Setup kthbuild
         uses: ./ci_utils/.github/actions/setup-kthbuild
       - name: 🔧 Get CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@6d674ef0d7703f12f77182ca400e1e7be99fd399
 
       # - uses: github/codeql-action/init@v2
       #   with:
@@ -121,7 +121,7 @@ jobs:
 
       - name: 🗄️ Restore ccache
         if: ${{ inputs.upload != true }}
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/Library/Caches/ccache
           # Two disjoint cache families ('sanitizers' / 'clean') so the
@@ -332,7 +332,7 @@ jobs:
       # next time hits stay low. Cheap when ccache.log doesn't exist.
       - name: 📤 Upload ccache log
         if: ${{ always() && inputs.upload != true }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         continue-on-error: true
         with:
           name: ccache-log-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}

--- a/.github/workflows/calc-deps-with-container.yml
+++ b/.github/workflows/calc-deps-with-container.yml
@@ -36,19 +36,19 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           submodules: true
 
       - name: 💾 Cache Conan packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/.conan/data
           key: alpine-${{ hashFiles('**/conan.lock') }}
 
 
       # - if: ${{ inputs.compiler != 'GCC' }}
-      #   uses: actions/setup-python@v5
+      #   uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       #   with:
       #     python-version: '3.11'
 
@@ -76,7 +76,7 @@ jobs:
           # conan graph build-order conanfile.py --lockfile=build/conan.lock -f json --order-by configuration --build=missing --reduce > build_order.json
 
       - name: 📦 Upload lockfile artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: conan-lockfile-container
           path: build/conan.lock

--- a/.github/workflows/calc-deps-without-container.yml
+++ b/.github/workflows/calc-deps-without-container.yml
@@ -32,19 +32,19 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           submodules: true
 
       - name: 💾 Cache Conan packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/.conan/data
           key: alpine-${{ hashFiles('**/conan.lock') }}
 
       # - if: ${{ inputs.compiler != 'GCC' }}
       - name: 🐍 Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.11'
 
@@ -74,7 +74,7 @@ jobs:
 
 
       - name: 📦 Upload lockfile artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: conan-lockfile-no-container
           path: build/conan.lock

--- a/.github/workflows/check-conan-updates.yml
+++ b/.github/workflows/check-conan-updates.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.11'
 
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload report as artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: conan-update-report
           path: update_report.txt

--- a/.github/workflows/cosmetic-changes.yml
+++ b/.github/workflows/cosmetic-changes.yml
@@ -26,7 +26,7 @@ jobs:
     
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           submodules: true
 
@@ -82,7 +82,7 @@ jobs:
       # non-fatal warning rather than a job failure.
       - name: 🗄️ Restore ccache
         id: restore-ccache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: /github/home/.cache/ccache
           key: ccache-coverage-${{ github.sha }}
@@ -131,7 +131,7 @@ jobs:
       - name: 🗄️ Save ccache
         if: always() && steps.restore-ccache.outputs.cache-hit != 'true'
         continue-on-error: true
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: /github/home/.cache/ccache
           key: ccache-coverage-${{ github.sha }}
@@ -214,7 +214,7 @@ jobs:
 
       - name: ☁️ Upload to Codecov
         if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac  # v5.5.5
         with:
           files: coverage.info
           fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
       - name: 🔐 Check permissions
         id: check
         continue-on-error: true
-        uses: prince-chrismc/check-actor-permissions-action@v3
+        uses: prince-chrismc/check-actor-permissions-action@d504e74ba31658f4cdf4fcfeb509d4c09736d88e  # v3.0.2
         with:
           permission: write
 
@@ -93,7 +93,7 @@ jobs:
       build-version: ${{ steps.version.outputs.build-version }}
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           submodules: true
           fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags
@@ -158,7 +158,7 @@ jobs:
   #     # name: docker.pkg.github.com/${{ github.repository }}/alpine-image
   #     name: docker.pkg.github.com/k-nuth/kth/alpine-image
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
   #       with:
   #         submodules: true
   #     - id: version
@@ -198,7 +198,7 @@ jobs:
           echo "Head ref: ${{ github.head_ref }}"
           echo "Base ref: ${{ github.base_ref }}"
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           submodules: true
       - name: 🧮 Generate Job Matrix
@@ -413,7 +413,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           submodules: true
 

--- a/ci_utils/.github/workflows/build-deps-with-container.yml
+++ b/ci_utils/.github/workflows/build-deps-with-container.yml
@@ -38,12 +38,12 @@ jobs:
           echo "inputs.reference: ${{ inputs.reference }}"
 
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           submodules: true
 
       # - if: ${{ inputs.reference != 'null' && inputs.compiler != 'GCC' }}
-      #   uses: actions/setup-python@v4
+      #   uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       #   with:
       #     python-version: '3.11'
       - if: ${{ inputs.reference != 'null' }}
@@ -54,7 +54,7 @@ jobs:
         run: conan remote login -p ${{ secrets.conan-password }} ${{ inputs.conan-remote }} ${{ secrets.conan-user }}
       - name: download
         if: ${{ inputs.reference != 'null' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: conan-lockfile-container
       - name: build

--- a/ci_utils/.github/workflows/build-deps-without-container.yml
+++ b/ci_utils/.github/workflows/build-deps-without-container.yml
@@ -46,12 +46,12 @@ jobs:
           # # python3 -m pip install kthbuild --upgrade
 
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           submodules: true
 
       - if: ${{ inputs.reference != 'null' && inputs.compiler != 'GCC' }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.11'
 
@@ -63,7 +63,7 @@ jobs:
         run: conan remote login -p ${{ secrets.conan-password }} ${{ inputs.conan-remote }} ${{ secrets.conan-user }}
       - name: download
         if: ${{ inputs.reference != 'null' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: conan-lockfile-no-container
       - name: build

--- a/ci_utils/.github/workflows/build-with-container.yml
+++ b/ci_utils/.github/workflows/build-with-container.yml
@@ -62,22 +62,22 @@ jobs:
           # echo "github.event_name:         ${{ github.event_name }}"
 
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           submodules: true
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/.conan/data
           key: ${{ runner.os }}-${{ hashFiles('**/conan.lock') }}
-      # - uses: actions/cache@v5
+      # - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
       #   with:
       #     path: ~/.cache/pip
       #     key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
 
 
       # - if: ${{ inputs.compiler != 'GCC' }}
-      #   uses: actions/setup-python@v4
+      #   uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       #   with:
       #     python-version: '3.11'
 

--- a/ci_utils/.github/workflows/build-without-container.yml
+++ b/ci_utils/.github/workflows/build-without-container.yml
@@ -57,28 +57,28 @@ jobs:
 
       # ----------------------------------------------------------------
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           submodules: true
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/.conan/data
           key: ${{ runner.os }}-${{ hashFiles('**/conan.lock') }}
-      # - uses: actions/cache@v5
+      # - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
       #   with:
       #     path: ~/.cache/pip
       #     key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
 
 
       # - if: ${{ inputs.compiler != 'GCC' }}
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.11'
 
       - uses: ./ci_utils/.github/actions/setup-conan
       - uses: ./ci_utils/.github/actions/setup-kthbuild
-      - uses: lukka/get-cmake@latest
+      - uses: lukka/get-cmake@6d674ef0d7703f12f77182ca400e1e7be99fd399
 
       # - uses: github/codeql-action/init@v2
       #   with:

--- a/ci_utils/.github/workflows/calc-deps-with-container.yml
+++ b/ci_utils/.github/workflows/calc-deps-with-container.yml
@@ -35,18 +35,18 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           submodules: true
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/.conan/data
           key: alpine-${{ hashFiles('**/conan.lock') }}
 
 
       # - if: ${{ inputs.compiler != 'GCC' }}
-      #   uses: actions/setup-python@v4
+      #   uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       #   with:
       #     python-version: '3.11'
 
@@ -69,7 +69,7 @@ jobs:
           # Conan 2.7 build order configuration
           # conan graph build-order conanfile.py --lockfile=build/conan.lock -f json --order-by configuration --build=missing --reduce > build_order.json
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: conan-lockfile-container
           path: build/conan.lock

--- a/ci_utils/.github/workflows/calc-deps-without-container.yml
+++ b/ci_utils/.github/workflows/calc-deps-without-container.yml
@@ -31,17 +31,17 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           submodules: true
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/.conan/data
           key: alpine-${{ hashFiles('**/conan.lock') }}
 
       # - if: ${{ inputs.compiler != 'GCC' }}
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.11'
 
@@ -65,7 +65,7 @@ jobs:
 
 
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: conan-lockfile-no-container
           path: build/conan.lock


### PR DESCRIPTION
## Why
PR #348's review flagged `actions/upload-artifact@v4` as a mutable tag — a real supply-chain risk. The same risk applies to **every** other action in the workflows (`actions/checkout@v4`, `actions/cache@v5`, …), and one (`lukka/get-cmake@latest`) is strictly worse. Pinning only the one the bot pointed out would be illusory security; this PR addresses the class.

A compromised action runs inside a job that has `GITHUB_TOKEN` and the project's `secrets.CONAN_*` in env. The `tj-actions/changed-files` incident (March 2025) is the recent real-world example of how a re-pointed tag turns into a secret-exfiltration vector across every consumer's next CI run.

## What
Every `uses:` reference to a third-party action is now pinned to a full-length commit SHA with a trailing `# vX.Y.Z` comment:

| Action | Pinned version |
|---|---|
| `actions/checkout` | `v4.3.1` |
| `actions/cache` (`+/restore`, `+/save`) | `v5.0.5` |
| `actions/setup-python` | `v5.6.0` |
| `actions/upload-artifact` | `v4.6.2` |
| `actions/download-artifact` | `v4.3.0` |
| `codecov/codecov-action` | `v5.5.5` |
| `prince-chrismc/check-actor-permissions-action` | `v3.0.2` |
| `lukka/get-cmake` | (existing pin, normalised everywhere) |

Notes:
- `actions/setup-python` references on `@v4` are bumped to `v5.6.0` so the matrix stops disagreeing with itself.
- `lukka/get-cmake@latest` in `ci_utils/.github/workflows/build-without-container.yml` is normalised to the SHA already in use elsewhere in the repo. That SHA has no semver tag, so no version comment; bumping to a tagged `v4.x` is a follow-up.

17 workflow files touched. No `@vN` references remain for the pinned actions; YAML still parses across all 17 files.

## Test plan
- [ ] CI green across all jobs (Linux container, Linux sanitizers, macOS, coverage, wasm).