### PR TITLE
c-api: migrate to coroutine API (WIP, stacks on v1.0)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,7 +26,6 @@ if (BUILD_NODE_EXE AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     add_subdirectory(node-exe)
 endif()
 
-# TODO(fernando): DESCOMENTAR ESTO CUANDO TERMINEMOS EL CLEANUP DE COROUTINES
-# if (BUILD_C_API)
-#     add_subdirectory(c-api)
-# endif()
+if (BUILD_C_API)
+    add_subdirectory(c-api)
+endif()

--- a/src/c-api/include/kth/capi/chain/chain_other.h
+++ b/src/c-api/include/kth/capi/chain/chain_other.h
@@ -15,7 +15,7 @@ extern "C" {
 #endif
 
 KTH_EXPORT
-void kth_chain_subscribe_blockchain(kth_node_t exec, kth_chain_t chain, void* ctx, kth_subscribe_block_handler_t handler);
+void kth_chain_subscribe_blockchain(kth_node_t exec, kth_chain_t chain, void* ctx, kth_subscribe_blockchain_handler_t handler);
 
 KTH_EXPORT
 void kth_chain_subscribe_transaction(kth_node_t exec, kth_chain_t chain, void* ctx, kth_subscribe_transaction_handler_t handler);

--- a/src/c-api/src/chain/chain_async.cpp
+++ b/src/c-api/src/chain/chain_async.cpp
@@ -4,10 +4,8 @@
 
 #include <kth/capi/chain/chain_async.h>
 #include <cstdio>
-#include <latch>
 #include <memory>
-
-// #include <boost/thread/latch.hpp>
+#include <system_error>
 
 #include <kth/domain/chain/block.hpp>
 #include <kth/domain/chain/header.hpp>
@@ -36,13 +34,6 @@ kth::domain::message::transaction::const_ptr tx_shared(kth_transaction_const_t t
     return kth::domain::message::transaction::const_ptr(tx_new);
 }
 
-// inline
-// kth::domain::chain::transaction::const_ptr tx_shared(kth_transaction_t tx) {
-//     auto const& tx_ref = *static_cast<kth::domain::chain::transaction const*>(tx);
-//     auto* tx_new = new kth::domain::chain::transaction(tx_ref);
-//     return kth::domain::chain::transaction::const_ptr(tx_new);
-// }
-
 inline
 kth::domain::message::block::const_ptr block_shared(kth_block_const_t block) {
     auto const& block_ref = *static_cast<kth::domain::chain::block const*>(block);
@@ -57,133 +48,237 @@ kth::domain::message::block::const_ptr block_shared(kth_block_const_t block) {
 extern "C" {
 
 void kth_chain_async_last_height(kth_chain_t chain, void* ctx, kth_last_height_fetch_handler_t handler) {
-    safe_chain(chain).fetch_last_height([chain, ctx, handler](std::error_code const& ec, size_t h) {
-        handler(chain, ctx, kth::to_c_err(ec), h);
-    });
+    auto& bc = safe_chain(chain);
+    ::asio::co_spawn(bc.executor(), [&bc, chain, ctx, handler]() -> ::asio::awaitable<void> {
+        auto result = co_await bc.fetch_last_height();
+        if (result) {
+            handler(chain, ctx, kth::to_c_err(std::error_code{}), result->block);
+        } else {
+            handler(chain, ctx, kth::to_c_err(result.error()), 0);
+        }
+    }, ::asio::detached);
 }
 
 void kth_chain_async_block_height(kth_chain_t chain, void* ctx, kth_hash_t hash, kth_block_height_fetch_handler_t handler) {
     auto hash_cpp = kth::to_array(hash.hash);
-    safe_chain(chain).fetch_block_height(hash_cpp, [chain, ctx, handler](std::error_code const& ec, size_t h) {
-        handler(chain, ctx, kth::to_c_err(ec), h);
-    });
+    auto& bc = safe_chain(chain);
+    ::asio::co_spawn(bc.executor(), [&bc, hash_cpp, chain, ctx, handler]() -> ::asio::awaitable<void> {
+        auto result = co_await bc.fetch_block_height(hash_cpp);
+        if (result) {
+            handler(chain, ctx, kth::to_c_err(std::error_code{}), *result);
+        } else {
+            handler(chain, ctx, kth::to_c_err(result.error()), 0);
+        }
+    }, ::asio::detached);
 }
 
 void kth_chain_async_block_header_by_height(kth_chain_t chain, void* ctx, kth_size_t height, kth_block_header_fetch_handler_t handler) {
-    safe_chain(chain).fetch_block_header(height, [chain, ctx, handler](std::error_code const& ec, kth::domain::chain::header::ptr header, size_t h) {
-        handler(chain, ctx, kth::to_c_err(ec), kth::leak_if_success(header, ec), h);
-    });
+    auto& bc = safe_chain(chain);
+    ::asio::co_spawn(bc.executor(), [&bc, height, chain, ctx, handler]() -> ::asio::awaitable<void> {
+        auto result = co_await bc.fetch_block_header(height);
+        if (result) {
+            auto const& [header, h] = *result;
+            handler(chain, ctx, kth::to_c_err(std::error_code{}), kth::leak_if_success(header, std::error_code{}), h);
+        } else {
+            handler(chain, ctx, kth::to_c_err(result.error()), nullptr, 0);
+        }
+    }, ::asio::detached);
 }
 
 void kth_chain_async_block_header_by_hash(kth_chain_t chain, void* ctx, kth_hash_t hash, kth_block_header_fetch_handler_t handler) {
     auto hash_cpp = kth::to_array(hash.hash);
-    safe_chain(chain).fetch_block_header(hash_cpp, [chain, ctx, handler](std::error_code const& ec, kth::domain::chain::header::ptr header, size_t h) {
-        handler(chain, ctx, kth::to_c_err(ec), kth::leak_if_success(header, ec), h);
-    });
+    auto& bc = safe_chain(chain);
+    ::asio::co_spawn(bc.executor(), [&bc, hash_cpp, chain, ctx, handler]() -> ::asio::awaitable<void> {
+        auto result = co_await bc.fetch_block_header(hash_cpp);
+        if (result) {
+            auto const& [header, h] = *result;
+            handler(chain, ctx, kth::to_c_err(std::error_code{}), kth::leak_if_success(header, std::error_code{}), h);
+        } else {
+            handler(chain, ctx, kth::to_c_err(result.error()), nullptr, 0);
+        }
+    }, ::asio::detached);
 }
 
 void kth_chain_async_block_by_height(kth_chain_t chain, void* ctx, kth_size_t height, kth_block_fetch_handler_t handler) {
-    safe_chain(chain).fetch_block(height, [chain, ctx, handler](std::error_code const& ec, kth::domain::message::block::const_ptr block, size_t h) {
-        handler(chain, ctx, kth::to_c_err(ec), kth::leak_if_success(block, ec), h);
-    });
+    auto& bc = safe_chain(chain);
+    ::asio::co_spawn(bc.executor(), [&bc, height, chain, ctx, handler]() -> ::asio::awaitable<void> {
+        auto result = co_await bc.fetch_block(height);
+        if (result) {
+            auto const& [block, h] = *result;
+            handler(chain, ctx, kth::to_c_err(std::error_code{}), kth::leak_if_success(block, std::error_code{}), h);
+        } else {
+            handler(chain, ctx, kth::to_c_err(result.error()), nullptr, 0);
+        }
+    }, ::asio::detached);
 }
 
 void kth_chain_async_block_by_hash(kth_chain_t chain, void* ctx, kth_hash_t hash, kth_block_fetch_handler_t handler) {
     auto hash_cpp = kth::to_array(hash.hash);
-    safe_chain(chain).fetch_block(hash_cpp, [chain, ctx, handler](std::error_code const& ec, kth::domain::message::block::const_ptr block, size_t h) {
-        handler(chain, ctx, kth::to_c_err(ec), kth::leak_if_success(block, ec), h);
-    });
+    auto& bc = safe_chain(chain);
+    ::asio::co_spawn(bc.executor(), [&bc, hash_cpp, chain, ctx, handler]() -> ::asio::awaitable<void> {
+        auto result = co_await bc.fetch_block(hash_cpp);
+        if (result) {
+            auto const& [block, h] = *result;
+            handler(chain, ctx, kth::to_c_err(std::error_code{}), kth::leak_if_success(block, std::error_code{}), h);
+        } else {
+            handler(chain, ctx, kth::to_c_err(result.error()), nullptr, 0);
+        }
+    }, ::asio::detached);
 }
 
 void kth_chain_async_block_header_by_hash_txs_size(kth_chain_t chain, void* ctx, kth_hash_t hash, kth_block_header_txs_size_fetch_handler_t handler) {
     auto hash_cpp = kth::to_array(hash.hash);
-
-    safe_chain(chain).fetch_block_header_txs_size(hash_cpp, [chain, ctx, handler](std::error_code const& ec, kth::domain::message::header::const_ptr header, size_t block_height, std::shared_ptr<kth::hash_list> tx_hashes, uint64_t block_serialized_size) {
-        handler(chain, ctx, kth::to_c_err(ec), kth::leak_if_success(header, ec), block_height, kth::leak_if_success(tx_hashes, ec), block_serialized_size);
-    });
+    auto& bc = safe_chain(chain);
+    ::asio::co_spawn(bc.executor(), [&bc, hash_cpp, chain, ctx, handler]() -> ::asio::awaitable<void> {
+        auto result = co_await bc.fetch_block_header_txs_size(hash_cpp);
+        if (result) {
+            auto const& [header, block_height, tx_hashes, block_serialized_size] = *result;
+            handler(chain, ctx, kth::to_c_err(std::error_code{}),
+                    kth::leak_if_success(header, std::error_code{}),
+                    block_height,
+                    kth::leak_if_success(tx_hashes, std::error_code{}),
+                    block_serialized_size);
+        } else {
+            handler(chain, ctx, kth::to_c_err(result.error()), nullptr, 0, nullptr, 0);
+        }
+    }, ::asio::detached);
 }
 
 void kth_chain_async_merkle_block_by_height(kth_chain_t chain, void* ctx, kth_size_t height, kth_merkle_block_fetch_handler_t handler) {
-    safe_chain(chain).fetch_merkle_block(height, [chain, ctx, handler](std::error_code const& ec, kth::domain::message::merkle_block::const_ptr block, size_t h) {
-        handler(chain, ctx, kth::to_c_err(ec), kth::leak_if_success(block, ec), h);
-    });
+    auto& bc = safe_chain(chain);
+    ::asio::co_spawn(bc.executor(), [&bc, height, chain, ctx, handler]() -> ::asio::awaitable<void> {
+        auto result = co_await bc.fetch_merkle_block(height);
+        if (result) {
+            auto const& [block, h] = *result;
+            handler(chain, ctx, kth::to_c_err(std::error_code{}), kth::leak_if_success(block, std::error_code{}), h);
+        } else {
+            handler(chain, ctx, kth::to_c_err(result.error()), nullptr, 0);
+        }
+    }, ::asio::detached);
 }
 
 void kth_chain_async_merkle_block_by_hash(kth_chain_t chain, void* ctx, kth_hash_t hash, kth_merkle_block_fetch_handler_t handler) {
     auto hash_cpp = kth::to_array(hash.hash);
-    safe_chain(chain).fetch_merkle_block(hash_cpp, [chain, ctx, handler](std::error_code const& ec, kth::domain::message::merkle_block::const_ptr block, size_t h) {
-        handler(chain, ctx, kth::to_c_err(ec), kth::leak_if_success(block, ec), h);
-    });
+    auto& bc = safe_chain(chain);
+    ::asio::co_spawn(bc.executor(), [&bc, hash_cpp, chain, ctx, handler]() -> ::asio::awaitable<void> {
+        auto result = co_await bc.fetch_merkle_block(hash_cpp);
+        if (result) {
+            auto const& [block, h] = *result;
+            handler(chain, ctx, kth::to_c_err(std::error_code{}), kth::leak_if_success(block, std::error_code{}), h);
+        } else {
+            handler(chain, ctx, kth::to_c_err(result.error()), nullptr, 0);
+        }
+    }, ::asio::detached);
 }
 
 void kth_chain_async_compact_block_by_height(kth_chain_t chain, void* ctx, kth_size_t height, kth_compact_block_fetch_handler_t handler) {
-    safe_chain(chain).fetch_compact_block(height, [chain, ctx, handler](std::error_code const& ec, kth::domain::message::compact_block::const_ptr block, size_t h) {
-        handler(chain, ctx, kth::to_c_err(ec), kth::leak_if_success(block, ec), h);
-    });
+    auto& bc = safe_chain(chain);
+    ::asio::co_spawn(bc.executor(), [&bc, height, chain, ctx, handler]() -> ::asio::awaitable<void> {
+        auto result = co_await bc.fetch_compact_block(height);
+        if (result) {
+            auto const& [block, h] = *result;
+            handler(chain, ctx, kth::to_c_err(std::error_code{}), kth::leak_if_success(block, std::error_code{}), h);
+        } else {
+            handler(chain, ctx, kth::to_c_err(result.error()), nullptr, 0);
+        }
+    }, ::asio::detached);
 }
 
 void kth_chain_async_compact_block_by_hash(kth_chain_t chain, void* ctx, kth_hash_t hash, kth_compact_block_fetch_handler_t handler) {
     auto hash_cpp = kth::to_array(hash.hash);
-
-    safe_chain(chain).fetch_compact_block(hash_cpp, [chain, ctx, handler](std::error_code const& ec, kth::domain::message::compact_block::const_ptr block, size_t h) {
-        handler(chain, ctx, kth::to_c_err(ec), kth::leak_if_success(block, ec), h);
-    });
+    auto& bc = safe_chain(chain);
+    ::asio::co_spawn(bc.executor(), [&bc, hash_cpp, chain, ctx, handler]() -> ::asio::awaitable<void> {
+        auto result = co_await bc.fetch_compact_block(hash_cpp);
+        if (result) {
+            auto const& [block, h] = *result;
+            handler(chain, ctx, kth::to_c_err(std::error_code{}), kth::leak_if_success(block, std::error_code{}), h);
+        } else {
+            handler(chain, ctx, kth::to_c_err(result.error()), nullptr, 0);
+        }
+    }, ::asio::detached);
 }
 
 void kth_chain_async_block_by_height_timestamp(kth_chain_t chain, void* ctx, kth_size_t height, kth_blockhash_timestamp_fetch_handler_t handler) {
-    safe_chain(chain).fetch_block_hash_timestamp(height, [chain, ctx, handler](std::error_code const& ec, kth::hash_digest const& hash, uint32_t timestamp, size_t h) {
-        if (ec == kth::error::success) {
-            handler(chain, ctx, kth::to_c_err(ec), kth::to_hash_t(hash), timestamp, h);
+    auto& bc = safe_chain(chain);
+    ::asio::co_spawn(bc.executor(), [&bc, height, chain, ctx, handler]() -> ::asio::awaitable<void> {
+        auto result = co_await bc.fetch_block_hash_timestamp(height);
+        if (result) {
+            auto const& [hash, timestamp, h] = *result;
+            handler(chain, ctx, kth::to_c_err(std::error_code{}), kth::to_hash_t(hash), timestamp, h);
         } else {
-            handler(chain, ctx, kth::to_c_err(ec), kth::to_hash_t(kth::null_hash), 0, h);
+            handler(chain, ctx, kth::to_c_err(result.error()), kth::to_hash_t(kth::null_hash), 0, 0);
         }
-    });
+    }, ::asio::detached);
 }
 
 void kth_chain_async_transaction(kth_chain_t chain, void* ctx, kth_hash_t hash, kth_bool_t require_confirmed, kth_transaction_fetch_handler_t handler) {
-    //precondition:  [hash, 32] is a valid range
     auto hash_cpp = kth::to_array(hash.hash);
-    safe_chain(chain).fetch_transaction(hash_cpp, kth::int_to_bool(require_confirmed), [chain, ctx, handler](std::error_code const& ec, kth::domain::message::transaction::const_ptr transaction, size_t i, size_t h) {
-        handler(chain, ctx, kth::to_c_err(ec), kth::leak_if_success(transaction, ec), i, h);
-    });
+    auto const confirmed = kth::int_to_bool(require_confirmed);
+    auto& bc = safe_chain(chain);
+    ::asio::co_spawn(bc.executor(), [&bc, hash_cpp, confirmed, chain, ctx, handler]() -> ::asio::awaitable<void> {
+        auto result = co_await bc.fetch_transaction(hash_cpp, confirmed);
+        if (result) {
+            auto const& [transaction, i, h] = *result;
+            handler(chain, ctx, kth::to_c_err(std::error_code{}), kth::leak_if_success(transaction, std::error_code{}), i, h);
+        } else {
+            handler(chain, ctx, kth::to_c_err(result.error()), nullptr, 0, 0);
+        }
+    }, ::asio::detached);
 }
 
 void kth_chain_async_transaction_position(kth_chain_t chain, void* ctx, kth_hash_t hash, int require_confirmed, kth_transaction_index_fetch_handler_t handler) {
     auto hash_cpp = kth::to_array(hash.hash);
-
-    safe_chain(chain).fetch_transaction_position(hash_cpp, kth::int_to_bool(require_confirmed), [chain, ctx, handler](std::error_code const& ec, size_t position, size_t height) {
-        handler(chain, ctx, kth::to_c_err(ec), position, height);
-    });
+    auto const confirmed = kth::int_to_bool(require_confirmed);
+    auto& bc = safe_chain(chain);
+    ::asio::co_spawn(bc.executor(), [&bc, hash_cpp, confirmed, chain, ctx, handler]() -> ::asio::awaitable<void> {
+        auto result = co_await bc.fetch_transaction_position(hash_cpp, confirmed);
+        if (result) {
+            auto const& [position, height] = *result;
+            handler(chain, ctx, kth::to_c_err(std::error_code{}), position, height);
+        } else {
+            handler(chain, ctx, kth::to_c_err(result.error()), 0, 0);
+        }
+    }, ::asio::detached);
 }
 
 void kth_chain_async_spend(kth_chain_t chain, void* ctx, kth_output_point_const_t op, kth_spend_fetch_handler_t handler) {
     auto const* outpoint_cpp = static_cast<kth::domain::chain::output_point const*>(op);
-
-    safe_chain(chain).fetch_spend(*outpoint_cpp, [chain, ctx, handler](std::error_code const& ec, kth::domain::chain::input_point input_point) {
-        handler(chain, ctx, kth::to_c_err(ec), kth::leak_if_success(input_point, ec));
-    });
+    auto& bc = safe_chain(chain);
+    ::asio::co_spawn(bc.executor(), [&bc, outpoint_cpp, chain, ctx, handler]() -> ::asio::awaitable<void> {
+        auto result = co_await bc.fetch_spend(*outpoint_cpp);
+        if (result) {
+            handler(chain, ctx, kth::to_c_err(std::error_code{}), kth::leak_if_success(*result, std::error_code{}));
+        } else {
+            handler(chain, ctx, kth::to_c_err(result.error()), nullptr);
+        }
+    }, ::asio::detached);
 }
 
 void kth_chain_async_history(kth_chain_t chain, void* ctx, kth_payment_address_t address, kth_size_t limit, kth_size_t from_height, kth_history_fetch_handler_t handler) {
-    safe_chain(chain).fetch_history(kth::cpp_ref<kth::domain::wallet::payment_address>(address).hash20(), limit, from_height, [chain, ctx, handler](std::error_code const& ec, kth::domain::chain::history_compact::list history) {
-        handler(chain, ctx, kth::to_c_err(ec), kth::leak_if_success(history, ec));
-    });
+    auto const addr_hash = kth::cpp_ref<kth::domain::wallet::payment_address>(address).hash20();
+    auto& bc = safe_chain(chain);
+    ::asio::co_spawn(bc.executor(), [&bc, addr_hash, limit, from_height, chain, ctx, handler]() -> ::asio::awaitable<void> {
+        auto result = co_await bc.fetch_history(addr_hash, limit, from_height);
+        if (result) {
+            handler(chain, ctx, kth::to_c_err(std::error_code{}), kth::leak_if_success(*result, std::error_code{}));
+        } else {
+            handler(chain, ctx, kth::to_c_err(result.error()), nullptr);
+        }
+    }, ::asio::detached);
 }
 
 void kth_chain_async_confirmed_transactions(kth_chain_t chain, void* ctx, kth_payment_address_t address, uint64_t max, uint64_t start_height, kth_transactions_by_address_fetch_handler_t handler) {
-    safe_chain(chain).fetch_confirmed_transactions(kth::cpp_ref<kth::domain::wallet::payment_address>(address).hash20(), max, start_height, [chain, ctx, handler](std::error_code const& ec, std::vector<kth::hash_digest> const& txs) {
-        handler(chain, ctx, kth::to_c_err(ec), kth::leak_if_success(txs, ec));
-    });
+    auto const addr_hash = kth::cpp_ref<kth::domain::wallet::payment_address>(address).hash20();
+    auto& bc = safe_chain(chain);
+    ::asio::co_spawn(bc.executor(), [&bc, addr_hash, max, start_height, chain, ctx, handler]() -> ::asio::awaitable<void> {
+        auto result = co_await bc.fetch_confirmed_transactions(addr_hash, max, start_height);
+        if (result) {
+            handler(chain, ctx, kth::to_c_err(std::error_code{}), kth::leak_if_success(*result, std::error_code{}));
+        } else {
+            handler(chain, ctx, kth::to_c_err(result.error()), nullptr);
+        }
+    }, ::asio::detached);
 }
-
-// void kth_chain_async_stealth(kth_chain_t chain, void* ctx, kth_binary_t filter, uint64_t from_height, kth_stealth_fetch_handler_t handler) {
-// 	auto* filter_cpp_ptr = static_cast<kth::binary const*>(filter);
-// 	kth::binary const& filter_cpp = *filter_cpp_ptr;
-
-//     safe_chain(chain).fetch_stealth(filter_cpp, from_height, [chain, ctx, handler](std::error_code const& ec, kth::domain::chain::stealth_compact::list stealth) {
-//         handler(chain, ctx, kth::to_c_err(ec), kth::leak_if_success(stealth, ec));
-//     });
-// }
 
 // Organizers.
 //-------------------------------------------------------------------------

--- a/src/c-api/src/chain/chain_other.cpp
+++ b/src/c-api/src/chain/chain_other.cpp
@@ -65,7 +65,7 @@ extern "C" {
 // Subscribers.
 //-------------------------------------------------------------------------
 
-void kth_chain_subscribe_blockchain(kth_node_t exec, kth_chain_t chain, void* ctx, kth_subscribe_block_handler_t handler) {
+void kth_chain_subscribe_blockchain(kth_node_t exec, kth_chain_t chain, void* ctx, kth_subscribe_blockchain_handler_t handler) {
     auto& bc = safe_chain(chain);
     auto channel = bc.subscribe_blockchain();
 

--- a/src/c-api/src/chain/chain_sync.cpp
+++ b/src/c-api/src/chain/chain_sync.cpp
@@ -4,10 +4,9 @@
 
 #include <kth/capi/chain/chain_sync.h>
 #include <cstdio>
-#include <latch>
+#include <future>
 #include <memory>
-
-// #include <boost/thread/latch.hpp>
+#include <system_error>
 
 #include <kth/domain/chain/block.hpp>
 #include <kth/domain/chain/header.hpp>
@@ -19,6 +18,8 @@
 #include <kth/capi/conversions.hpp>
 #include <kth/capi/helpers.hpp>
 
+#include <asio/co_spawn.hpp>
+#include <asio/use_future.hpp>
 
 namespace {
 
@@ -34,18 +35,20 @@ kth::domain::message::transaction::const_ptr tx_shared(kth_transaction_const_t t
     return kth::domain::message::transaction::const_ptr(tx_new);
 }
 
-// inline
-// kth::domain::chain::transaction::const_ptr tx_shared(kth_transaction_t tx) {
-//     auto const& tx_ref = *static_cast<kth::domain::chain::transaction const*>(tx);
-//     auto* tx_new = new kth::domain::chain::transaction(tx_ref);
-//     return kth::domain::chain::transaction::const_ptr(tx_new);
-// }
-
 inline
 kth::domain::message::block::const_ptr block_shared(kth_block_const_t block) {
     auto const& block_ref = *static_cast<kth::domain::chain::block const*>(block);
     auto* block_new = new kth::domain::message::block(block_ref);
     return kth::domain::message::block::const_ptr(block_new);
+}
+
+// Run an awaitable on the chain's executor and block until it completes.
+// Returns the awaitable's value type (typically std::expected<T, code> for
+// fetch_* methods, or code for organize()).
+template <typename Awaitable>
+auto sync_wait(kth::blockchain::block_chain& bc, Awaitable awaitable) {
+    auto fut = ::asio::co_spawn(bc.executor(), std::move(awaitable), ::asio::use_future);
+    return fut.get();
 }
 
 } /* end of anonymous namespace */
@@ -55,320 +58,255 @@ kth::domain::message::block::const_ptr block_shared(kth_block_const_t block) {
 extern "C" {
 
 kth_error_code_t kth_chain_sync_last_height(kth_chain_t chain, kth_size_t* out_height) {
-    std::latch latch(1); //Note: workaround to fix an error on some versions of Boost.Threads
-
-    kth_error_code_t res;
-    safe_chain(chain).fetch_last_height([&](std::error_code const& ec, size_t h) {
-       *out_height = h;
-       res = kth::to_c_err(ec);
-       latch.count_down();
-    });
-
-    latch.wait();
-    return res;
+    auto& bc = safe_chain(chain);
+    auto result = sync_wait(bc, bc.fetch_last_height());
+    if (result) {
+        *out_height = result->block;
+        return kth::to_c_err(std::error_code{});
+    }
+    *out_height = 0;
+    return kth::to_c_err(result.error());
 }
 
 kth_error_code_t kth_chain_sync_block_height(kth_chain_t chain, kth_hash_t hash, kth_size_t* out_height) {
-    std::latch latch(1); //Note: workaround to fix an error on some versions of Boost.Threads
-    kth_error_code_t res;
-
+    auto& bc = safe_chain(chain);
     auto hash_cpp = kth::to_array(hash.hash);
-
-    safe_chain(chain).fetch_block_height(hash_cpp, [&](std::error_code const& ec, size_t h) {
-        *out_height = h;
-        res = kth::to_c_err(ec);
-        latch.count_down();
-    });
-
-    latch.wait();
-    return res;
+    auto result = sync_wait(bc, bc.fetch_block_height(hash_cpp));
+    if (result) {
+        *out_height = *result;
+        return kth::to_c_err(std::error_code{});
+    }
+    *out_height = 0;
+    return kth::to_c_err(result.error());
 }
 
 kth_error_code_t kth_chain_sync_block_header_by_height(kth_chain_t chain, kth_size_t height, kth_header_mut_t* out_header, kth_size_t* out_height) {
-    std::latch latch(1); //Note: workaround to fix an error on some versions of Boost.Threads
-    kth_error_code_t res;
-
-    safe_chain(chain).fetch_block_header(height, [&](std::error_code const& ec, kth::domain::chain::header::ptr header, size_t h) {
-        *out_header = kth::leak_if_success(header, ec);
+    auto& bc = safe_chain(chain);
+    auto result = sync_wait(bc, bc.fetch_block_header(height));
+    if (result) {
+        auto const& [header, h] = *result;
+        *out_header = kth::leak_if_success(header, std::error_code{});
         *out_height = h;
-        res = kth::to_c_err(ec);
-        latch.count_down();
-    });
-
-    latch.wait();
-    return res;
+        return kth::to_c_err(std::error_code{});
+    }
+    *out_header = nullptr;
+    *out_height = 0;
+    return kth::to_c_err(result.error());
 }
 
 kth_error_code_t kth_chain_sync_block_header_by_hash(kth_chain_t chain, kth_hash_t hash, kth_header_mut_t* out_header, kth_size_t* out_height) {
-    std::latch latch(1); //Note: workaround to fix an error on some versions of Boost.Threads
-    kth_error_code_t res;
-
+    auto& bc = safe_chain(chain);
     auto hash_cpp = kth::to_array(hash.hash);
-
-    safe_chain(chain).fetch_block_header(hash_cpp, [&](std::error_code const& ec, kth::domain::chain::header::ptr header, size_t h) {
-        *out_header = kth::leak_if_success(header, ec);
+    auto result = sync_wait(bc, bc.fetch_block_header(hash_cpp));
+    if (result) {
+        auto const& [header, h] = *result;
+        *out_header = kth::leak_if_success(header, std::error_code{});
         *out_height = h;
-        res = kth::to_c_err(ec);
-        latch.count_down();
-    });
-
-    latch.wait();
-    return res;
+        return kth::to_c_err(std::error_code{});
+    }
+    *out_header = nullptr;
+    *out_height = 0;
+    return kth::to_c_err(result.error());
 }
 
 kth_error_code_t kth_chain_sync_block_by_height(kth_chain_t chain, kth_size_t height, kth_block_mut_t* out_block, kth_size_t* out_height) {
-    std::latch latch(1); //Note: workaround to fix an error on some versions of Boost.Threads
-    kth_error_code_t res;
-
-    safe_chain(chain).fetch_block(height, [&](std::error_code const& ec, kth::domain::message::block::const_ptr block, size_t h) {
-        if (ec == kth::error::success) {
-            *out_block = kth::leak_if_success(block, ec);
-        } else {
-            *out_block = nullptr;
-        }
-
+    auto& bc = safe_chain(chain);
+    auto result = sync_wait(bc, bc.fetch_block(height));
+    if (result) {
+        auto const& [block, h] = *result;
+        *out_block = kth::leak_if_success(block, std::error_code{});
         *out_height = h;
-        res = kth::to_c_err(ec);
-        latch.count_down();
-    });
-
-    latch.wait();
-    return res;
+        return kth::to_c_err(std::error_code{});
+    }
+    *out_block = nullptr;
+    *out_height = 0;
+    return kth::to_c_err(result.error());
 }
 
 kth_error_code_t kth_chain_sync_block_by_hash(kth_chain_t chain, kth_hash_t hash, kth_block_mut_t* out_block, kth_size_t* out_height) {
-    std::latch latch(1); //Note: workaround to fix an error on some versions of Boost.Threads
-    kth_error_code_t res;
-
+    auto& bc = safe_chain(chain);
     auto hash_cpp = kth::to_array(hash.hash);
-
-    safe_chain(chain).fetch_block(hash_cpp, [&](std::error_code const& ec, kth::domain::message::block::const_ptr block, size_t h) {
-        if (ec == kth::error::success) {
-            *out_block = kth::leak_if_success(block, ec);
-        } else {
-            *out_block = nullptr;
-        }
-
+    auto result = sync_wait(bc, bc.fetch_block(hash_cpp));
+    if (result) {
+        auto const& [block, h] = *result;
+        *out_block = kth::leak_if_success(block, std::error_code{});
         *out_height = h;
-        res = kth::to_c_err(ec);
-        latch.count_down();
-    });
-
-    latch.wait();
-    return res;
+        return kth::to_c_err(std::error_code{});
+    }
+    *out_block = nullptr;
+    *out_height = 0;
+    return kth::to_c_err(result.error());
 }
 
 kth_error_code_t kth_chain_sync_block_header_byhash_txs_size(kth_chain_t chain, kth_hash_t hash, kth_header_mut_t* out_header, uint64_t* out_block_height, kth_hash_list_mut_t* out_tx_hashes, uint64_t* out_serialized_size) {
-    std::latch latch(1); //Note: workaround to fix an error on some versions of Boost.Threads
-    kth_error_code_t res;
-
+    auto& bc = safe_chain(chain);
     auto hash_cpp = kth::to_array(hash.hash);
-
-    safe_chain(chain).fetch_block_header_txs_size(hash_cpp, [&](std::error_code const& ec, kth::domain::message::header::const_ptr header, size_t block_height, std::shared_ptr<kth::hash_list> tx_hashes, uint64_t block_serialized_size) {
-        *out_header = kth::leak_if_success(header, ec);
+    auto result = sync_wait(bc, bc.fetch_block_header_txs_size(hash_cpp));
+    if (result) {
+        auto const& [header, block_height, tx_hashes, block_serialized_size] = *result;
+        *out_header = kth::leak_if_success(header, std::error_code{});
         *out_block_height = block_height;
-        *out_tx_hashes = kth::leak_if_success(tx_hashes, ec);
+        *out_tx_hashes = kth::leak_if_success(tx_hashes, std::error_code{});
         *out_serialized_size = block_serialized_size;
-        res = kth::to_c_err(ec);
-        latch.count_down();
-    });
-
-    latch.wait();
-    return res;
+        return kth::to_c_err(std::error_code{});
+    }
+    *out_header = nullptr;
+    *out_block_height = 0;
+    *out_tx_hashes = nullptr;
+    *out_serialized_size = 0;
+    return kth::to_c_err(result.error());
 }
 
 kth_error_code_t kth_chain_sync_merkle_block_by_height(kth_chain_t chain, kth_size_t height, kth_merkle_block_mut_t* out_block, kth_size_t* out_height) {
-    std::latch latch(1); //Note: workaround to fix an error on some versions of Boost.Threads
-    kth_error_code_t res;
-
-    safe_chain(chain).fetch_merkle_block(height, [&](std::error_code const& ec, kth::domain::message::merkle_block::const_ptr block, size_t h) {
-        *out_block = kth::leak_if_success(block, ec);
+    auto& bc = safe_chain(chain);
+    auto result = sync_wait(bc, bc.fetch_merkle_block(height));
+    if (result) {
+        auto const& [block, h] = *result;
+        *out_block = kth::leak_if_success(block, std::error_code{});
         *out_height = h;
-        res = kth::to_c_err(ec);
-        latch.count_down();
-    });
-
-    latch.wait();
-    return res;
+        return kth::to_c_err(std::error_code{});
+    }
+    *out_block = nullptr;
+    *out_height = 0;
+    return kth::to_c_err(result.error());
 }
 
 kth_error_code_t kth_chain_sync_merkle_block_by_hash(kth_chain_t chain, kth_hash_t hash, kth_merkle_block_mut_t* out_block, kth_size_t* out_height) {
-    std::latch latch(1); //Note: workaround to fix an error on some versions of Boost.Threads
-    kth_error_code_t res;
-
+    auto& bc = safe_chain(chain);
     auto hash_cpp = kth::to_array(hash.hash);
-
-    safe_chain(chain).fetch_merkle_block(hash_cpp, [&](std::error_code const& ec, kth::domain::message::merkle_block::const_ptr block, size_t h) {
-        *out_block = kth::leak_if_success(block, ec);
+    auto result = sync_wait(bc, bc.fetch_merkle_block(hash_cpp));
+    if (result) {
+        auto const& [block, h] = *result;
+        *out_block = kth::leak_if_success(block, std::error_code{});
         *out_height = h;
-        res = kth::to_c_err(ec);
-        latch.count_down();
-    });
-
-    latch.wait();
-    return res;
+        return kth::to_c_err(std::error_code{});
+    }
+    *out_block = nullptr;
+    *out_height = 0;
+    return kth::to_c_err(result.error());
 }
 
 kth_error_code_t kth_chain_sync_compact_block_by_height(kth_chain_t chain, kth_size_t height, kth_compact_block_mut_t* out_block, kth_size_t* out_height) {
-    std::latch latch(1); //Note: workaround to fix an error on some versions of Boost.Threads
-    kth_error_code_t res;
-
-    safe_chain(chain).fetch_compact_block(height, [&](std::error_code const& ec, kth::domain::message::compact_block::const_ptr block, size_t h) {
-        *out_block = kth::leak_if_success(block, ec);
+    auto& bc = safe_chain(chain);
+    auto result = sync_wait(bc, bc.fetch_compact_block(height));
+    if (result) {
+        auto const& [block, h] = *result;
+        *out_block = kth::leak_if_success(block, std::error_code{});
         *out_height = h;
-        res = kth::to_c_err(ec);
-        latch.count_down();
-    });
-
-    latch.wait();
-    return res;
+        return kth::to_c_err(std::error_code{});
+    }
+    *out_block = nullptr;
+    *out_height = 0;
+    return kth::to_c_err(result.error());
 }
 
 kth_error_code_t kth_chain_sync_compact_block_by_hash(kth_chain_t chain, kth_hash_t hash, kth_compact_block_mut_t* out_block, kth_size_t* out_height) {
-    std::latch latch(1); //Note: workaround to fix an error on some versions of Boost.Threads
-    kth_error_code_t res;
-
+    auto& bc = safe_chain(chain);
     auto hash_cpp = kth::to_array(hash.hash);
-
-    safe_chain(chain).fetch_compact_block(hash_cpp, [&](std::error_code const& ec, kth::domain::message::compact_block::const_ptr block, size_t h) {
-        *out_block = kth::leak_if_success(block, ec);
+    auto result = sync_wait(bc, bc.fetch_compact_block(hash_cpp));
+    if (result) {
+        auto const& [block, h] = *result;
+        *out_block = kth::leak_if_success(block, std::error_code{});
         *out_height = h;
-        res = kth::to_c_err(ec);
-        latch.count_down();
-    });
-
-    latch.wait();
-    return res;
+        return kth::to_c_err(std::error_code{});
+    }
+    *out_block = nullptr;
+    *out_height = 0;
+    return kth::to_c_err(result.error());
 }
 
 kth_error_code_t kth_chain_sync_block_by_height_timestamp(kth_chain_t chain, kth_size_t height, kth_hash_t* out_hash, uint32_t* out_timestamp) {
-    std::latch latch(1); //Note: workaround to fix an error on some versions of Boost.Threads
-    kth_error_code_t res;
-
-    safe_chain(chain).fetch_block_hash_timestamp(height, [&](std::error_code const& ec, kth::hash_digest const& hash, uint32_t timestamp, size_t h) {
-        if (ec == kth::error::success) {
-            kth::copy_c_hash(hash, out_hash);
-            *out_timestamp = timestamp;
-        } else {
-            kth::copy_c_hash(kth::null_hash, out_hash);
-            *out_timestamp = 0;
-        }
-
-        res = kth::to_c_err(ec);
-        latch.count_down();
-    });
-
-    latch.wait();
-    return res;
+    auto& bc = safe_chain(chain);
+    auto result = sync_wait(bc, bc.fetch_block_hash_timestamp(height));
+    if (result) {
+        auto const& [hash, timestamp, h] = *result;
+        kth::copy_c_hash(hash, out_hash);
+        *out_timestamp = timestamp;
+        return kth::to_c_err(std::error_code{});
+    }
+    kth::copy_c_hash(kth::null_hash, out_hash);
+    *out_timestamp = 0;
+    return kth::to_c_err(result.error());
 }
 
 
 
 kth_error_code_t kth_chain_sync_block_hash(kth_chain_t chain, kth_size_t height, kth_hash_t* out_hash) {
-    kth::hash_digest block_hash;
-    bool found_block = safe_chain(chain).get_block_hash(block_hash, height);
-    if( ! found_block ) {
+    auto result = safe_chain(chain).get_block_hash(height);
+    if ( ! result) {
         return kth_ec_not_found;
     }
-    kth::copy_c_hash(block_hash, out_hash);
+    kth::copy_c_hash(*result, out_hash);
     return kth_ec_success;
 }
 
 kth_error_code_t kth_chain_sync_transaction(kth_chain_t chain, kth_hash_t hash, int require_confirmed, kth_transaction_mut_t* out_transaction, kth_size_t* out_height, kth_size_t* out_index) {
-    std::latch latch(1); //Note: workaround to fix an error on some versions of Boost.Threads
-    kth_error_code_t res;
-
+    auto& bc = safe_chain(chain);
     auto hash_cpp = kth::to_array(hash.hash);
-
-    safe_chain(chain).fetch_transaction(hash_cpp, kth::int_to_bool(require_confirmed), [&](std::error_code const& ec, kth::domain::message::transaction::const_ptr transaction, size_t i, size_t h) {
-        *out_transaction = kth::leak_if_success(transaction, ec);
+    auto result = sync_wait(bc, bc.fetch_transaction(hash_cpp, kth::int_to_bool(require_confirmed)));
+    if (result) {
+        auto const& [transaction, i, h] = *result;
+        *out_transaction = kth::leak_if_success(transaction, std::error_code{});
         *out_height = h;
         *out_index = i;
-        res = kth::to_c_err(ec);
-        latch.count_down();
-    });
-
-    latch.wait();
-    return res;
+        return kth::to_c_err(std::error_code{});
+    }
+    *out_transaction = nullptr;
+    *out_height = 0;
+    *out_index = 0;
+    return kth::to_c_err(result.error());
 }
 
 kth_error_code_t kth_chain_sync_transaction_position(kth_chain_t chain, kth_hash_t hash, int require_confirmed, kth_size_t* out_position, kth_size_t* out_height) {
-    std::latch latch(1); //Note: workaround to fix an error on some versions of Boost.Threads
-    kth_error_code_t res;
-
+    auto& bc = safe_chain(chain);
     auto hash_cpp = kth::to_array(hash.hash);
-
-    safe_chain(chain).fetch_transaction_position(hash_cpp, kth::int_to_bool(require_confirmed), [&](std::error_code const& ec, size_t position, size_t height) {
-        *out_height = height;
+    auto result = sync_wait(bc, bc.fetch_transaction_position(hash_cpp, kth::int_to_bool(require_confirmed)));
+    if (result) {
+        auto const& [position, height] = *result;
         *out_position = position;
-        res = kth::to_c_err(ec);
-        latch.count_down();
-    });
-
-    latch.wait();
-    return res;
+        *out_height = height;
+        return kth::to_c_err(std::error_code{});
+    }
+    *out_position = 0;
+    *out_height = 0;
+    return kth::to_c_err(result.error());
 }
 
 kth_error_code_t kth_chain_sync_spend(kth_chain_t chain, kth_output_point_const_t op, kth_input_point_mut_t* out_input_point) {
-    std::latch latch(1); //Note: workaround to fix an error on some versions of Boost.Threads
-    kth_error_code_t res;
-
+    auto& bc = safe_chain(chain);
     auto const* outpoint_cpp = static_cast<kth::domain::chain::output_point const*>(op);
-
-    safe_chain(chain).fetch_spend(*outpoint_cpp, [&](std::error_code const& ec, kth::domain::chain::input_point input_point) {
-        *out_input_point = kth::leak_if_success(input_point, ec);
-        res = kth::to_c_err(ec);
-        latch.count_down();
-    });
-
-    latch.wait();
-    return res;
+    auto result = sync_wait(bc, bc.fetch_spend(*outpoint_cpp));
+    if (result) {
+        *out_input_point = kth::leak_if_success(*result, std::error_code{});
+        return kth::to_c_err(std::error_code{});
+    }
+    *out_input_point = nullptr;
+    return kth::to_c_err(result.error());
 }
 
 kth_error_code_t kth_chain_sync_history(kth_chain_t chain, kth_payment_address_t address, kth_size_t limit, kth_size_t from_height, kth_history_compact_list_mut_t* out_history) {
-    std::latch latch(1); //Note: workaround to fix an error on some versions of Boost.Threads
-    kth_error_code_t res;
-
-    safe_chain(chain).fetch_history(kth::cpp_ref<kth::domain::wallet::payment_address>(address).hash20(), limit, from_height, [&](std::error_code const& ec, kth::domain::chain::history_compact::list history) {
-        *out_history = kth::leak_if_success(history, ec);
-        res = kth::to_c_err(ec);
-        latch.count_down();
-    });
-
-    latch.wait();
-    return res;
+    auto& bc = safe_chain(chain);
+    auto const addr_hash = kth::cpp_ref<kth::domain::wallet::payment_address>(address).hash20();
+    auto result = sync_wait(bc, bc.fetch_history(addr_hash, limit, from_height));
+    if (result) {
+        *out_history = kth::leak_if_success(*result, std::error_code{});
+        return kth::to_c_err(std::error_code{});
+    }
+    *out_history = nullptr;
+    return kth::to_c_err(result.error());
 }
 
 kth_error_code_t kth_chain_sync_confirmed_transactions(kth_chain_t chain, kth_payment_address_t address, uint64_t max, uint64_t start_height, kth_hash_list_mut_t* out_tx_hashes) {
-    std::latch latch(1); //Note: workaround to fix an error on some versions of Boost.Threads
-    kth_error_code_t res;
-
-    safe_chain(chain).fetch_confirmed_transactions(kth::cpp_ref<kth::domain::wallet::payment_address>(address).hash20(), max, start_height, [&](std::error_code const& ec, std::vector<kth::hash_digest> const& txs) {
-        *out_tx_hashes = kth::leak_if_success(txs, ec);
-        res = kth::to_c_err(ec);
-        latch.count_down();
-    });
-
-    latch.wait();
-    return res;
+    auto& bc = safe_chain(chain);
+    auto const addr_hash = kth::cpp_ref<kth::domain::wallet::payment_address>(address).hash20();
+    auto result = sync_wait(bc, bc.fetch_confirmed_transactions(addr_hash, max, start_height));
+    if (result) {
+        *out_tx_hashes = kth::leak_if_success(*result, std::error_code{});
+        return kth::to_c_err(std::error_code{});
+    }
+    *out_tx_hashes = nullptr;
+    return kth::to_c_err(result.error());
 }
-
-// kth_error_code_t kth_chain_sync_stealth(kth_chain_t chain, kth_binary_t filter, uint64_t from_height, kth_stealth_compact_list_t* out_list) {
-//     std::latch latch(1); //Note: workaround to fix an error on some versions of Boost.Threads
-//     kth_error_code_t res;
-
-// 	auto* filter_cpp_ptr = static_cast<kth::binary const*>(filter);
-// 	kth::binary const& filter_cpp  = *filter_cpp_ptr;
-
-//     safe_chain(chain).fetch_stealth(filter_cpp, from_height, [&](std::error_code const& ec, kth::domain::chain::stealth_compact::list stealth) {
-//         *out_list = kth::leak_if_success(stealth, ec);
-//         res = kth::to_c_err(ec);
-//         latch.count_down();
-//     });
-
-//     latch.wait();
-//     return res;
-// }
 
 // ------------------------------------------------------------------
 
@@ -393,29 +331,15 @@ kth_transaction_list_mut_t kth_chain_sync_mempool_transactions_from_wallets(kth_
 //-------------------------------------------------------------------------
 
 int kth_chain_sync_organize_block(kth_chain_t chain, kth_block_mut_t block) {
-    std::latch latch(1); //Note: workaround to fix an error on some versions of Boost.Threads
-    kth_error_code_t res;
-
-    safe_chain(chain).organize(block_shared(block), [&](std::error_code const& ec) {
-        res = kth::to_c_err(ec);
-        latch.count_down();
-    });
-
-    latch.wait();
-    return res;
+    auto& bc = safe_chain(chain);
+    auto ec = sync_wait(bc, bc.organize(block_shared(block)));
+    return kth::to_c_err(ec);
 }
 
 int kth_chain_sync_organize_transaction(kth_chain_t chain, kth_transaction_mut_t transaction) {
-    std::latch latch(1); //Note: workaround to fix an error on some versions of Boost.Threads
-    kth_error_code_t res;
-
-    safe_chain(chain).organize(tx_shared(transaction), [&](std::error_code const& ec) {
-        res = kth::to_c_err(ec);
-        latch.count_down();
-    });
-
-    latch.wait();
-    return res;
+    auto& bc = safe_chain(chain);
+    auto ec = sync_wait(bc, bc.organize(tx_shared(transaction)));
+    return kth::to_c_err(ec);
 }
 
 //-------------------------------------------------------------------------

--- a/src/c-api/src/node/settings.cpp
+++ b/src/c-api/src/node/settings.cpp
@@ -14,7 +14,7 @@
 #include <kth/domain/multi_crypto_support.hpp>
 
 #if ! defined(__EMSCRIPTEN__)
-#include <kth/network/p2p.hpp>
+#include <kth/network/p2p_node.hpp>
 #endif
 
 // ---------------------------------------------------------------------------
@@ -28,7 +28,7 @@ kth_currency_t kth_node_settings_get_currency() {
 kth_network_t kth_node_settings_get_network(kth_node_t exec) {
 
     kth_p2p_t p2p_node = kth_node_get_p2p(exec);
-    auto const& node = *static_cast<kth::network::p2p*>(p2p_node);
+    auto const& node = *static_cast<kth::network::p2p_node*>(p2p_node);
 
     auto const& sett = node.network_settings();
     auto id = sett.identifier;

--- a/src/c-api/src/p2p/p2p.cpp
+++ b/src/c-api/src/p2p/p2p.cpp
@@ -4,14 +4,14 @@
 
 #include <kth/capi/p2p/p2p.h>
 
-#include <kth/network/p2p.hpp>
+#include <kth/network/p2p_node.hpp>
 #include <kth/capi/helpers.hpp>
 
 namespace {
 
 inline
-kth::network::p2p& p2p_cast(kth_p2p_t p2p) {
-    return *static_cast<kth::network::p2p*>(p2p);
+kth::network::p2p_node& p2p_cast(kth_p2p_t p2p) {
+    return *static_cast<kth::network::p2p_node*>(p2p);
 }
 
 } /* end of anonymous namespace */
@@ -27,8 +27,12 @@ void kth_p2p_stop(kth_p2p_t p2p) {
     p2p_cast(p2p).stop();
 }
 
+// v1.0 replaced `p2p::close()` with `stop()` + `join()`. Preserve the
+// existing C-API semantics: kth_p2p_close blocks until shutdown is done.
 void kth_p2p_close(kth_p2p_t p2p) {
-    p2p_cast(p2p).close();
+    auto& node = p2p_cast(p2p);
+    node.stop();
+    node.join();
 }
 
 kth_bool_t kth_p2p_stopped(kth_p2p_t p2p) {

--- a/src/c-api/test/wallet/wallet_data.cpp
+++ b/src/c-api/test/wallet/wallet_data.cpp
@@ -35,7 +35,7 @@ TEST_CASE("C-API WalletData - destruct null is safe", "[C-API WalletData]") {
 TEST_CASE("C-API WalletData - create with English default returns a handle",
           "[C-API WalletData]") {
     kth_wallet_data_mut_t wd = NULL;
-    kth_error_code_t ec = kth_wallet_create(
+    kth_error_code_t ec = kth_wallet_create_simple(
         "testpassword", "testpassphrase", &wd);
     REQUIRE(ec == kth_ec_success);
     REQUIRE(wd != NULL);
@@ -70,7 +70,7 @@ TEST_CASE("C-API WalletData - create with English default returns a handle",
 TEST_CASE("C-API WalletData - copy preserves mnemonics count and xpub validity",
           "[C-API WalletData]") {
     kth_wallet_data_mut_t original = NULL;
-    REQUIRE(kth_wallet_create(
+    REQUIRE(kth_wallet_create_simple(
         "pwd", "passphrase", &original) == kth_ec_success);
 
     kth_wallet_data_mut_t copy = kth_wallet_wallet_data_copy(original);
@@ -97,7 +97,7 @@ TEST_CASE("C-API WalletData - copy preserves mnemonics count and xpub validity",
 TEST_CASE("C-API WalletData - set_mnemonics replaces the word list",
           "[C-API WalletData]") {
     kth_wallet_data_mut_t wd = NULL;
-    REQUIRE(kth_wallet_create(
+    REQUIRE(kth_wallet_create_simple(
         "p", "p", &wd) == kth_ec_success);
 
     kth_string_list_mut_t replacement = kth_core_string_list_construct_default();
@@ -116,7 +116,7 @@ TEST_CASE("C-API WalletData - set_mnemonics replaces the word list",
 TEST_CASE("C-API WalletData - set_encrypted_seed_unsafe round-trip",
           "[C-API WalletData]") {
     kth_wallet_data_mut_t wd = NULL;
-    REQUIRE(kth_wallet_create(
+    REQUIRE(kth_wallet_create_simple(
         "p", "p", &wd) == kth_ec_success);
 
     uint8_t replacement[96];
@@ -146,33 +146,33 @@ TEST_CASE("C-API WalletData - mnemonics getter null aborts",
 
 TEST_CASE("C-API WalletData - create null out aborts",
           "[C-API WalletData][precondition]") {
-    KTH_EXPECT_ABORT(kth_wallet_create("p", "p", NULL));
+    KTH_EXPECT_ABORT(kth_wallet_create_simple("p", "p", NULL));
 }
 
 TEST_CASE("C-API WalletData - create null password aborts",
           "[C-API WalletData][precondition]") {
     kth_wallet_data_mut_t wd = NULL;
-    KTH_EXPECT_ABORT(kth_wallet_create(NULL, "p", &wd));
+    KTH_EXPECT_ABORT(kth_wallet_create_simple(NULL, "p", &wd));
 }
 
 TEST_CASE("C-API WalletData - create null passphrase aborts",
           "[C-API WalletData][precondition]") {
     kth_wallet_data_mut_t wd = NULL;
-    KTH_EXPECT_ABORT(kth_wallet_create("p", NULL, &wd));
+    KTH_EXPECT_ABORT(kth_wallet_create_simple("p", NULL, &wd));
 }
 
 TEST_CASE("C-API WalletData - create non-null *out aborts",
           "[C-API WalletData][precondition]") {
     kth_wallet_data_mut_t already = NULL;
-    REQUIRE(kth_wallet_create("p", "p", &already) == kth_ec_success);
-    KTH_EXPECT_ABORT(kth_wallet_create("p", "p", &already));
+    REQUIRE(kth_wallet_create_simple("p", "p", &already) == kth_ec_success);
+    KTH_EXPECT_ABORT(kth_wallet_create_simple("p", "p", &already));
     kth_wallet_wallet_data_destruct(already);
 }
 
 TEST_CASE("C-API WalletData - set_encrypted_seed_unsafe null aborts",
           "[C-API WalletData][precondition]") {
     kth_wallet_data_mut_t wd = NULL;
-    REQUIRE(kth_wallet_create("p", "p", &wd) == kth_ec_success);
+    REQUIRE(kth_wallet_create_simple("p", "p", &wd) == kth_ec_success);
     KTH_EXPECT_ABORT(kth_wallet_wallet_data_set_encrypted_seed_unsafe(wd, NULL));
     kth_wallet_wallet_data_destruct(wd);
 }


### PR DESCRIPTION
## Summary

Re-enables the \`src/c-api\` subdir and tracks the migration of c-api
call sites from the legacy callback-based \`block_chain\` API to the
\`awaitable_expected<>\`-based one introduced by v1.0 (#151).

**Status: WIP.** This branch is intentionally non-building at HEAD; it
exists so the migration can land incrementally on top of \`version1\`
without holding up the v1.0 PR.

## Scope of the migration

| File | Call sites | Notes |
|------|-----------:|-------|
| \`src/c-api/src/chain/chain_async.cpp\` | 18 | callback → \`co_spawn\` |
| \`src/c-api/src/chain/chain_sync.cpp\` | 23 | callback-with-\`std::latch\` → \`asio::sync_wait\` |
| \`src/c-api/src/p2p/p2p.cpp\` | 4 | \`#include <kth/network/p2p.hpp>\` → \`p2p_node.hpp\` + API |
| \`src/c-api/src/node/settings.cpp\` | 1 | header rename |
| \`src/c-api/src/chain/chain_other.cpp\` | 1 | header rename |

## Why a separate PR

- \`#151\` already moves +36k/-18k LOC; loading the c-api port on top
  would balloon the surface another ~2k LOC.
- The c-api has a dedicated test binary (\`kth_capi_test\`) and a
  downstream Python consumer (\`py-native\`); the port deserves its
  own review and CI signal.
- This stack lets \`#151\` merge cleanly while the c-api work continues.

## Test plan
- [ ] Each call-site migration compiles
- [ ] \`kth_capi_test\` passes
- [ ] \`py-native\` regenerates and its tests pass