### PR TITLE
cleanup: resolve high-severity TODOs flagged in PR #151 audit

### DIFF
--- a/src/blockchain/src/pools/header_organizer.cpp
+++ b/src/blockchain/src/pools/header_organizer.cpp
@@ -43,16 +43,29 @@ bool header_organizer::stop() {
 // =============================================================================
 
 void header_organizer::sync_tip() {
-    // Sync tip from the header index (assumes index is already initialized)
+    // Tip = entry with maximum cumulative chain_work. The header_index
+    // now stores chain_work as uint256_t (computed from header bits via
+    // header_basis::proof), so this is the canonical Bitcoin tip even
+    // when forks coexist in the index. Tie-break on the lowest index_t,
+    // which corresponds to the entry that landed first.
     auto const size = index_.size();
-    if (size > 0) {
-        // For now, assume tip is the last added entry (index size - 1)
-        // TODO(fernando): properly track the actual chain tip when we support forks
-        tip_index_ = index_t(size - 1);
-        tip_hash_ = index_.get_hash(tip_index_);
-        spdlog::info("[header_organizer] Synced tip: index {}, hash {}",
-            tip_index_, encode_hash(tip_hash_));
+    if (size == 0) {
+        return;
     }
+
+    index_t best_idx = 0;
+    uint256_t best_work = index_.get_chain_work(best_idx);
+    for (index_t i = 1; i < index_t(size); ++i) {
+        auto const w = index_.get_chain_work(i);
+        if (w > best_work) {
+            best_work = w;
+            best_idx = i;
+        }
+    }
+    tip_index_ = best_idx;
+    tip_hash_ = index_.get_hash(tip_index_);
+    spdlog::info("[header_organizer] Synced tip: index {}, hash {}",
+        tip_index_, encode_hash(tip_hash_));
 }
 
 // =============================================================================

--- a/src/infrastructure/include/kth/infrastructure/utility/task_group.hpp
+++ b/src/infrastructure/include/kth/infrastructure/utility/task_group.hpp
@@ -7,9 +7,11 @@
 
 #include <atomic>
 #include <chrono>
-#include <cstddef>
 #include <concepts>
+#include <cstddef>
+#include <exception>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -119,7 +121,17 @@ public:
                     }
                 } catch (...) {
                     spdlog::debug("[task_group:{}] EXCEPTION: {}", state->name, name);
-                    // TODO: Store exception for later propagation
+                    // Stash the first exception so join() can rethrow it.
+                    // Subsequent exceptions are swallowed (logged above) — we
+                    // can only carry one exception out of join() and the
+                    // first one is the most useful for diagnosis. Exception
+                    // capture is a slow path; a mutex here is cheaper than
+                    // the cost of materializing the std::current_exception
+                    // we'd be throwing away on contention.
+                    std::lock_guard<std::mutex> lk(state->exception_mutex);
+                    if ( ! state->first_exception) {
+                        state->first_exception = std::current_exception();
+                    }
                 }
                 spdlog::debug("[task_group:{}] END: {} (active: {})", state->name, name, state->active_count.load() - 1);
                 state->decrement_and_signal();
@@ -146,6 +158,18 @@ public:
             }
             timer.expires_after(std::chrono::milliseconds(1));
             co_await timer.async_wait(::asio::use_awaitable);
+        }
+        // If any task threw, re-throw its exception now that everyone has
+        // wound down. We move it out of the slot first so a re-entrant
+        // join() on the same state doesn't re-fire the same exception.
+        std::exception_ptr ex;
+        {
+            std::lock_guard<std::mutex> lk(state_->exception_mutex);
+            ex = std::move(state_->first_exception);
+            state_->first_exception = nullptr;
+        }
+        if (ex) {
+            std::rethrow_exception(ex);
         }
         co_return;
     }
@@ -185,6 +209,13 @@ private:
         ::asio::any_io_executor executor;
         std::atomic<size_t> active_count{0};
         std::atomic<size_t> total_spawned{0};
+        // First exception thrown by any spawned task. join() re-throws it
+        // after all tasks complete so callers see the failure instead of
+        // it being silently swallowed in the detached coroutine.
+        // std::exception_ptr is not trivially copyable, so it lives behind
+        // a mutex rather than in a std::atomic.
+        std::mutex exception_mutex;
+        std::exception_ptr first_exception;
     };
 
     std::shared_ptr<shared_state> state_;

--- a/src/infrastructure/test/task_group.cpp
+++ b/src/infrastructure/test/task_group.cpp
@@ -195,7 +195,7 @@ TEST_CASE("task_group handles rapid task completion without deadlock", "[task_gr
     pool.join();
 }
 
-TEST_CASE("task_group exception in task still allows join to complete", "[task_group tests]") {
+TEST_CASE("task_group exception in task is propagated by join", "[task_group tests]") {
     threadpool pool("test", 2);
     auto executor = pool.get_executor();
 
@@ -220,12 +220,23 @@ TEST_CASE("task_group exception in task still allows join to complete", "[task_g
             task2_completed = true;
         });
 
-        co_await group.join();
+        bool rethrown = false;
+        std::string ex_what;
+        try {
+            co_await group.join();
+        } catch (std::exception const& ex) {
+            rethrown = true;
+            ex_what = ex.what();
+        }
 
-        // Both tasks should be considered "done" (one threw, one completed)
+        // join() must wait for every task (both flags set) AND rethrow the
+        // first exception so the caller can react instead of having it
+        // swallowed silently in the spawned coroutine.
         REQUIRE(task1_completed);
         REQUIRE(task2_completed);
         REQUIRE(group.active_count() == 0);
+        REQUIRE(rethrown);
+        REQUIRE(ex_what == "test exception");
 
         done.set_value();
     }, ::asio::detached);

--- a/src/node/src/sync/orchestrator.cpp
+++ b/src/node/src/sync/orchestrator.cpp
@@ -587,19 +587,8 @@ static
     uint32_t const checkpoint_height = uint32_t(chain.chain_settings().max_checkpoint_height);
     spdlog::info("[sync_orchestrator] Fast IBD mode up to checkpoint height {}", checkpoint_height);
 
-    // Check if we need to build UTXO set on startup
-    // UTXO build on startup — no longer needed, handled incrementally by block_storage_task.
-    // TODO(fernando): remove this block once incremental UTXO build is validated.
-    // if (initial_block_height >= checkpoint_height) {
-    //     auto utxo_height = chain.get_utxo_built_height();
-    //     uint32_t current_utxo_height = utxo_height.value_or(0);
-    //     if (current_utxo_height < checkpoint_height) {
-    //         auto utxo_result = co_await blockchain::build_utxo_set(
-    //             chain, network.thread_pool().get(), 1, checkpoint_height,
-    //             blockchain::utxo_build_strategy::sequential_batch);
-    //         if (utxo_result != database::result_code::success) { co_return; }
-    //     }
-    // }
+    // UTXO build now happens incrementally inside block_storage_task as
+    // each block lands; no startup-time bulk build is needed.
 
     all_tasks.spawn("block_validation_task", block_validation_task(
         chain,


### PR DESCRIPTION
Stacked on top of `version1`. Resolves the three orange-flagged TODOs
that came out of the PR #151 audit; targets the v1.0 integration branch
so it lands before the v1.0 merge to master.

## Changes

### `header_organizer::sync_tip()` — pick tip by chain_work
Previously assumed the tip was "the last added entry (index size - 1)".
With chain_work now stored as uint256_t (PR #151), the canonical tip is
the entry with maximum cumulative work. Tie-break on lowest index_t.
Removes the `properly track the actual chain tip when we support forks`
TODO.

### `orchestrator` — drop commented-out startup UTXO build
The block was already inert. Incremental UTXO build inside
`block_storage_task` is what runs in practice and the 3-server
validation past Leibniz (height 951'146) confirmed it.
Removes the `remove this block once incremental UTXO build is validated`
TODO and the dead lines under it.

### `task_group` — propagate first exception via `join()`
Before: a spawned task that threw had its exception swallowed in the
detached `co_spawn` site (only a debug log was emitted). Now the catch
stashes `std::current_exception()` behind a mutex (exception_ptr is not
trivially copyable so std::atomic doesn't fit), and `join()` re-throws
after every task has wound down. Existing test updated to assert the
propagation contract.

## Test plan
- [x] Local: domain 1,011,143 / blockchain 522 / infrastructure 104,445
      / network 1,459 / node 128 / c-api 2,807 — all pass
- [ ] CI green (await)