### PR TITLE
ci: bump pinned action versions (pass 1 of #367)

### DIFF
--- a/.github/workflows/build-deps-with-container.yml
+++ b/.github/workflows/build-deps-with-container.yml
@@ -44,12 +44,12 @@ jobs:
 
 
       - name: 📥 Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: true
 
       # - if: ${{ inputs.reference != 'null' && inputs.compiler != 'GCC' }}
-      #   uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      #   uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       #   with:
       #     python-version: '3.11'
       - name: 🔧 Setup Conan
@@ -63,7 +63,7 @@ jobs:
         run: conan remote login -p ${{ secrets.conan-password }} ${{ inputs.conan-remote }} ${{ secrets.conan-user }}
       - name: 📥 Download artifact
         if: ${{ inputs.reference != 'null' }}
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: conan-lockfile-container
       - name: 🏗️ Build dependencies

--- a/.github/workflows/build-deps-without-container.yml
+++ b/.github/workflows/build-deps-without-container.yml
@@ -52,13 +52,13 @@ jobs:
 
 
       - name: 📥 Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: true
 
       - name: 🐍 Setup Python
         if: ${{ inputs.reference != 'null' && inputs.compiler != 'GCC' }}
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
 
@@ -73,7 +73,7 @@ jobs:
         run: conan remote login -p ${{ secrets.conan-password }} ${{ inputs.conan-remote }} ${{ secrets.conan-user }}
       - name: 📥 Download artifact
         if: ${{ inputs.reference != 'null' }}
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: conan-lockfile-no-container
       - name: 🏗️ Build dependencies

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -32,7 +32,7 @@ jobs:
     outputs:
       build-version: ${{ steps.version.outputs.build-version }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: true
           fetch-depth: 0
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: true
 
@@ -65,7 +65,7 @@ jobs:
           new-version: ${{ needs.setup.outputs.build-version }}
 
       - name: 🐍 Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
 

--- a/.github/workflows/build-with-container.yml
+++ b/.github/workflows/build-with-container.yml
@@ -81,7 +81,7 @@ jobs:
 
 
       - name: 📥 Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: true
 
@@ -103,7 +103,7 @@ jobs:
 
 
       # - if: ${{ inputs.compiler != 'GCC' }}
-      #   uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      #   uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       #   with:
       #     python-version: '3.11'
 

--- a/.github/workflows/build-without-container.yml
+++ b/.github/workflows/build-without-container.yml
@@ -76,7 +76,7 @@ jobs:
       # ----------------------------------------------------------------
 
       - name: 📥 Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: true
 
@@ -93,7 +93,7 @@ jobs:
 
       # - if: ${{ inputs.compiler != 'GCC' }}
       - name: 🐍 Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
 
@@ -332,7 +332,7 @@ jobs:
       # next time hits stay low. Cheap when ccache.log doesn't exist.
       - name: 📤 Upload ccache log
         if: ${{ always() && inputs.upload != true }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         continue-on-error: true
         with:
           name: ccache-log-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}

--- a/.github/workflows/calc-deps-with-container.yml
+++ b/.github/workflows/calc-deps-with-container.yml
@@ -36,7 +36,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: true
 
@@ -48,7 +48,7 @@ jobs:
 
 
       # - if: ${{ inputs.compiler != 'GCC' }}
-      #   uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      #   uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       #   with:
       #     python-version: '3.11'
 
@@ -76,7 +76,7 @@ jobs:
           # conan graph build-order conanfile.py --lockfile=build/conan.lock -f json --order-by configuration --build=missing --reduce > build_order.json
 
       - name: 📦 Upload lockfile artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: conan-lockfile-container
           path: build/conan.lock

--- a/.github/workflows/calc-deps-without-container.yml
+++ b/.github/workflows/calc-deps-without-container.yml
@@ -32,7 +32,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: true
 
@@ -44,7 +44,7 @@ jobs:
 
       # - if: ${{ inputs.compiler != 'GCC' }}
       - name: 🐍 Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
 
@@ -74,7 +74,7 @@ jobs:
 
 
       - name: 📦 Upload lockfile artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: conan-lockfile-no-container
           path: build/conan.lock

--- a/.github/workflows/check-conan-updates.yml
+++ b/.github/workflows/check-conan-updates.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
 
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload report as artifact
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: conan-update-report
           path: update_report.txt

--- a/.github/workflows/cosmetic-changes.yml
+++ b/.github/workflows/cosmetic-changes.yml
@@ -26,7 +26,7 @@ jobs:
     
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: true
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,7 +95,7 @@ jobs:
       build-version: ${{ steps.version.outputs.build-version }}
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: true
           fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags
@@ -160,7 +160,7 @@ jobs:
   #     # name: docker.pkg.github.com/${{ github.repository }}/alpine-image
   #     name: docker.pkg.github.com/k-nuth/kth/alpine-image
   #   steps:
-  #     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+  #     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
   #       with:
   #         submodules: true
   #     - id: version
@@ -200,7 +200,7 @@ jobs:
           echo "Head ref: ${{ github.head_ref }}"
           echo "Base ref: ${{ github.base_ref }}"
       - name: 📥 Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: true
       - name: 🧮 Generate Job Matrix
@@ -415,7 +415,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: true
 

--- a/ci_utils/.github/workflows/build-deps-with-container.yml
+++ b/ci_utils/.github/workflows/build-deps-with-container.yml
@@ -38,12 +38,12 @@ jobs:
           echo "inputs.reference: ${{ inputs.reference }}"
 
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: true
 
       # - if: ${{ inputs.reference != 'null' && inputs.compiler != 'GCC' }}
-      #   uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      #   uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       #   with:
       #     python-version: '3.11'
       - if: ${{ inputs.reference != 'null' }}
@@ -54,7 +54,7 @@ jobs:
         run: conan remote login -p ${{ secrets.conan-password }} ${{ inputs.conan-remote }} ${{ secrets.conan-user }}
       - name: download
         if: ${{ inputs.reference != 'null' }}
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: conan-lockfile-container
       - name: build

--- a/ci_utils/.github/workflows/build-deps-without-container.yml
+++ b/ci_utils/.github/workflows/build-deps-without-container.yml
@@ -46,12 +46,12 @@ jobs:
           # # python3 -m pip install kthbuild --upgrade
 
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: true
 
       - if: ${{ inputs.reference != 'null' && inputs.compiler != 'GCC' }}
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
 
@@ -63,7 +63,7 @@ jobs:
         run: conan remote login -p ${{ secrets.conan-password }} ${{ inputs.conan-remote }} ${{ secrets.conan-user }}
       - name: download
         if: ${{ inputs.reference != 'null' }}
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: conan-lockfile-no-container
       - name: build

--- a/ci_utils/.github/workflows/build-with-container.yml
+++ b/ci_utils/.github/workflows/build-with-container.yml
@@ -62,7 +62,7 @@ jobs:
           # echo "github.event_name:         ${{ github.event_name }}"
 
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: true
 
@@ -77,7 +77,7 @@ jobs:
 
 
       # - if: ${{ inputs.compiler != 'GCC' }}
-      #   uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      #   uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       #   with:
       #     python-version: '3.11'
 

--- a/ci_utils/.github/workflows/build-without-container.yml
+++ b/ci_utils/.github/workflows/build-without-container.yml
@@ -57,7 +57,7 @@ jobs:
 
       # ----------------------------------------------------------------
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: true
 
@@ -72,7 +72,7 @@ jobs:
 
 
       # - if: ${{ inputs.compiler != 'GCC' }}
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
 

--- a/ci_utils/.github/workflows/calc-deps-with-container.yml
+++ b/ci_utils/.github/workflows/calc-deps-with-container.yml
@@ -35,7 +35,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: true
 
@@ -46,7 +46,7 @@ jobs:
 
 
       # - if: ${{ inputs.compiler != 'GCC' }}
-      #   uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      #   uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       #   with:
       #     python-version: '3.11'
 
@@ -69,7 +69,7 @@ jobs:
           # Conan 2.7 build order configuration
           # conan graph build-order conanfile.py --lockfile=build/conan.lock -f json --order-by configuration --build=missing --reduce > build_order.json
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: conan-lockfile-container
           path: build/conan.lock

--- a/ci_utils/.github/workflows/calc-deps-without-container.yml
+++ b/ci_utils/.github/workflows/calc-deps-without-container.yml
@@ -31,7 +31,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: true
 
@@ -41,7 +41,7 @@ jobs:
           key: alpine-conan2-${{ hashFiles('**/conan.lock') }}
 
       # - if: ${{ inputs.compiler != 'GCC' }}
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
 
@@ -65,7 +65,7 @@ jobs:
 
 
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: conan-lockfile-no-container
           path: build/conan.lock


### PR DESCRIPTION
First of three CI maintenance passes from #367.

Bumps the four heavily-used third-party actions to current upstream majors:

| Action | Old | New |
|---|---|---|
| \`actions/checkout\` | v4.3.1 | **v7.0.0** |
| \`actions/upload-artifact\` | v4.6.2 | **v7.0.1** |
| \`actions/download-artifact\` | v4.3.0 | **v8.0.1** |
| \`actions/setup-python\` | v5.6.0 | **v6.2.0** |

SHAs and version comments updated together so the supply-chain pinning is preserved. \`actions/cache\` is already on its current major (v5.0.5) so it's left alone.

Pass 2 (runner images / container images) and pass 3 (compilers) are tracked separately.