### PR TITLE
chore(conan): default embed_utxo_bloom to False

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -124,7 +124,7 @@ class KthRecipe(KnuthConanFileV2):
         # For now, keep disabled until a proper solution is implemented.
         "with_jemalloc": False,
         "with_stats": False,
-        "embed_utxo_bloom": True,
+        "embed_utxo_bloom": False,
         "utxoz_compact": False,
         "asio_standalone": True,
 


### PR DESCRIPTION
## Summary

Workaround for #366 — flip the default for the `embed_utxo_bloom` Conan option from `True` to `False` so new installs reach the mainnet tip via plain headers-then-blocks sync. The option itself stays; users that want the embedded bloom can opt in with `-o "&:embed_utxo_bloom=True"` once #366 is fixed.

See #366 for the full diagnosis (single-locator `getheaders` against a bloom-derived tip → peers reply from genesis → stale-batch detection → peer ban → IBD stalls).

## Test plan

- [x] Build (`conan install`) with the default → linker no longer pulls `data/utxo_bloom.dat`; binary smaller; node starts with empty header_index from genesis.
- [ ] IBD experiment on athens/rome/troy reaches mainnet tip (in progress).