### PR TITLE
ci: make Setup Conan idempotent against a pre-populated ~/.conan2

### DIFF
--- a/ci_utils/.github/actions/setup-conan/action.yml
+++ b/ci_utils/.github/actions/setup-conan/action.yml
@@ -18,7 +18,7 @@ runs:
     - run: conan --version
       shell: bash
 
-    - run: conan profile detect
+    - run: conan profile detect --force
       shell: bash
 
     - run: conan config install -t dir ./ci_utils/.conan


### PR DESCRIPTION
## Why
PR #351's re-run validation surfaced that \`conan profile detect\` errors out with *"Profile already exists"* when the conan home is restored from a previous run's cache. The mac re-run of run \`27561426530\` restored \`~/.conan2/profiles/default\` (saved by attempt 1) and then attempt 2 died at the very first Conan command — before the build even started.

\`\`\`
ERROR: Profile '/Users/runner/.conan2/profiles/default' already exists
\`\`\`

## Fix
Add \`--force\`. Profile detection is content-deterministic given the same environment, so re-running it produces the same file the cache already contained — the change is only about the error message.

## Note
The matching change in the upstream \`k-nuth/ci_utils\` repo needs the same edit; this PR only touches the kth-master copy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Conan build configuration to force profile re-detection during setup, ensuring fresh configuration state for each build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->