### PR TITLE
docs: announce v1.x on master and v0.x maintenance branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 
 > High-performance Bitcoin Cash development platform.
 
+> [!IMPORTANT]
+> **Branch model — June 2026 onwards**
+>
+> `master` now tracks the **v1.x** line: a coroutine-based node with
+> UTXO-Z storage, fast full IBD (mainnet from genesis to tip in under
+> an hour on typical hardware), and a public C++/C API rebuilt around
+> `asio::awaitable`. The first tag on this line is **v1.0.0**.
+>
+> The previous callback-based architecture lives on as a maintenance
+> branch: [**`v0.x`**](https://github.com/k-nuth/kth/tree/v0.x).
+> While v1.x stabilises in the field we keep `v0.x` shipping critical
+> bug fixes (consensus-class issues, security patches, build/dep
+> upgrades) so existing integrations have a safe place to stay. New
+> features land on `master` only.
+>
+> If you're an existing consumer of the C-API or any language binding,
+> see the **Breaking changes** section of the v1.0.0 release notes
+> before upgrading — `block_chain` async methods are now
+> `awaitable_expected<T>`, `p2p::close()` is replaced by
+> `stop()` + `join()`, and a few legacy types were removed.
+
 Knuth is a high-performance implementation of the Bitcoin protocol aimed at users that need extra performance and flexibility — wallets, exchanges, block explorers and miners.
 
 ## Not just a node


### PR DESCRIPTION
Adds a prominent **branch model** banner at the top of the README so
new contributors / consumers landing on the repo know:

- \`master\` is now the **v1.x** line (coroutines, UTXO-Z, fast full IBD,
  awaitable-based public APIs). First tag is **v1.0.0**.
- The previous callback-based architecture stays alive on the
  [\`v0.x\`](https://github.com/k-nuth/kth/tree/v0.x) maintenance
  branch while v1.x stabilises in the field. Only critical fixes
  (consensus, security, build/dep upgrades) land there.
- Existing C-API / language-binding consumers should read the v1.0.0
  release notes' **Breaking changes** section before upgrading.

Docs-only change. No code touched.