### PR TITLE
refactor(domain): functional / valid-by-construction simplifications

### DIFF
--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -362,7 +362,7 @@ struct KB_API block_chain {
     fetch_block_locator(domain::chain::block::indexes const& heights) const;
 
     // Server queries
-    [[nodiscard]] awaitable_expected<domain::chain::input_point>
+    [[nodiscard]] awaitable_expected<domain::chain::input_point_opt>
     fetch_spend(domain::chain::output_point const& outpoint) const;
 
     [[nodiscard]] awaitable_expected<domain::chain::history_compact::list>

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -1375,7 +1375,7 @@ block_chain::fetch_block_locator(block::indexes const& heights) const {
     co_return message;
 }
 
-awaitable_expected<domain::chain::input_point>
+awaitable_expected<domain::chain::input_point_opt>
 block_chain::fetch_spend(domain::chain::output_point const& outpoint) const {
     if (stopped()) {
         co_return std::unexpected(error::service_stopped);
@@ -1391,7 +1391,7 @@ block_chain::fetch_spend(domain::chain::output_point const& outpoint) const {
         co_return std::unexpected(error::not_found);
     }
 
-    co_return *point;
+    co_return domain::chain::input_point_opt{*point};
 }
 
 awaitable_expected<domain::chain::history_compact::list>

--- a/src/c-api/include/kth/capi/chain/double_spend_proof.h
+++ b/src/c-api/include/kth/capi/chain/double_spend_proof.h
@@ -96,18 +96,6 @@ void kth_chain_double_spend_proof_set_spender1(kth_double_spend_proof_mut_t self
 KTH_EXPORT
 void kth_chain_double_spend_proof_set_spender2(kth_double_spend_proof_mut_t self, kth_double_spend_proof_spender_const_t x);
 
-
-// Predicates
-
-KTH_EXPORT
-kth_bool_t kth_chain_double_spend_proof_is_valid(kth_double_spend_proof_const_t self);
-
-
-// Operations
-
-KTH_EXPORT
-void kth_chain_double_spend_proof_reset(kth_double_spend_proof_mut_t self);
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/c-api/include/kth/capi/chain/input.h
+++ b/src/c-api/include/kth/capi/chain/input.h
@@ -16,10 +16,6 @@ extern "C" {
 
 // Constructors
 
-/** @return Owned `kth_input_mut_t`. Caller must release with `kth_chain_input_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_input_mut_t kth_chain_input_construct_default(void);
-
 /** @param[out] out Must point to a null `kth_input_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_input_destruct`. Untouched on error. */
 KTH_EXPORT
 kth_error_code_t kth_chain_input_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_input_mut_t* out);
@@ -106,9 +102,6 @@ void kth_chain_input_set_sequence(kth_input_mut_t self, uint32_t value);
 // Predicates
 
 KTH_EXPORT
-kth_bool_t kth_chain_input_is_valid(kth_input_const_t self);
-
-KTH_EXPORT
 kth_bool_t kth_chain_input_is_final(kth_input_const_t self);
 
 KTH_EXPORT
@@ -119,9 +112,6 @@ kth_bool_t kth_chain_input_is_locked(kth_input_const_t self, kth_size_t block_he
 
 KTH_EXPORT
 kth_size_t kth_chain_input_signature_operations(kth_input_const_t self, kth_bool_t bip16, kth_bool_t bip141);
-
-KTH_EXPORT
-void kth_chain_input_reset(kth_input_mut_t self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/include/kth/capi/chain/input_point.h
+++ b/src/c-api/include/kth/capi/chain/input_point.h
@@ -16,10 +16,6 @@ extern "C" {
 
 // Constructors
 
-/** @return Owned `kth_input_point_mut_t`. Caller must release with `kth_chain_input_point_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_input_point_mut_t kth_chain_input_point_construct_default(void);
-
 /** @param[out] out Must point to a null `kth_input_point_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_input_point_destruct`. Untouched on error. */
 KTH_EXPORT
 kth_error_code_t kth_chain_input_point_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_input_point_mut_t* out);
@@ -105,16 +101,7 @@ void kth_chain_input_point_set_index(kth_input_point_mut_t self, uint32_t value)
 // Predicates
 
 KTH_EXPORT
-kth_bool_t kth_chain_input_point_is_valid(kth_input_point_const_t self);
-
-KTH_EXPORT
 kth_bool_t kth_chain_input_point_is_null(kth_input_point_const_t self);
-
-
-// Operations
-
-KTH_EXPORT
-void kth_chain_input_point_reset(kth_input_point_mut_t self);
 
 
 // Static utilities

--- a/src/c-api/include/kth/capi/chain/output_point.h
+++ b/src/c-api/include/kth/capi/chain/output_point.h
@@ -115,16 +115,7 @@ KTH_EXPORT
 kth_bool_t kth_chain_output_point_is_mature(kth_output_point_const_t self, kth_size_t height);
 
 KTH_EXPORT
-kth_bool_t kth_chain_output_point_is_valid(kth_output_point_const_t self);
-
-KTH_EXPORT
 kth_bool_t kth_chain_output_point_is_null(kth_output_point_const_t self);
-
-
-// Operations
-
-KTH_EXPORT
-void kth_chain_output_point_reset(kth_output_point_mut_t self);
 
 
 // Static utilities

--- a/src/c-api/include/kth/capi/chain/point.h
+++ b/src/c-api/include/kth/capi/chain/point.h
@@ -16,10 +16,6 @@ extern "C" {
 
 // Constructors
 
-/** @return Owned `kth_point_mut_t`. Caller must release with `kth_chain_point_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_point_mut_t kth_chain_point_construct_default(void);
-
 /** @param[out] out Must point to a null `kth_point_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_point_destruct`. Untouched on error. */
 KTH_EXPORT
 kth_error_code_t kth_chain_point_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_point_mut_t* out);
@@ -105,16 +101,7 @@ void kth_chain_point_set_index(kth_point_mut_t self, uint32_t value);
 // Predicates
 
 KTH_EXPORT
-kth_bool_t kth_chain_point_is_valid(kth_point_const_t self);
-
-KTH_EXPORT
 kth_bool_t kth_chain_point_is_null(kth_point_const_t self);
-
-
-// Operations
-
-KTH_EXPORT
-void kth_chain_point_reset(kth_point_mut_t self);
 
 
 // Static utilities

--- a/src/c-api/src/chain/chain_async.cpp
+++ b/src/c-api/src/chain/chain_async.cpp
@@ -247,7 +247,7 @@ void kth_chain_async_spend(kth_chain_t chain, void* ctx, kth_output_point_const_
     ::asio::co_spawn(bc.executor(), [&bc, outpoint_cpp, chain, ctx, handler]() -> ::asio::awaitable<void> {
         auto result = co_await bc.fetch_spend(*outpoint_cpp);
         if (result) {
-            handler(chain, ctx, kth::to_c_err(std::error_code{}), kth::leak_if_success(*result, std::error_code{}));
+            handler(chain, ctx, kth::to_c_err(std::error_code{}), kth::leak_if_success(**result, std::error_code{}));
         } else {
             handler(chain, ctx, kth::to_c_err(result.error()), nullptr);
         }

--- a/src/c-api/src/chain/chain_sync.cpp
+++ b/src/c-api/src/chain/chain_sync.cpp
@@ -277,7 +277,7 @@ kth_error_code_t kth_chain_sync_spend(kth_chain_t chain, kth_output_point_const_
     auto const* outpoint_cpp = static_cast<kth::domain::chain::output_point const*>(op);
     auto result = sync_wait(bc, bc.fetch_spend(*outpoint_cpp));
     if (result) {
-        *out_input_point = kth::leak_if_success(*result, std::error_code{});
+        *out_input_point = kth::leak_if_success(**result, std::error_code{});
         return kth::to_c_err(std::error_code{});
     }
     *out_input_point = nullptr;

--- a/src/c-api/src/chain/double_spend_proof.cpp
+++ b/src/c-api/src/chain/double_spend_proof.cpp
@@ -133,20 +133,4 @@ void kth_chain_double_spend_proof_set_spender2(kth_double_spend_proof_mut_t self
     kth::cpp_ref<cpp_t>(self).set_spender2(x_cpp);
 }
 
-
-// Predicates
-
-kth_bool_t kth_chain_double_spend_proof_is_valid(kth_double_spend_proof_const_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_valid());
-}
-
-
-// Operations
-
-void kth_chain_double_spend_proof_reset(kth_double_spend_proof_mut_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<cpp_t>(self).reset();
-}
-
 } // extern "C"

--- a/src/c-api/src/chain/input.cpp
+++ b/src/c-api/src/chain/input.cpp
@@ -22,10 +22,6 @@ extern "C" {
 
 // Constructors
 
-kth_input_mut_t kth_chain_input_construct_default(void) {
-    return kth::leak<cpp_t>();
-}
-
 kth_error_code_t kth_chain_input_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_input_mut_t* out) {
     KTH_PRECONDITION(data != nullptr || n == 0);
     KTH_PRECONDITION(out != nullptr);
@@ -150,11 +146,6 @@ void kth_chain_input_set_sequence(kth_input_mut_t self, uint32_t value) {
 
 // Predicates
 
-kth_bool_t kth_chain_input_is_valid(kth_input_const_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_valid());
-}
-
 kth_bool_t kth_chain_input_is_final(kth_input_const_t self) {
     KTH_PRECONDITION(self != nullptr);
     return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_final());
@@ -174,11 +165,6 @@ kth_size_t kth_chain_input_signature_operations(kth_input_const_t self, kth_bool
     auto const bip16_cpp = kth::int_to_bool(bip16);
     auto const bip141_cpp = kth::int_to_bool(bip141);
     return kth::cpp_ref<cpp_t>(self).signature_operations(bip16_cpp, bip141_cpp);
-}
-
-void kth_chain_input_reset(kth_input_mut_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<cpp_t>(self).reset();
 }
 
 } // extern "C"

--- a/src/c-api/src/chain/input_point.cpp
+++ b/src/c-api/src/chain/input_point.cpp
@@ -22,10 +22,6 @@ extern "C" {
 
 // Constructors
 
-kth_input_point_mut_t kth_chain_input_point_construct_default(void) {
-    return kth::leak<cpp_t>();
-}
-
 kth_error_code_t kth_chain_input_point_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_input_point_mut_t* out) {
     KTH_PRECONDITION(data != nullptr || n == 0);
     KTH_PRECONDITION(out != nullptr);
@@ -141,22 +137,9 @@ void kth_chain_input_point_set_index(kth_input_point_mut_t self, uint32_t value)
 
 // Predicates
 
-kth_bool_t kth_chain_input_point_is_valid(kth_input_point_const_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_valid());
-}
-
 kth_bool_t kth_chain_input_point_is_null(kth_input_point_const_t self) {
     KTH_PRECONDITION(self != nullptr);
     return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_null());
-}
-
-
-// Operations
-
-void kth_chain_input_point_reset(kth_input_point_mut_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<cpp_t>(self).reset();
 }
 
 

--- a/src/c-api/src/chain/output_point.cpp
+++ b/src/c-api/src/chain/output_point.cpp
@@ -153,22 +153,9 @@ kth_bool_t kth_chain_output_point_is_mature(kth_output_point_const_t self, kth_s
     return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_mature(height_cpp));
 }
 
-kth_bool_t kth_chain_output_point_is_valid(kth_output_point_const_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_valid());
-}
-
 kth_bool_t kth_chain_output_point_is_null(kth_output_point_const_t self) {
     KTH_PRECONDITION(self != nullptr);
     return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_null());
-}
-
-
-// Operations
-
-void kth_chain_output_point_reset(kth_output_point_mut_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<cpp_t>(self).reset();
 }
 
 

--- a/src/c-api/src/chain/point.cpp
+++ b/src/c-api/src/chain/point.cpp
@@ -22,10 +22,6 @@ extern "C" {
 
 // Constructors
 
-kth_point_mut_t kth_chain_point_construct_default(void) {
-    return kth::leak<cpp_t>();
-}
-
 kth_error_code_t kth_chain_point_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_point_mut_t* out) {
     KTH_PRECONDITION(data != nullptr || n == 0);
     KTH_PRECONDITION(out != nullptr);
@@ -141,22 +137,9 @@ void kth_chain_point_set_index(kth_point_mut_t self, uint32_t value) {
 
 // Predicates
 
-kth_bool_t kth_chain_point_is_valid(kth_point_const_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_valid());
-}
-
 kth_bool_t kth_chain_point_is_null(kth_point_const_t self) {
     KTH_PRECONDITION(self != nullptr);
     return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_null());
-}
-
-
-// Operations
-
-void kth_chain_point_reset(kth_point_mut_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<cpp_t>(self).reset();
 }
 
 

--- a/src/c-api/test/chain/input_point.cpp
+++ b/src/c-api/test/chain/input_point.cpp
@@ -48,15 +48,14 @@ TEST_CASE("C-API InputPoint - destruct frees an allocated handle", "[C-API Input
 // Smoke coverage of the alias-prefixed surface.
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API InputPoint - default construct is invalid", "[C-API InputPoint]") {
-    kth_input_point_mut_t ip = kth_chain_input_point_construct_default();
-    REQUIRE(kth_chain_input_point_is_valid(ip) == 0);
+TEST_CASE("C-API InputPoint - null factory yields coinbase sentinel", "[C-API InputPoint]") {
+    kth_input_point_mut_t ip = kth_chain_input_point_null();
+    REQUIRE(kth_chain_input_point_is_null(ip) != 0);
     kth_chain_input_point_destruct(ip);
 }
 
 TEST_CASE("C-API InputPoint - field constructor preserves hash and index", "[C-API InputPoint]") {
     kth_input_point_mut_t ip = kth_chain_input_point_construct(&kHash, 1234u);
-    REQUIRE(kth_chain_input_point_is_valid(ip) != 0);
     REQUIRE(kth_chain_input_point_index(ip) == 1234u);
     REQUIRE(kth_hash_equal(kth_chain_input_point_hash(ip), kHash) != 0);
     kth_chain_input_point_destruct(ip);

--- a/src/c-api/test/chain/point.cpp
+++ b/src/c-api/test/chain/point.cpp
@@ -41,15 +41,14 @@ static kth_hash_t const kAllOnes = {{
 // Constructors
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API Point - default construct is invalid", "[C-API Point]") {
-    kth_point_mut_t point = kth_chain_point_construct_default();
-    REQUIRE(kth_chain_point_is_valid(point) == 0);
+TEST_CASE("C-API Point - null factory yields coinbase sentinel", "[C-API Point]") {
+    kth_point_mut_t point = kth_chain_point_null();
+    REQUIRE(kth_chain_point_is_null(point) != 0);
     kth_chain_point_destruct(point);
 }
 
 TEST_CASE("C-API Point - field constructor preserves hash and index", "[C-API Point]") {
     kth_point_mut_t point = kth_chain_point_construct(&kHash, 1234u);
-    REQUIRE(kth_chain_point_is_valid(point) != 0);
     REQUIRE(kth_chain_point_index(point) == 1234u);
     REQUIRE(kth_hash_equal(kth_chain_point_hash(point), kHash) != 0);
     kth_chain_point_destruct(point);
@@ -81,7 +80,6 @@ TEST_CASE("C-API Point - to_data / from_data roundtrip", "[C-API Point]") {
     REQUIRE(ec == kth_ec_success);
     REQUIRE(parsed != NULL);
 
-    REQUIRE(kth_chain_point_is_valid(parsed) != 0);
     REQUIRE(kth_chain_point_equals(expected, parsed) != 0);
     REQUIRE(kth_chain_point_index(parsed) == 53213u);
     REQUIRE(kth_hash_equal(kth_chain_point_hash(parsed), kHash) != 0);
@@ -96,7 +94,7 @@ TEST_CASE("C-API Point - to_data / from_data roundtrip", "[C-API Point]") {
 // ---------------------------------------------------------------------------
 
 TEST_CASE("C-API Point - hash setter roundtrip", "[C-API Point]") {
-    kth_point_mut_t point = kth_chain_point_construct_default();
+    kth_point_mut_t point = kth_chain_point_null();
     REQUIRE(kth_hash_is_null(kth_chain_point_hash(point)) != 0);
 
     kth_chain_point_set_hash(point, &kHash);
@@ -106,8 +104,7 @@ TEST_CASE("C-API Point - hash setter roundtrip", "[C-API Point]") {
 }
 
 TEST_CASE("C-API Point - index setter roundtrip", "[C-API Point]") {
-    kth_point_mut_t point = kth_chain_point_construct_default();
-    REQUIRE(kth_chain_point_index(point) != 1254u);
+    kth_point_mut_t point = kth_chain_point_null();
     kth_chain_point_set_index(point, 1254u);
     REQUIRE(kth_chain_point_index(point) == 1254u);
     kth_chain_point_destruct(point);
@@ -121,7 +118,6 @@ TEST_CASE("C-API Point - copy preserves fields", "[C-API Point]") {
     kth_point_mut_t original = kth_chain_point_construct(&kHash, 524342u);
     kth_point_mut_t copy = kth_chain_point_copy(original);
 
-    REQUIRE(kth_chain_point_is_valid(copy) != 0);
     REQUIRE(kth_chain_point_equals(original, copy) != 0);
     REQUIRE(kth_chain_point_index(copy) == 524342u);
 
@@ -132,7 +128,7 @@ TEST_CASE("C-API Point - copy preserves fields", "[C-API Point]") {
 TEST_CASE("C-API Point - equals duplicates", "[C-API Point]") {
     kth_point_mut_t a = kth_chain_point_construct(&kHash, 524342u);
     kth_point_mut_t b = kth_chain_point_construct(&kHash, 524342u);
-    kth_point_mut_t c = kth_chain_point_construct_default();
+    kth_point_mut_t c = kth_chain_point_null();
 
     REQUIRE(kth_chain_point_equals(a, b) != 0);
     REQUIRE(kth_chain_point_equals(a, c) == 0);
@@ -218,7 +214,7 @@ TEST_CASE("C-API Point - construct_unsafe null hash aborts",
 
 TEST_CASE("C-API Point - to_data null out_size aborts",
           "[C-API Point][precondition]") {
-    kth_point_mut_t point = kth_chain_point_construct_default();
+    kth_point_mut_t point = kth_chain_point_null();
     KTH_EXPECT_ABORT(kth_chain_point_to_data(point, 1, NULL));
     kth_chain_point_destruct(point);
 }
@@ -230,21 +226,21 @@ TEST_CASE("C-API Point - copy null self aborts",
 
 TEST_CASE("C-API Point - set_hash null aborts",
           "[C-API Point][precondition]") {
-    kth_point_mut_t point = kth_chain_point_construct_default();
+    kth_point_mut_t point = kth_chain_point_null();
     KTH_EXPECT_ABORT(kth_chain_point_set_hash(point, NULL));
     kth_chain_point_destruct(point);
 }
 
 TEST_CASE("C-API Point - set_hash_unsafe null aborts",
           "[C-API Point][precondition]") {
-    kth_point_mut_t point = kth_chain_point_construct_default();
+    kth_point_mut_t point = kth_chain_point_null();
     KTH_EXPECT_ABORT(kth_chain_point_set_hash_unsafe(point, NULL));
     kth_chain_point_destruct(point);
 }
 
 TEST_CASE("C-API Point - equals null self aborts",
           "[C-API Point][precondition]") {
-    kth_point_mut_t other = kth_chain_point_construct_default();
+    kth_point_mut_t other = kth_chain_point_null();
     KTH_EXPECT_ABORT(kth_chain_point_equals(NULL, other));
     kth_chain_point_destruct(other);
 }

--- a/src/database/include/kth/database/databases/history_entry.hpp
+++ b/src/database/include/kth/database/databases/history_entry.hpp
@@ -12,31 +12,28 @@ namespace kth::database {
 
 struct KD_API history_entry {
 
-    history_entry() = default;
-
-    history_entry(uint64_t id, domain::chain::point const& point, domain::chain::point_kind kind, uint32_t height, uint32_t index, uint64_t value_or_checksum);
+    constexpr history_entry(uint64_t id, domain::chain::point const& point, domain::chain::point_kind kind, uint32_t height, uint32_t index, uint64_t value_or_checksum)
+        : id_(id), point_(point), point_kind_(kind), height_(height), index_(index), value_or_checksum_(value_or_checksum)
+    {}
 
     // Getters
-    uint64_t id () const;
-    domain::chain::point const& point() const;
-    domain::chain::point_kind point_kind() const;
-    uint64_t value_or_checksum() const;
-    uint32_t height() const;
-    uint32_t index() const;
+    constexpr uint64_t id() const { return id_; }
+    constexpr domain::chain::point const& point() const { return point_; }
+    constexpr domain::chain::point_kind point_kind() const { return point_kind_; }
+    constexpr uint64_t value_or_checksum() const { return value_or_checksum_; }
+    constexpr uint32_t height() const { return height_; }
+    constexpr uint32_t index() const { return index_; }
 
-    bool is_valid() const;
-
-    //TODO(fernando): make domain::chain::point::serialized_size() static and constexpr to make this constexpr too
-    // constexpr
-    static
-    size_t serialized_size(domain::chain::point const& point);
+    static constexpr size_t serialized_size(domain::chain::point const& point) {
+        return sizeof(uint64_t) + point.serialized_size(false) + sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint64_t);
+    }
 
     data_chunk to_data() const;
     void to_data(std::ostream& stream) const;
 
     template <typename W, KTH_IS_WRITER(W)>
     void to_data(W& sink) const {
-        factory_to_data(sink,id_, point_, point_kind_, height_, index_, value_or_checksum_ );
+        factory_to_data(sink, id_, point_, point_kind_, height_, index_, value_or_checksum_);
     }
 
     static
@@ -46,7 +43,7 @@ struct KD_API history_entry {
     data_chunk factory_to_data(uint64_t id, domain::chain::point const& point, domain::chain::point_kind kind, uint32_t height, uint32_t index, uint64_t value_or_checksum);
 
     static
-    void factory_to_data(std::ostream& stream,uint64_t id, domain::chain::point const& point, domain::chain::point_kind kind, uint32_t height, uint32_t index, uint64_t value_or_checksum);
+    void factory_to_data(std::ostream& stream, uint64_t id, domain::chain::point const& point, domain::chain::point_kind kind, uint32_t height, uint32_t index, uint64_t value_or_checksum);
 
     template <typename W, KTH_IS_WRITER(W)>
     static
@@ -60,14 +57,12 @@ struct KD_API history_entry {
     }
 
 private:
-    void reset();
-
-    uint64_t id_ = max_uint64;
+    uint64_t id_;
     domain::chain::point point_;
     domain::chain::point_kind point_kind_;
-    uint32_t height_ = max_uint32;
-    uint32_t index_ = max_uint32;
-    uint64_t value_or_checksum_ = max_uint64;
+    uint32_t height_;
+    uint32_t index_;
+    uint64_t value_or_checksum_;
 };
 
 } // namespace kth::database

--- a/src/database/src/databases/history_entry.cpp
+++ b/src/database/src/databases/history_entry.cpp
@@ -7,61 +7,9 @@
 #include <cstddef>
 #include <cstdint>
 
-// #include <kth/infrastructure.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::database {
-
-history_entry::history_entry(uint64_t id, domain::chain::point const& point, domain::chain::point_kind kind, uint32_t height, uint32_t index, uint64_t value_or_checksum)
-    : id_(id), point_(point), point_kind_(kind), height_(height), index_(index), value_or_checksum_(value_or_checksum)
-{}
-
-uint64_t history_entry::id() const {
-    return id_;
-}
-
-domain::chain::point const& history_entry::point() const {
-    return point_;
-}
-
-domain::chain::point_kind history_entry::point_kind() const {
-    return point_kind_;
-}
-
-uint32_t history_entry::height() const {
-    return height_;
-}
-
-uint32_t history_entry::index() const {
-    return index_;
-}
-
-uint64_t history_entry::value_or_checksum() const {
-    return value_or_checksum_;
-}
-
-// private
-void history_entry::reset() {
-    id_ = max_uint64;
-    point_ = domain::chain::point{};
-    point_kind_ = kth::domain::chain::point_kind::output;
-    height_ = max_uint32;
-    index_ = max_uint32;
-    value_or_checksum_ = max_uint64;
-}
-
-// Empty scripts are valid, validation relies on not_found only.
-bool history_entry::is_valid() const {
-    return id_ != max_uint64 && point_.is_valid() && height_ != kth::max_uint32 && index_ != max_uint32 && value_or_checksum_ != max_uint64;
-}
-
-// Size.
-//-----------------------------------------------------------------------------
-// constexpr
-//TODO(fernando): make domain::chain::point::serialized_size() static and constexpr to make this constexpr too
-size_t history_entry::serialized_size(domain::chain::point const& point) {
-    return sizeof(uint64_t) + point.serialized_size(false) + sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint64_t);
-}
 
 // Deserialization.
 //-----------------------------------------------------------------------------
@@ -129,9 +77,6 @@ void history_entry::factory_to_data(std::ostream& stream, uint64_t id, domain::c
     factory_to_data(sink, id, point, kind, height, index, value_or_checksum);
 }
 
-// Serialization.
-//-----------------------------------------------------------------------------
-
 data_chunk history_entry::to_data() const {
     data_chunk data;
     auto const size = serialized_size(point_);
@@ -149,4 +94,3 @@ void history_entry::to_data(std::ostream& stream) const {
 }
 
 } // namespace kth::database
-

--- a/src/domain/include/kth/domain/chain/block.hpp
+++ b/src/domain/include/kth/domain/chain/block.hpp
@@ -71,8 +71,12 @@ public:
     // Operators.
     //-------------------------------------------------------------------------
 
+    // NOTE: `==` is not `= default` because the `validation` member is
+    // tracing metadata, not part of the value's identity. `!=` is defaulted
+    // (delegates to `!(==)`) so callers that spell out the member call still
+    // resolve.
     bool operator==(block const& x) const;
-    bool operator!=(block const& x) const;
+    bool operator!=(block const& x) const = default;
 
     // Deserialization.
     //-------------------------------------------------------------------------

--- a/src/domain/include/kth/domain/chain/input.hpp
+++ b/src/domain/include/kth/domain/chain/input.hpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <istream>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include <kth/domain/chain/output_point.hpp>
@@ -27,11 +28,11 @@ namespace kth::domain::chain {
 
 struct KD_API input {
     using list = std::vector<input>;
+    using opt = std::optional<input>;
 
     // Constructors.
     //-------------------------------------------------------------------------
 
-    input() = default;
     input(output_point const& previous_output, chain::script const& script, uint32_t sequence);
     input(output_point&& previous_output, chain::script&& script, uint32_t sequence);
 
@@ -39,19 +40,13 @@ struct KD_API input {
     //-------------------------------------------------------------------------
 
     friend
-    bool operator==(input const&, input const&);
-
-    friend
-    bool operator!=(input const&, input const&);
+    constexpr bool operator==(input const&, input const&) = default;
 
     // Deserialization.
     //-------------------------------------------------------------------------
 
     static
     expect<input> from_data(byte_reader& reader, bool wire);
-
-    [[nodiscard]]
-    bool is_valid() const;
 
     // Serialization.
     //-------------------------------------------------------------------------
@@ -122,13 +117,13 @@ struct KD_API input {
     [[nodiscard]]
     expect<chain::script> extract_embedded_script() const;
 
-    void reset();
-
 private:
     output_point previous_output_;
     chain::script script_;
     uint32_t sequence_{0};
 };
+
+using input_opt = input::opt;
 
 } // namespace kth::domain::chain
 

--- a/src/domain/include/kth/domain/chain/input_point.hpp
+++ b/src/domain/include/kth/domain/chain/input_point.hpp
@@ -10,6 +10,7 @@
 namespace kth::domain::chain {
 
 using input_point = point;
+using input_point_opt = input_point::opt;
 
 } // namespace kth::domain::chain
 

--- a/src/domain/include/kth/domain/chain/output.hpp
+++ b/src/domain/include/kth/domain/chain/output.hpp
@@ -51,11 +51,15 @@ struct KD_API output {
     // Operators.
     //-------------------------------------------------------------------------
 
+    // NOTE: `==` is not `= default` because the `validation` member is
+    // tracing metadata, not part of the value's identity. `!=` is defaulted
+    // (delegates to `!(==)`) so callers that spell out the member call still
+    // resolve.
     friend
     bool operator==(output const&, output const&);
 
     friend
-    bool operator!=(output const&, output const&);
+    bool operator!=(output const&, output const&) = default;
 
     // Deserialization.
     //-------------------------------------------------------------------------

--- a/src/domain/include/kth/domain/chain/output_point.hpp
+++ b/src/domain/include/kth/domain/chain/output_point.hpp
@@ -52,6 +52,12 @@ public:
     // Constructors.
     //-------------------------------------------------------------------------
 
+    // NOTE: default ctor produces the coinbase null prevout (null_hash,
+    // null_index). Kept because several aggregate types (history,
+    // token_genesis_params, utxo, config::point) rely on it as a
+    // default-init member; removing it cascades through wallet/cashtoken
+    // and the config wrappers. Tracked as a follow-up to fully apply the
+    // "valid by construction" pattern (see task list).
     output_point();
     output_point(hash_digest const& hash, uint32_t index);
 
@@ -76,6 +82,11 @@ public:
     // Operators.
     //-------------------------------------------------------------------------
 
+    // NOTE: `==` is not `= default` because `validation` is tracing/cache
+    // metadata — equality is defined over the (hash, index) base, ignoring
+    // it. Self-self `!=` is defaulted (delegates to `!(==)`); cross-type
+    // pairs cannot be defaulted (the standard requires identical parameter
+    // types), so they are hand-written.
     friend bool operator==(output_point const& x, point const& y);
     friend bool operator!=(output_point const& x, point const& y);
 
@@ -83,7 +94,7 @@ public:
     friend bool operator!=(point const& x, output_point const& y);
 
     friend bool operator==(output_point const& x, output_point const& y);
-    friend bool operator!=(output_point const& x, output_point const& y);
+    friend bool operator!=(output_point const& x, output_point const& y) = default;
 
     // Validation.
     //-------------------------------------------------------------------------

--- a/src/domain/include/kth/domain/chain/point.hpp
+++ b/src/domain/include/kth/domain/chain/point.hpp
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <istream>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -34,47 +35,27 @@ struct KD_API point {
     uint32_t null_index = no_previous_output;
 
     using list = std::vector<point>;
+    using opt = std::optional<point>;
     using indexes = std::vector<uint32_t>;
 
     // Constructors.
     //-------------------------------------------------------------------------
 
-    // constexpr
-    point();
-
-    // constexpr
-    point(hash_digest const& hash, uint32_t index);
-
-    // constexpr
-    point(point const& x) = default;
-
-    // constexpr
-    point& operator=(point const& x) = default;
+    constexpr point(hash_digest const& hash, uint32_t index)
+        : index_(index), hash_(hash)
+    {}
 
     // Operators.
     //-------------------------------------------------------------------------
 
-    // constexpr    //Note(kth): Could be constexpr in C++20
-    friend bool operator==(point const& x, point const& y);
-
-    // constexpr    //Note(kth): Could be constexpr in C++20
-    friend bool operator!=(point const& x, point const& y);
-
-    // constexpr
-    friend bool operator<(point const& x, point const& y);
-
-    // constexpr
-    friend bool operator>(point const& x, point const& y);
-
-    // constexpr
-    friend bool operator<=(point const& x, point const& y);
-
-    // constexpr
-    friend bool operator>=(point const& x, point const& y);
+    // Member order (index_, then hash_) is deliberate: it makes the defaulted
+    // `<=>` compare index first — index comparisons are cheaper than 32-byte
+    // hashes, and this matches the pre-refactor hand-written `operator<`
+    // ("arbitrary order to support set uniqueness").
+    friend constexpr auto operator<=>(point const&, point const&) = default;
 
     // Deserialization.
     //-------------------------------------------------------------------------
-
 
     static
     expect<point> from_data(byte_reader& reader, bool wire = true);
@@ -84,10 +65,6 @@ struct KD_API point {
     static constexpr point null() noexcept {
         return point{null_hash, null_index};
     }
-
-    // constexpr
-    [[nodiscard]]
-    bool is_valid() const;
 
     // Serialization.
     //-------------------------------------------------------------------------
@@ -121,60 +98,73 @@ struct KD_API point {
     // Properties (size, accessors, cache).
     //-------------------------------------------------------------------------
 
-    // constexpr
-    static
-    size_t satoshi_fixed_size();
-
-    // constexpr
     [[nodiscard]]
-    size_t serialized_size(bool wire = true) const;
+    static constexpr size_t satoshi_fixed_size() {
+        return hash_size + sizeof(index_);
+    }
+
+    [[nodiscard]]
+    constexpr size_t serialized_size(bool wire = true) const {
+        return wire ? point::satoshi_fixed_size() : (hash_size + sizeof(uint16_t));
+    }
 
     // deprecated (unsafe)
-    // constexpr
-    hash_digest& hash();
+    constexpr hash_digest& hash() {
+        return hash_;
+    }
 
-    // constexpr
     [[nodiscard]]
-    hash_digest const& hash() const;
+    constexpr hash_digest const& hash() const {
+        return hash_;
+    }
 
-    // constexpr
-    void set_hash(hash_digest const& value);
+    constexpr void set_hash(hash_digest const& value) {
+        hash_ = value;
+    }
 
-    // constexpr
     [[nodiscard]]
-    uint32_t index() const;
+    constexpr uint32_t index() const {
+        return index_;
+    }
 
-    // constexpr
-    void set_index(uint32_t value);
+    constexpr void set_index(uint32_t value) {
+        index_ = value;
+    }
 
     // Utilities.
     //-------------------------------------------------------------------------
 
     /// This is for client-server, not related to consensus or p2p networking.
     [[nodiscard]]
-    uint64_t checksum() const;
+    constexpr uint64_t checksum() const {
+        // Reserve 49 bits for the tx hash and 15 bits (32768) for the input index.
+        constexpr uint64_t mask = 0xffffffffffff8000;
+
+        // Use an offset to the middle of the hash to avoid coincidental mining
+        // of values into the front or back of tx hash (not a security feature).
+        // Use most possible bits of tx hash to make intentional collision hard.
+        auto const tx = from_little_endian_unsafe<uint64_t>(std::span{hash_}.subspan(12));
+        auto const index = uint64_t(index_);
+
+        auto const tx_upper_49_bits = tx & mask;
+        auto const index_lower_15_bits = index & ~mask;
+        return tx_upper_49_bits | index_lower_15_bits;
+    }
 
     // Validation.
     //-------------------------------------------------------------------------
 
-    // constexpr
     [[nodiscard]]
-    bool is_null() const;
-
-// protected:
-    // point(hash_digest const& hash, uint32_t index, bool valid);
-    void reset();
+    constexpr bool is_null() const {
+        return index_ == null_index && hash_ == null_hash;
+    }
 
 private:
-    // Design note: A default-constructed point is "uninitialized" (not valid).
-    // A "null" point (null_hash + null_index) represents a coinbase input and IS valid.
-    // These are distinct concepts:
-    //   - is_valid(): has been properly initialized (explicitly or via deserialization)
-    //   - is_null(): references no previous output (coinbase input)
-    hash_digest hash_{null_hash};
-    uint32_t index_{0};  // Intentionally 0, not null_index. See comment above.
-    bool valid_{false};
+    uint32_t index_;
+    hash_digest hash_;
 };
+
+using point_opt = point::opt;
 
 } // namespace kth::domain::chain
 

--- a/src/domain/include/kth/domain/chain/point_iterator.hpp
+++ b/src/domain/include/kth/domain/chain/point_iterator.hpp
@@ -47,8 +47,7 @@ struct KD_API point_iterator {
     point_iterator operator--(int);
     point_iterator operator+(int value) const;
     point_iterator operator-(int value) const;
-    bool operator==(point_iterator const& x) const;
-    bool operator!=(point_iterator const& x) const;
+    bool operator==(point_iterator const&) const = default;
 
 
 protected:

--- a/src/domain/include/kth/domain/chain/point_value.hpp
+++ b/src/domain/include/kth/domain/chain/point_value.hpp
@@ -21,7 +21,7 @@ public:
     // Constructors.
     //-------------------------------------------------------------------------
 
-    point_value() = default;
+    point_value() : point(null_hash, null_index) {}
     point_value(point const& p, uint64_t value);
 
     // point_value(point_value const& x) = default;
@@ -31,10 +31,7 @@ public:
     //-------------------------------------------------------------------------
 
     friend
-    bool operator==(point_value const& x, point_value const& y);
-
-    friend
-    bool operator!=(point_value const& x, point_value const& y);
+    bool operator==(point_value const&, point_value const&) = default;
 
     // Swap implementation required to properly handle base class.
     friend

--- a/src/domain/include/kth/domain/chain/script.hpp
+++ b/src/domain/include/kth/domain/chain/script.hpp
@@ -73,10 +73,7 @@ struct KD_API script {
     //-------------------------------------------------------------------------
 
     friend
-    bool operator==(script const& x, script const& y);
-
-    friend
-    bool operator!=(script const& x, script const& y);
+    constexpr bool operator==(script const&, script const&) = default;
 
     // Deserialization.
     //-------------------------------------------------------------------------

--- a/src/domain/include/kth/domain/chain/transaction.hpp
+++ b/src/domain/include/kth/domain/chain/transaction.hpp
@@ -108,8 +108,12 @@ struct KD_API transaction {
     // Operators.
     //-----------------------------------------------------------------------------
 
+    // NOTE: `==` is not `= default` because the `validation` member is
+    // tracing metadata, not part of the value's identity. `!=` is defaulted
+    // (delegates to `!(==)`) so callers that spell out the member call still
+    // resolve.
     bool operator==(transaction const& x) const;
-    bool operator!=(transaction const& x) const;
+    bool operator!=(transaction const& x) const = default;
 
     // Deserialization.
     //-----------------------------------------------------------------------------

--- a/src/domain/include/kth/domain/chain/witness.hpp
+++ b/src/domain/include/kth/domain/chain/witness.hpp
@@ -49,8 +49,11 @@ struct KD_API witness {
     // Operators.
     //-------------------------------------------------------------------------
 
+    // NOTE: `==` is not `= default` because the `valid_` member is internal
+    // "has-been-parsed" state — equality is defined by the witness stack
+    // alone. `!=` is defaulted (delegates to `!(==)`).
     bool operator==(witness const& x) const;
-    bool operator!=(witness const& x) const;
+    bool operator!=(witness const& x) const = default;
 
     // Deserialization (from witness stack).
     //-------------------------------------------------------------------------

--- a/src/domain/include/kth/domain/config/input.hpp
+++ b/src/domain/include/kth/domain/config/input.hpp
@@ -66,9 +66,10 @@ struct KD_API input {
 
 private:
     /**
-     * The state of this object.
+     * The state of this object — populated by the string-tuple ctor
+     * or the stream-in operator. Empty until populated.
      */
-    chain::input value_;
+    chain::input_opt value_;
 };
 
 } // namespace kth::domain::config

--- a/src/domain/include/kth/domain/message/double_spend_proof.hpp
+++ b/src/domain/include/kth/domain/message/double_spend_proof.hpp
@@ -144,11 +144,6 @@ struct KD_API double_spend_proof {
     expect<double_spend_proof> from_data(byte_reader& reader, uint32_t /*version*/);
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
     size_t serialized_size(uint32_t /*version*/) const {
         return out_point_.serialized_size() +
             spender1_.serialized_size() +

--- a/src/domain/include/kth/domain/version.hpp
+++ b/src/domain/include/kth/domain/version.hpp
@@ -15,7 +15,7 @@
 namespace kth {
 
 // Version string from build system (conan -> cmake -> C++)
-inline constexpr std::string_view version = "1.0.0";
+inline constexpr std::string_view version = "0.0.0-dev";
 
 // Currency identifier
 #if defined(KTH_CURRENCY_BCH)

--- a/src/domain/src/chain/block.cpp
+++ b/src/domain/src/chain/block.cpp
@@ -191,11 +191,7 @@ block::block(chain::header const& header, transaction::list&& transactions)
 //-----------------------------------------------------------------------------
 
 bool block::operator==(block const& x) const {
-    return (header_ == x.header_) && (transactions_ == x.transactions_);
-}
-
-bool block::operator!=(block const& x) const {
-    return !(*this == x);
+    return header_ == x.header_ && transactions_ == x.transactions_;
 }
 
 // Deserialization.

--- a/src/domain/src/chain/input.cpp
+++ b/src/domain/src/chain/input.cpp
@@ -33,32 +33,6 @@ input::input(output_point&& previous_output, chain::script&& script, uint32_t se
     , sequence_(sequence)
 {}
 
-// Operators.
-//-----------------------------------------------------------------------------
-
-bool operator==(input const& a, input const& b) {
-    return a.previous_output_ == b.previous_output_
-        && a.script_ == b.script_
-        && a.sequence_ == b.sequence_;
-}
-
-bool operator!=(input const& a, input const& b) {
-    return !(a == b);
-}
-
-void input::reset() {
-    previous_output_.reset();
-    script_.reset();
-    sequence_ = 0;
-}
-
-// Since empty scripts and zero sequence are valid this relies on the prevout.
-bool input::is_valid() const {
-    return sequence_ != 0
-        || previous_output_.is_valid()
-        || script_.is_valid();
-}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/src/chain/output.cpp
+++ b/src/domain/src/chain/output.cpp
@@ -41,10 +41,6 @@ bool operator==(output const& a, output const& b) {
         && a.token_data_ == b.token_data_;
 }
 
-bool operator!=(output const& a, output const& b) {
-    return !(a == b);
-}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/src/chain/output_point.cpp
+++ b/src/domain/src/chain/output_point.cpp
@@ -16,8 +16,9 @@ namespace kth::domain::chain {
 // Constructors.
 //-----------------------------------------------------------------------------
 
+// Default = coinbase null prevout (matches `output_point::null()`).
 output_point::output_point()
-    : validation{}
+    : point(null_hash, null_index), validation{}
 {}
 
 output_point::output_point(hash_digest const& hash, uint32_t index)
@@ -32,8 +33,8 @@ output_point::output_point(point const& x)
 //-----------------------------------------------------------------------------
 
 output_point& output_point::operator=(point const& x) {
-    reset();
     point::operator=(x);
+    validation = {};
     return *this;
 }
 
@@ -55,10 +56,6 @@ bool operator!=(point const& x, output_point const& y) {
 
 bool operator==(output_point const& x, output_point const& y) {
     return static_cast<point const&>(x) == static_cast<point const&>(y);
-}
-
-bool operator!=(output_point const& x, output_point const& y) {
-    return !(x == y);
 }
 
 // Validation.

--- a/src/domain/src/chain/point.cpp
+++ b/src/domain/src/chain/point.cpp
@@ -5,84 +5,19 @@
 #include <kth/domain/chain/point.hpp>
 
 #include <cstdint>
-#include <sstream>
 #include <utility>
 
-// #include <kth/domain/constants.hpp>
-#include <kth/infrastructure/formats/base_16.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/assert.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/ostream_writer.hpp>
-#include <kth/infrastructure/utility/serializer.hpp>
 
 namespace kth::domain::chain {
 
 constexpr auto store_point_size = std::tuple_size<point>::value;
 
-// Constructors.
-//-----------------------------------------------------------------------------
-
-// A default instance is invalid (until modified).
-// constexpr
-point::point()
-    : hash_(null_hash)
-{}
-
-// constexpr
-point::point(hash_digest const& hash, uint32_t index)
-    : hash_(hash), index_(index), valid_(true) {}
-
-// Operators.
-//-----------------------------------------------------------------------------
-
-// constexpr    //Note(kth): Could be constexpr in C++20
-bool operator==(point const& x, point const& y) {
-    return (x.hash_ == y.hash_) && (x.index_ == y.index_);
-}
-
-// constexpr
-bool operator!=(point const& x, point const& y) {
-    return !(x == y);
-}
-
-// This arbitrary order is produced to support set uniqueness determinations.
-// constexpr
-bool operator<(point const& x, point const& y) {
-    // The index is primary only because its comparisons are simpler.
-    return x.index_ == y.index_ ? x.hash_ < y.hash_ : x.index_ < y.index_;
-}
-
-// constexpr
-bool operator>(point const& x, point const& y) {
-    return y < x;
-}
-
-// constexpr
-bool operator<=(point const& x, point const& y) {
-    return !(y < x);
-}
-
-// constexpr
-bool operator>=(point const& x, point const& y) {
-    return !(x < y);
-}
-
-// protected
-void point::reset() {
-    valid_ = false;
-    hash_ = null_hash;
-    index_ = 0;
-}
-
-// constexpr
-bool point::is_valid() const {
-    return valid_ || (hash_ != null_hash) || (index_ != 0);
-}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
-
 
 expect<point> point::from_data(byte_reader& reader, bool wire) {
     auto const hash = read_hash(reader);
@@ -136,78 +71,6 @@ point_iterator point::begin() const {
 
 point_iterator point::end() const {
     return {*this, unsigned(store_point_size)};
-}
-
-// Properties.
-//-----------------------------------------------------------------------------
-
-// constexpr
-size_t point::serialized_size(bool wire /*= true*/) const {
-    return wire ? point::satoshi_fixed_size() : store_point_size;
-}
-
-// constexpr
-size_t point::satoshi_fixed_size() {
-    return hash_size + sizeof(index_);
-}
-
-// constexpr
-hash_digest& point::hash() {
-    return hash_;
-}
-
-// constexpr
-hash_digest const& point::hash() const {
-    return hash_;
-}
-
-// constexpr
-void point::set_hash(hash_digest const& value) {
-    // This is no longer a default instance, so valid.
-    valid_ = true;
-    hash_ = value;
-}
-
-// constexpr
-uint32_t point::index() const {
-    return index_;
-}
-
-// constexpr
-void point::set_index(uint32_t value) {
-    // This is no longer a default instance, so valid.
-    valid_ = true;
-    index_ = value;
-}
-
-// Utilities.
-//-----------------------------------------------------------------------------
-
-// Changed in v3.0 and again in v3.1 (3.0 was unmasked, lots of collisions).
-// This is used with output_point identification within a set of history rows
-// of the same address. Collision will result in miscorrelation of points by
-// client callers. This is stored in database. This is NOT a bitcoin checksum.
-uint64_t point::checksum() const {
-    // Reserve 49 bits for the tx hash and 15 bits (32768) for the input index.
-    static constexpr uint64_t mask = 0xffffffffffff8000;
-
-    // Use an offset to the middle of the hash to avoid coincidental mining
-    // of values into the front or back of tx hash (not a security feature).
-    // Use most possible bits of tx hash to make intentional collision hard.
-    auto const tx = from_little_endian_unsafe<uint64_t>(std::span{hash_}.subspan(12));
-    auto const index = uint64_t(index_);
-
-    auto const tx_upper_49_bits = tx & mask;
-    auto const index_lower_15_bits = index & ~mask;
-    return tx_upper_49_bits | index_lower_15_bits;
-}
-
-// Validation.
-//-----------------------------------------------------------------------------
-
-// constexpr
-bool point::is_null() const {
-    return (index_ == null_index) && (hash_ == null_hash);
 }
 
 } // namespace kth::domain::chain

--- a/src/domain/src/chain/point_iterator.cpp
+++ b/src/domain/src/chain/point_iterator.cpp
@@ -85,14 +85,6 @@ point_iterator point_iterator::operator-(int value) const {
     return value < 0 ? increase(unsigned(std::abs(value))) : decrease(value);
 }
 
-bool point_iterator::operator==(point_iterator const& x) const {
-    return (current_ == x.current_) && (point_ == x.point_);
-}
-
-bool point_iterator::operator!=(point_iterator const& x) const {
-    return !(*this == x);
-}
-
 // Utilities.
 //-----------------------------------------------------------------------------
 // private

--- a/src/domain/src/chain/point_value.cpp
+++ b/src/domain/src/chain/point_value.cpp
@@ -28,16 +28,6 @@ point_value::point_value(point const& p, uint64_t value)
 // }
 
 // friend
-bool operator==(point_value const& x, point_value const& y) {
-    return static_cast<point const&>(x) == static_cast<point const&>(y) && x.value_ == y.value_;
-}
-
-// friend
-bool operator!=(point_value const& x, point_value const& y) {
-    return !(x == y);
-}
-
-// friend
 void swap(point_value& x, point_value& y) {
     using std::swap;
     swap(static_cast<point&>(x), static_cast<point&>(y));

--- a/src/domain/src/chain/script.cpp
+++ b/src/domain/src/chain/script.cpp
@@ -87,17 +87,6 @@ script::script(data_chunk const& encoded, bool prefix) {
     *this = std::move(obj.value());
 }
 
-// Operators.
-//-----------------------------------------------------------------------------
-
-bool operator==(script const& x, script const& y) {
-    return x.bytes_ == y.bytes_;
-}
-
-bool operator!=(script const& x, script const& y) {
-    return !(x == y);
-}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/src/chain/transaction.cpp
+++ b/src/domain/src/chain/transaction.cpp
@@ -73,10 +73,6 @@ bool transaction::operator==(transaction const& x) const {
         && outputs_ == x.outputs_;
 }
 
-bool transaction::operator!=(transaction const& x) const {
-    return !(*this == x);
-}
-
 void transaction::reset() {
     version_ = 0;
     locktime_ = 0;

--- a/src/domain/src/chain/witness.cpp
+++ b/src/domain/src/chain/witness.cpp
@@ -78,10 +78,6 @@ bool witness::operator==(witness const& x) const {
     return stack_ == x.stack_;
 }
 
-bool witness::operator!=(witness const& x) const {
-    return !(*this == x);
-}
-
 // private/static
 size_t witness::serialized_size(data_stack const& stack) {
     auto const sum = [](size_t total, data_chunk const& element) {

--- a/src/domain/src/config/input.cpp
+++ b/src/domain/src/config/input.cpp
@@ -21,20 +21,21 @@ using namespace boost::program_options;
 
 // input is currently a private encoding in bx.
 static
-bool decode_input(chain::input& input, std::string const& tuple) {
+chain::input_opt decode_input(std::string const& tuple) {
     auto const tokens = split(tuple, point::delimeter);
     if (tokens.size() != 2 && tokens.size() != 3) {
-        return false;
+        return std::nullopt;
     }
 
-    input.set_sequence(max_input_sequence);
-    input.set_previous_output(point(tokens[0] + ":" + tokens[1]));
+    auto const sequence = (tokens.size() == 3)
+        ? deserialize<uint32_t>(tokens[2], true)
+        : max_input_sequence;
 
-    if (tokens.size() == 3) {
-        input.set_sequence(deserialize<uint32_t>(tokens[2], true));
-    }
-
-    return true;
+    return chain::input{
+        chain::output_point{point(tokens[0] + ":" + tokens[1])},
+        chain::script{},
+        sequence
+    };
 }
 
 // input is currently a private encoding in bx.
@@ -55,28 +56,32 @@ input::input(chain::input const& value)
     : value_(value) {}
 
 input::input(input const& x)
-    : input(x.value_) {}
+    : value_(x.value_) {}
 
 input::input(chain::input_point const& value)
     : value_(chain::input{value, {}, max_input_sequence}) {}
 
 input::operator chain::input const&() const {
-    return value_;
+    KTH_ASSERT(value_.has_value());
+    return *value_;
 }
 
 std::istream& operator>>(std::istream& stream, input& argument) {
     std::string tuple;
     stream >> tuple;
 
-    if ( ! decode_input(argument.value_, tuple)) {
+    auto decoded = decode_input(tuple);
+    if ( ! decoded) {
         BOOST_THROW_EXCEPTION(invalid_option_value(tuple));
     }
+    argument.value_ = std::move(*decoded);
 
     return stream;
 }
 
 std::ostream& operator<<(std::ostream& output, input const& argument) {
-    output << encode_input(argument.value_);
+    KTH_ASSERT(argument.value_.has_value());
+    output << encode_input(*argument.value_);
     return output;
 }
 

--- a/src/domain/src/message/double_spend_proof.cpp
+++ b/src/domain/src/message/double_spend_proof.cpp
@@ -27,19 +27,6 @@ double_spend_proof::double_spend_proof(chain::output_point const& out_point, spe
     , spender2_(spender2)
 {}
 
-bool double_spend_proof::is_valid() const {
-    return out_point_.is_valid()
-        && spender1_.is_valid()
-        && spender2_.is_valid();
-}
-
-void double_spend_proof::reset() {
-    out_point_.reset();
-    spender1_.reset();
-    spender2_.reset();
-}
-
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/src/utility/property_tree.cpp
+++ b/src/domain/src/utility/property_tree.cpp
@@ -112,10 +112,8 @@ ptree property_tree(const config::input& input) {
 }
 
 ptree property_tree(std::vector<config::input> const& inputs, bool json) {
-    auto const tx_inputs = cast<input, chain::input>(inputs);
-
     ptree tree;
-    tree.add_child("inputs", property_tree_list("input", tx_inputs, json));
+    tree.add_child("inputs", property_tree_list("input", inputs, json));
     return tree;
 }
 

--- a/src/domain/test/chain/transaction.cpp
+++ b/src/domain/test/chain/transaction.cpp
@@ -418,7 +418,7 @@ TEST_CASE("chain transaction  is locktime conflict  input max sequence  returns 
     // This must be non-const.
     chain::input::list inputs;
 
-    inputs.emplace_back();
+    inputs.emplace_back(chain::output_point{}, chain::script{}, 0u);
     inputs.back().set_sequence(max_input_sequence);
     chain::transaction const instance(0, 2143u, std::move(inputs), {});
     REQUIRE(instance.is_locktime_conflict());
@@ -608,7 +608,7 @@ TEST_CASE("chain transaction  is oversized coinbase  script size below min  retu
 TEST_CASE("chain transaction  is oversized coinbase  script size above max  returns true", "[chain transaction]") {
     chain::transaction instance;
     auto& inputs = instance.inputs();
-    inputs.emplace_back();
+    inputs.emplace_back(chain::output_point{}, chain::script{}, 0u);
     inputs.back().previous_output().set_index(chain::point::null_index);
     inputs.back().previous_output().set_hash(null_hash);
     
@@ -626,7 +626,7 @@ TEST_CASE("chain transaction  is oversized coinbase  script size above max  retu
 TEST_CASE("chain transaction  is oversized coinbase  script size within bounds  returns false", "[chain transaction]") {
     chain::transaction instance;
     auto& inputs = instance.inputs();
-    inputs.emplace_back();
+    inputs.emplace_back(chain::output_point{}, chain::script{}, 0u);
     inputs.back().previous_output().set_index(chain::point::null_index);
     inputs.back().previous_output().set_hash(null_hash);
 
@@ -659,8 +659,8 @@ TEST_CASE("chain transaction  is null non coinbase  no null input prevout  retur
 TEST_CASE("chain transaction  is null non coinbase  null input prevout  returns true", "[chain transaction]") {
     chain::transaction instance;
     auto& inputs = instance.inputs();
-    inputs.emplace_back();
-    inputs.emplace_back();
+    inputs.emplace_back(chain::output_point{}, chain::script{}, 0u);
+    inputs.emplace_back(chain::output_point{}, chain::script{}, 0u);
     inputs.back().previous_output().set_index(chain::point::null_index);
     inputs.back().previous_output().set_hash(null_hash);
     REQUIRE( ! instance.is_coinbase());
@@ -678,9 +678,9 @@ TEST_CASE("chain transaction  total input value  no cache  returns zero", "[chai
 TEST_CASE("chain transaction  total input value  cache  returns cache value sum", "[chain transaction]") {
     chain::transaction instance;
     auto& inputs = instance.inputs();
-    inputs.emplace_back();
+    inputs.emplace_back(chain::output_point{}, chain::script{}, 0u);
     inputs.back().previous_output().validation.cache.set_value(123u);
-    inputs.emplace_back();
+    inputs.emplace_back(chain::output_point{}, chain::script{}, 0u);
     inputs.back().previous_output().validation.cache.set_value(321u);
     REQUIRE(instance.total_input_value() == 444u);
 }
@@ -707,9 +707,9 @@ TEST_CASE("chain transaction  total output value  non empty outputs  returns sum
 TEST_CASE("chain transaction  fees  nonempty  returns outputs minus inputs", "[chain transaction]") {
     chain::transaction instance;
     auto& inputs = instance.inputs();
-    inputs.emplace_back();
+    inputs.emplace_back(chain::output_point{}, chain::script{}, 0u);
     inputs.back().previous_output().validation.cache.set_value(123u);
-    inputs.emplace_back();
+    inputs.emplace_back(chain::output_point{}, chain::script{}, 0u);
     inputs.back().previous_output().validation.cache.set_value(321u);
     instance.outputs().emplace_back();
     instance.outputs().back().set_value(44u);

--- a/src/domain/test/machine/interpreter.cpp
+++ b/src/domain/test/machine/interpreter.cpp
@@ -432,7 +432,7 @@ TEST_CASE("OP_CHECKLOCKTIMEVERIFY propagates top_number parse error",
     // Needs a transaction context with at least one input (CLTV
     // reads tx.inputs()[input_index]).
     chain::transaction tx;
-    tx.inputs().push_back(chain::input{});
+    tx.inputs().emplace_back(chain::output_point{}, chain::script{}, 0u);
     auto scr = script_of({operation(opcode::checklocktimeverify)});
     program prog(scr, tx, 0, script_flags::bip65_rule, 0);
     auto const result = interpreter::run(prog);
@@ -450,7 +450,7 @@ TEST_CASE("OP_CHECKSEQUENCEVERIFY propagates top_number parse error",
     // pre-check at the top of `op_check_sequence_verify` doesn't
     // preempt with its own error.
     chain::transaction tx;
-    tx.inputs().push_back(chain::input{});
+    tx.inputs().emplace_back(chain::output_point{}, chain::script{}, 0u);
     auto scr = script_of({
         operation(data_chunk{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}),
         operation(opcode::checksequenceverify),


### PR DESCRIPTION
Follow-up on the value-types stack (#387). Pushes the domain primitives further toward "pure data, valid by construction": shed the synthetic state (`valid_`, `is_valid()`, `reset()`) and the redundant `operator!=`, modernize the comparisons (`= default`, `<=>`), and contain partial state in `std::optional<T>` where it genuinely exists (boost::program_options config wrappers, asio coroutine result slots).

**Base**: `refactor/domain-value-types`. Merges in after #387 lands.

## Summary by type

### `chain::point`
- Drop `point()`, `valid_` member, `is_valid()`, `reset()` — a constructed `point` is valid by construction; partial state belongs in the caller via `std::optional<point>`.
- Replace the hand-written `==` / `<` / `<=` / `>` / `>=` family with `operator<=> = default`. Member order is now `(index_, hash_)` so the lexicographic default keeps the previous index-first semantic.
- Mark every member that can be `constexpr` as such (ctors, comparisons, accessors, `serialized_size`, `satoshi_fixed_size`, `checksum`, `is_null`).
- Inner alias `using opt = std::optional<point>` plus free-namespace `point_opt`.

### `chain::input`
- Drop `input()`, `is_valid()`, `reset()`; ctor now mandatory.
- Inner alias `using opt = std::optional<input>` plus `input_opt`.

### `chain::output_point`
- Drop `is_valid()` / `reset()` — both were synthetic delegations to point and had zero live callers outside auto-generated C-API bindings.
- The default ctor stays (initialises to the coinbase null prevout). Dropping it cleanly cascades through `utxo`, `token_genesis_params`, `chain::history`, `config::point`, and `double_spend_proof`; tracked as a follow-up.

### `script` / `point_value` / `point_iterator`
- `operator==` `= default`; `operator!=` removed (C++20 rewrites `a != b` from `==` automatically). `script` / `point` versions are `constexpr`.

### `output` / `transaction` / `block` / `witness` / `output_point` self-self
- `operator==` stays hand-written — it deliberately skips the `validation` / `valid_` members.
- `operator!=` removed everywhere; `message::block` and `message::transaction` wrapper `!=` overrides rewritten as `!(operator==)` since the chain-side `operator!=` are gone.

### `database::history_entry`
- Drop default ctor, `is_valid()`, `reset()`. Grep confirms zero live callers — every match for `entry.is_valid()` in the existing audit resolved to `transaction_entry::is_valid()` (a different type) or commented-out blocks.
- `point_` is now a plain `chain::point` (not `optional`); all paths come through the explicit factory.
- All accessors + `serialized_size` made `constexpr`; ctor inlined to the header.

### `message::double_spend_proof`
- Drop `is_valid()` / `reset()` (synthetic, no live callers).

### `config::input`
- `value_` becomes `chain::input_opt` instead of `chain::input`, so the default-then-stream pattern boost::program_options needs survives without giving `chain::input` a default ctor.
- `decode_input` rewritten to build the value by construction and assign the resulting optional. `operator chain::input const&()` asserts on population.

### `blockchain::block_chain::fetch_spend`
- Return type goes from `awaitable_expected<input_point>` to `awaitable_expected<input_point_opt>` so asio's coroutine machinery can default-construct the result slot during suspension (the inner `expected<input_point>` needed a default ctor of `input_point` = `point`, which is gone).
- Semantics preserved: errors still surface as `std::unexpected`, found prevouts as the populated optional.

### `property_tree(vector<config::input>)`
- Stop routing through `cast<config::input, chain::input>`. The existing `property_list(config::input)` overload makes the conversion unnecessary, and avoiding it removes the implicit default-construction inside `cast<>`'s vector resize.

## C-API

- `point`, `input_point`, `output_point`, `input`, `double_spend_proof` regenerated by the kth-tools generator (no hand edits): the now-gone `construct_default` / `is_valid` / `reset` entry points drop out automatically.
- C-API tests updated by hand to use `_null()` factories in place of `construct_default`, and to remove the `is_valid()` assertions that no longer apply.

## Numbers

49 files changed, ~155 insertions / 604 deletions — net **−449 LOC**.

## Test plan
- [x] Local build green across `consensus`, `infrastructure`, `domain`, `network`, `database`, `blockchain`, `node`, `node-exe`, `c-api`
- [ ] CI green
- [ ] IBD smoke test (after CI)