### PR TITLE
ci: bump Linux toolchain to GCC 16

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,7 +40,7 @@ jobs:
     # GHA default.
     timeout-minutes: 130
     container:
-      image: kthnode/gcc15-ubuntu24.04
+      image: kthnode/gcc16-ubuntu24.04
 
     steps:
       - name: 📥 Checkout

--- a/ci_utils/.conan/profiles/general-ci-cd
+++ b/ci_utils/.conan/profiles/general-ci-cd
@@ -9,3 +9,9 @@ compiler.cppstd=23
 # where the consumer conanfile's options aren't applied. kth doesn't
 # use cobalt.
 boost/*:without_cobalt=True
+# stacktrace_backtrace expects an external libbacktrace at build time;
+# the GCC 16 toolchain image bundles libbacktrace inside GCC rather
+# than via apt's libbacktrace-dev, so boost's auto-detection skips the
+# component and package_info() then raises "expected to be built".
+# kth doesn't use boost.stacktrace.
+boost/*:without_stacktrace_backtrace=True

--- a/ci_utils/.conan/profiles/linux-ci-cd
+++ b/ci_utils/.conan/profiles/linux-ci-cd
@@ -15,3 +15,9 @@ compiler.cppstd=23
 # where the consumer conanfile's options aren't applied. kth doesn't
 # use cobalt.
 boost/*:without_cobalt=True
+# stacktrace_backtrace expects an external libbacktrace at build time;
+# the GCC 16 toolchain image bundles libbacktrace inside GCC rather
+# than via apt's libbacktrace-dev, so boost's auto-detection skips the
+# component and package_info() then raises "expected to be built".
+# kth doesn't use boost.stacktrace.
+boost/*:without_stacktrace_backtrace=True

--- a/ci_utils/.github/matrix.json
+++ b/ci_utils/.github/matrix.json
@@ -1,1 +1,1 @@
-{"config": [{"name": "Linux x86_64 GCC 15","compiler": "GCC","version": "15","os": "ubuntu-24.04","docker_suffix": "-ubuntu24.04"},{"name": "macOS - arm64 - apple-clang 17","compiler": "apple-clang","version": "17","os": "macos-15"}]}
+{"config": [{"name": "Linux x86_64 GCC 16","compiler": "GCC","version": "16","os": "ubuntu-24.04","docker_suffix": "-ubuntu24.04"},{"name": "macOS - arm64 - apple-clang 17","compiler": "apple-clang","version": "17","os": "macos-15"}]}


### PR DESCRIPTION
Third (and last) of the CI bumps from #367.

Now that the \`kthnode/gcc16-ubuntu24.04\` image is published from \`k-nuth/docker-images\` PR #1, switch the Linux build matrix to use it.

- \`ci_utils/.github/matrix.json\`: name \"Linux x86_64 GCC 15\" → \"16\" and \`version\` field \`\"15\"\` → \`\"16\"\`. The image is composed at workflow time from \`kthnode/gcc\${version}\${docker_suffix}\`, so the version field is what drives the image pull.
- \`.github/workflows/coverage.yml\`: the only workflow that hard-codes the image name rather than going through the matrix. Updated in step.

macOS apple-clang 17 stays as-is. The conan profile doesn't pin \`compiler.version\` (commented out), so it picks up whatever the image provides.