### PR TITLE
ci: pin runners to specific versions + bump macOS to apple-clang 21

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -28,7 +28,7 @@ jobs:
        !startsWith(github.head_ref, 'style/') &&
        !startsWith(github.head_ref, 'chore/') &&
        !startsWith(github.head_ref, 'noci/'))
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       build-version: ${{ steps.version.outputs.build-version }}
     steps:
@@ -50,7 +50,7 @@ jobs:
        !startsWith(github.head_ref, 'release/') &&
        !startsWith(github.head_ref, 'hotfix/') &&
        !startsWith(github.head_ref, 'dev-publish/'))
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: WebAssembly (Emscripten)
 
     steps:

--- a/.github/workflows/check-conan-updates.yml
+++ b/.github/workflows/check-conan-updates.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   check-updates:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/cosmetic-changes.yml
+++ b/.github/workflows/cosmetic-changes.yml
@@ -22,7 +22,7 @@ jobs:
         startsWith(github.head_ref, 'style/') || 
         startsWith(github.head_ref, 'chore/') || 
         startsWith(github.head_ref, 'noci/')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     
     steps:
       - name: 📥 Checkout code
@@ -114,7 +114,7 @@ jobs:
     if: startsWith(github.head_ref, 'docs/') || 
         startsWith(github.head_ref, 'style/') ||
         startsWith(github.head_ref, 'chore/')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: cosmetic-check
     
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # Advisory job: a failure here doesn't block the PR's required
     # checks. The hosted runner (7 GB) consistently OOMs on
     # instrumented builds for this project's current TU count —

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ env:
 
 jobs:
   debug:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       permitted: ${{ steps.check.outputs.permitted }}
     steps:
@@ -65,7 +65,7 @@ jobs:
        !startsWith(github.head_ref, 'style/') &&
        !startsWith(github.head_ref, 'chore/') &&
        !startsWith(github.head_ref, 'noci/'))
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       permitted: ${{ steps.check.outputs.permitted }}
     steps:
@@ -90,7 +90,7 @@ jobs:
        !startsWith(github.head_ref, 'style/') &&
        !startsWith(github.head_ref, 'chore/') &&
        !startsWith(github.head_ref, 'noci/'))
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       build-version: ${{ steps.version.outputs.build-version }}
     steps:
@@ -152,7 +152,7 @@ jobs:
 
   # build-base-docker-image:
   #   name: Builds Alpine Docker image
-  #   runs-on: ubuntu-latest
+  #   runs-on: ubuntu-24.04
   #   outputs:
   #     # name: docker.pkg.github.com/${{ github.repository }}/alpine-image:${{ steps.version.outputs.version }}
   #     name: docker.pkg.github.com/k-nuth/kth/alpine-image:${{ steps.version.outputs.version }}
@@ -189,7 +189,7 @@ jobs:
        !startsWith(github.head_ref, 'chore/') &&
        !startsWith(github.head_ref, 'noci/'))
     name: Generate Job Matrix
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -412,7 +412,7 @@ jobs:
        !startsWith(github.head_ref, 'chore/') &&
        !startsWith(github.head_ref, 'noci/'))
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 📥 Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/ci_utils/.github/matrix.json
+++ b/ci_utils/.github/matrix.json
@@ -1,1 +1,1 @@
-{"config": [{"name": "Linux x86_64 GCC 16","compiler": "GCC","version": "16","os": "ubuntu-24.04","docker_suffix": "-ubuntu24.04"},{"name": "macOS - arm64 - apple-clang 17","compiler": "apple-clang","version": "17","os": "macos-15"}]}
+{"config": [{"name": "Linux x86_64 GCC 16","compiler": "GCC","version": "16","os": "ubuntu-24.04","docker_suffix": "-ubuntu24.04"},{"name": "macOS - arm64 - apple-clang 21","compiler": "apple-clang","version": "21","os": "macos-26"}]}


### PR DESCRIPTION
Stacks on #379. Two cleanups in one pass on the GitHub Actions runner side:

## Pin Ubuntu runners to a specific LTS
\`ubuntu-latest\` currently resolves to \`ubuntu-24.04\` but rolls forward whenever GitHub flips the alias (next move: \`ubuntu-26.04\`, already in preview). Pinning to \`ubuntu-24.04\` means CI behaviour doesn't change under us mid-day; we bump deliberately. Same for the two jobs still on \`ubuntu-22.04\` — bring them in line.

## Bump macOS to apple-clang 21 / macos-26
- \`macos-15\` is still supported but \`macos-26\` (Tahoe) is the current LTS
- \`macos-26\` only ships Xcode 26.x → apple-clang 21 (LLVM 21)
- Four-LLVM-major jump from apple-clang 17
- Conan 2.27+ recognises \`apple-clang=21\` natively, no settings.yml patch

## Risks (calling them out)
- ConanCenter may not have prebuilts for apple-clang 21 on every dep; existing \`--build=missing\` rebuilds from source on first run (~20 min extra), cached after
- apple-clang 21 enables more default warnings; a clean-build run might surface them

The \`matrix-macos-x64.json\` and \`matrix-windows.json\` files in the same directory aren't referenced by any workflow — left untouched to keep PR scope tight.

Closes pass 2 of #367 (runner images) and is the macOS half of pass 3 (compilers).