### PR TITLE
ci: fix Conan cache path (Conan 2.x lives in ~/.conan2, not ~/.conan/data)

### DIFF
--- a/.github/workflows/build-with-container.yml
+++ b/.github/workflows/build-with-container.yml
@@ -94,8 +94,8 @@ jobs:
         id: restore-conan
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
-          path: ~/.conan/data
-          key: ${{ runner.os }}-${{ hashFiles('**/conan.lock') }}
+          path: ~/.conan2
+          key: ${{ runner.os }}-conan2-${{ hashFiles('**/conan.lock') }}
       # - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
       #   with:
       #     path: ~/.cache/pip
@@ -253,7 +253,7 @@ jobs:
         continue-on-error: true
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
-          path: ~/.conan/data
+          path: ~/.conan2
           key: ${{ steps.restore-conan.outputs.cache-primary-key }}
 
       - name: 🗄️ Save ccache

--- a/.github/workflows/build-without-container.yml
+++ b/.github/workflows/build-without-container.yml
@@ -83,8 +83,8 @@ jobs:
       - name: 💾 Cache Conan packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
-          path: ~/.conan/data
-          key: ${{ runner.os }}-${{ hashFiles('**/conan.lock') }}
+          path: ~/.conan2
+          key: ${{ runner.os }}-conan2-${{ hashFiles('**/conan.lock') }}
       # - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
       #   with:
       #     path: ~/.cache/pip

--- a/.github/workflows/calc-deps-with-container.yml
+++ b/.github/workflows/calc-deps-with-container.yml
@@ -43,8 +43,8 @@ jobs:
       - name: 💾 Cache Conan packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
-          path: ~/.conan/data
-          key: alpine-${{ hashFiles('**/conan.lock') }}
+          path: ~/.conan2
+          key: alpine-conan2-${{ hashFiles('**/conan.lock') }}
 
 
       # - if: ${{ inputs.compiler != 'GCC' }}

--- a/.github/workflows/calc-deps-without-container.yml
+++ b/.github/workflows/calc-deps-without-container.yml
@@ -39,8 +39,8 @@ jobs:
       - name: 💾 Cache Conan packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
-          path: ~/.conan/data
-          key: alpine-${{ hashFiles('**/conan.lock') }}
+          path: ~/.conan2
+          key: alpine-conan2-${{ hashFiles('**/conan.lock') }}
 
       # - if: ${{ inputs.compiler != 'GCC' }}
       - name: 🐍 Setup Python

--- a/ci_utils/.github/workflows/build-with-container.yml
+++ b/ci_utils/.github/workflows/build-with-container.yml
@@ -68,8 +68,8 @@ jobs:
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
-          path: ~/.conan/data
-          key: ${{ runner.os }}-${{ hashFiles('**/conan.lock') }}
+          path: ~/.conan2
+          key: ${{ runner.os }}-conan2-${{ hashFiles('**/conan.lock') }}
       # - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
       #   with:
       #     path: ~/.cache/pip

--- a/ci_utils/.github/workflows/build-without-container.yml
+++ b/ci_utils/.github/workflows/build-without-container.yml
@@ -63,8 +63,8 @@ jobs:
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
-          path: ~/.conan/data
-          key: ${{ runner.os }}-${{ hashFiles('**/conan.lock') }}
+          path: ~/.conan2
+          key: ${{ runner.os }}-conan2-${{ hashFiles('**/conan.lock') }}
       # - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
       #   with:
       #     path: ~/.cache/pip

--- a/ci_utils/.github/workflows/calc-deps-with-container.yml
+++ b/ci_utils/.github/workflows/calc-deps-with-container.yml
@@ -41,8 +41,8 @@ jobs:
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
-          path: ~/.conan/data
-          key: alpine-${{ hashFiles('**/conan.lock') }}
+          path: ~/.conan2
+          key: alpine-conan2-${{ hashFiles('**/conan.lock') }}
 
 
       # - if: ${{ inputs.compiler != 'GCC' }}

--- a/ci_utils/.github/workflows/calc-deps-without-container.yml
+++ b/ci_utils/.github/workflows/calc-deps-without-container.yml
@@ -37,8 +37,8 @@ jobs:
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
-          path: ~/.conan/data
-          key: alpine-${{ hashFiles('**/conan.lock') }}
+          path: ~/.conan2
+          key: alpine-conan2-${{ hashFiles('**/conan.lock') }}
 
       # - if: ${{ inputs.compiler != 'GCC' }}
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0


### PR DESCRIPTION
## Why
The `Cache Conan packages` step in every workflow was pointing at `~/.conan/data` — the **Conan 1.x** home — while every workflow actually runs **Conan 2.x** and writes to `~/.conan2/p/...`. The cache step was archiving an empty / nonexistent directory on every run, and on restore put nothing back, so Conan reinstalled every package from scratch every time.

That had two visible effects:

1. **Cold conan installs** added several minutes to every macOS build (the job has no container layer to fall back on).
2. **Conan's package-storage short-paths drift between runs.** Conan 2.x stores each package under `~/.conan2/p/<short-hash>/p/...` where `<short-hash>` is assigned at install time. With nothing cached, every install assigns new short-paths:

   - run #348 merge: `boost3748b2e071a14`, `gmp413638bce90ef`, …
   - run #349 merge: `boostb2dd623713c4d`, `gmp70ab810b4d6c9`, …

   Same lockfile, same Xcode 16.4, same MacOSX 15.5 SDK, identical workspace path — just different short-paths. ccache's direct mode hashes the full compiler command line including every `-isystem /Users/runner/.conan2/p/<short>/p/include`, so direct hits collapsed to **3 / 1082 (0.3 %)** on macOS. The ~6 % aggregate we kept seeing was all preprocessed-mode rescue.

Verified end-to-end against the \`ccache.log\` artifact uploaded by #348.

The Linux jobs accidentally avoided the worst of this because their container image (\`kthnode/gcc15-ubuntu24.04\`) layer-caches the conan packages at the image level — short-paths stay stable across runs. macOS has no container, so the bug bit there.

## What

- Point the cache action at \`~/.conan2\` everywhere (8 workflow files, 9 occurrences — includes the paired \`Save Conan packages\` step in \`build-with-container.yml\`).
- Insert \`conan2-\` into every cache key right after the OS prefix. Old caches under the previous keys are live snapshots of an empty \`~/.conan/data\` and would otherwise be restored by exact-key hit, skipping save and pinning the loop to the bad state.

## Test plan
- [ ] First run after merge is still a cold install under the new key (expected).
- [ ] **Second** run after merge: macOS ccache --show-stats should jump well above the 0.3 % direct-hit / ~6 % aggregate floor. If conan short-paths stabilise, the ceiling becomes the Xcode/SDK path stability — which has been fine in recent runs.
- [ ] Linux jobs unchanged in behaviour (they were already stable via container layering).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow caching configuration across all build pipelines to improve package management consistency. Build workflows now cache packages using the updated Conan 2 directory structure, enhancing cache efficiency and build performance. Changes applied consistently to both containerized and non-containerized build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->