### PR TITLE
feat(ci): publish node Docker image to GHCR on release

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,20 @@
+name: Docker image
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: kth version to build (e.g. v1.0.0)
+        required: true
+        type: string
+
+jobs:
+  node-image:
+    permissions:
+      contents: read
+      packages: write
+    uses: k-nuth/docker-images/.github/workflows/build-node.yml@master
+    with:
+      version: ${{ github.event.release.tag_name || inputs.version }}


### PR DESCRIPTION
## Publish the node Docker image on release

Adds `.github/workflows/docker-release.yml`: on every published release it calls the reusable
`build-node` workflow in `k-nuth/docker-images`, which builds and pushes
`ghcr.io/k-nuth/kth:<tag>` and `:latest`. So tagging a release is all that's needed — the
image appears under this repo's Packages automatically.

- Authenticates with the built-in `GITHUB_TOKEN` (`packages: write`).
- `workflow_dispatch` is included to (re)build a specific version on demand.

**Order:** this depends on the companion PR that adds `build-node.yml` to
`k-nuth/docker-images` — please merge that one first. After it's in, this can be tried
immediately via the Actions tab (workflow_dispatch) without cutting a release.
