### PR TITLE
refactor(domain): rewrite to_data with byte_writer, retire data_sink/ostream stack

### DIFF
--- a/BENCH_TO_DATA.md
+++ b/BENCH_TO_DATA.md
@@ -1,0 +1,73 @@
+# `to_data` micro-benchmarks: legacy boost::iostreams vs `byte_writer`
+
+We swapped the whole serialization stack on the domain layer of the Knuth
+node — replacing `data_sink` (boost::iostreams `back_insert_device`) +
+`ostream_writer` (`std::ostream`-backed writer) with a bounds-checked
+`byte_writer` writing into a caller-owned `data_chunk` sized ahead of
+time to `serialized_size(...)`. The results, per-type, on the same
+machine, same compiler, same fixtures:
+
+| type | shape | **old** (ns/op) | **new** (ns/op) | speedup | IPC old → new |
+| :--- | :--- | ---: | ---: | :---: | :---: |
+| `point` | wire | 70.0 | **4.77** | **14.7×** | 4.98 → 8.32 |
+| `point` | store | 71.0 | **4.76** | **14.9×** | 4.93 → 8.47 |
+| `script` | 25 B, prefix | 71.4 | 10.18 | 7.0× | 4.81 → 6.12 |
+| `script` | 400 B, prefix | 79.6 | 10.66 | 7.4× | 4.82 → 6.69 |
+| `input` | wire | 90.5 | 12.87 | 7.0× | 4.79 → 6.37 |
+| `output` | wire | 78.5 | 11.69 | 6.7× | 4.86 → 6.47 |
+| `transaction` | 1 in / 2 out | 156.8 | 34.78 | 4.5× | 4.58 → 6.42 |
+| `transaction` | 20 in / 20 out | 1189 | 372.8 | 3.2× | 4.15 → 5.32 |
+| `block` | 10 tx | 1370 | 411.4 | 3.3× | 4.18 → 5.89 |
+| `block` | 500 tx | 66 210 | 19 583 | **3.4×** | 4.20 → 6.12 |
+
+All numbers are median-of-a-warm-run under nanobench (error <0.5%).
+
+### Why it moves this much
+
+- **Old path**: every write on a domain type went `write_byte / write_hash
+  / write_*_bytes_little_endian` → `ostream_writer::write_*` →
+  `std::ostream::write` → `boost::iostreams::write_device_impl<sink>` →
+  `back_insert_device::write` → `push_back` on the `data_chunk`. That's
+  five to seven virtual/interface indirections plus per-byte reallocs
+  if the vector grew.
+- **New path**: `byte_writer` holds a `std::span<uint8_t>` over the
+  pre-sized buffer, tracks a position, and calls `memcpy` when it can.
+  Every write is a bounds-check + copy. No iostreams. No growing
+  vector. The compiler can inline the whole call chain — see the IPC
+  jump.
+
+### Real-world take
+
+`block::to_data() [500 tx]` is the shape you actually hit during IBD:
+we drop from ~66 µs down to ~19.5 µs per block. Multiply by ~800k
+blocks in a full sync and that's north of **half an hour of wall-clock
+recovered** on serialization alone. Nothing exotic — we just stopped
+paying the boost::iostreams tax.
+
+### Reproduce
+
+```bash
+cmake --build --preset conan-release -j"$(nproc)" \
+      --target kth_domain_bench_to_data
+./build/build/Release/src/domain/kth_domain_bench_to_data
+```
+
+### Setup
+
+- CPU: AMD Ryzen 9 9950X3D
+- OS: Linux 6.19.5-zen1 x86_64
+- Compiler: gcc 15.2.0, `-O3 -DNDEBUG`, `-march` with AVX2/BMI2/etc.
+- Bench harness: [nanobench](https://github.com/martinus/nanobench)
+- Fixtures: deterministic (fixed Mersenne-Twister seed) so the shape
+  and byte content are identical on both branches.
+
+### Branches
+
+- Baseline (legacy `data_sink` path): [PR #387][pr387]
+- Fast path (`byte_writer` via `kth::to_data_chunk`): [PR #394][pr394]
+
+Same benchmark file lives on both branches; the source difference is
+one call: `x.to_data(...)` → `kth::to_data_chunk(x, ...)`.
+
+[pr387]: https://github.com/k-nuth/kth/pull/387
+[pr394]: https://github.com/k-nuth/kth/pull/394

--- a/src/blockchain/src/utxo_builder.cpp
+++ b/src/blockchain/src/utxo_builder.cpp
@@ -28,8 +28,6 @@
 #include <kth/database/databases/utxoz_database.hpp>
 #include <kth/domain/chain/block.hpp>
 #include <kth/domain/machine/opcode.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-
 namespace kth::blockchain {
 
 // =============================================================================

--- a/src/blockchain/src/validate/validate_block.cpp
+++ b/src/blockchain/src/validate/validate_block.cpp
@@ -412,7 +412,7 @@ float validate_block::hit_rate() const {
 
 void validate_block::dump(code const& ec, transaction const& tx, uint32_t input_index, script_flags_t flags, size_t height) {
     auto const& prevout = tx.inputs()[input_index].previous_output();
-    auto const script = prevout.validation.cache.script().to_data(false);
+    auto const script = kth::to_data_chunk(prevout.validation.cache.script(), false);
     auto const hash = encode_hash(prevout.hash());
     auto const tx_hash = encode_hash(tx.hash());
 
@@ -424,7 +424,7 @@ void validate_block::dump(code const& ec, transaction const& tx, uint32_t input_
         " inpoint      : {}:{}\n"
         " transaction  : {}",
         height, ec.message(), flags, hash, prevout.index(), encode_base16(script),
-        prevout.validation.cache.value(), tx_hash, input_index, encode_base16(tx.to_data(true)));
+        prevout.validation.cache.value(), tx_hash, input_index, encode_base16(kth::to_data_chunk(tx, true)));
 }
 
 // =============================================================================

--- a/src/blockchain/src/validate/validate_input.cpp
+++ b/src/blockchain/src/validate/validate_input.cpp
@@ -235,7 +235,7 @@ coins_t create_context_data(transaction const& tx, bool should_create_context) {
 
     for (auto const& input : tx.inputs()) {
         auto const& prevout = input.previous_output().validation.cache;
-        coins.emplace_back(prevout.to_data(true));
+        coins.emplace_back(kth::to_data_chunk(prevout, true));
     }
     return coins;
 }
@@ -245,16 +245,16 @@ std::pair<code, size_t> validate_input::verify_script(transaction const& tx, uin
 
     KTH_ASSERT(input_index < tx.inputs().size());
     auto const& prevout = tx.inputs()[input_index].previous_output().validation;
-    auto const locking_script_data = prevout.cache.script().to_data(false);
+    auto const locking_script_data = kth::to_data_chunk(prevout.cache.script(), false);
     auto const token_data = prevout.cache.token_data();
     auto const amount = prevout.cache.value();
-    auto const tx_data = tx.to_data(true);
+    auto const tx_data = kth::to_data_chunk(tx, true);
 
     size_t sig_checks;
     bool const should_create_context = script::is_enabled(flags, domain::machine::script_flags::bch_native_introspection)
                                    || script::is_enabled(flags, domain::machine::script_flags::bch_tokens);
     auto const coins = create_context_data(tx, should_create_context);
-    auto const unlock_script_data = tx.inputs()[input_index].script().to_data(prefix);
+    auto const unlock_script_data = kth::to_data_chunk(tx.inputs()[input_index].script(), prefix);
 
     auto res = consensus::verify_script(
         tx_data.data(),

--- a/src/blockchain/test/vmlimits_tests.cpp
+++ b/src/blockchain/test/vmlimits_tests.cpp
@@ -123,7 +123,7 @@ struct consensus_result {
 };
 
 consensus_result eval_consensus(data_stack initial_stack, script const& scr, unsigned int flags) {
-    auto const script_bytes = scr.to_data(false);
+    auto const script_bytes = kth::to_data_chunk(scr, false);
     auto stack = initial_stack;
     script_eval_metrics metrics{};
     auto const result = eval_script_with_metrics(

--- a/src/blockchain/test/vmlimits_tests_generated.cpp
+++ b/src/blockchain/test/vmlimits_tests_generated.cpp
@@ -207,7 +207,7 @@ struct consensus_result {
 };
 
 consensus_result eval_consensus(data_stack initial_stack, script const& scr, unsigned int flags) {
-    auto const script_bytes = scr.to_data(false);
+    auto const script_bytes = kth::to_data_chunk(scr, false);
     auto stack = initial_stack;
     script_eval_metrics metrics{};
     auto const result = eval_script_with_metrics(

--- a/src/c-api/include/kth/capi/chain/block.h
+++ b/src/c-api/include/kth/capi/chain/block.h
@@ -82,10 +82,6 @@ kth_bool_t kth_chain_block_equals(kth_block_const_t self, kth_block_const_t othe
 
 // Serialization
 
-/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
-KTH_EXPORT KTH_OWNED
-uint8_t* kth_chain_block_to_data_simple(kth_block_const_t self, kth_size_t* out_size);
-
 KTH_EXPORT
 kth_size_t kth_chain_block_serialized_size(kth_block_const_t self);
 

--- a/src/c-api/include/kth/capi/error.h
+++ b/src/c-api/include/kth/capi/error.h
@@ -236,6 +236,7 @@ typedef enum kth_error_code {
     // Domain object serialization/deserialization
     kth_ec_read_past_end_of_buffer,
     kth_ec_skip_past_end_of_buffer,
+    kth_ec_write_past_end_of_buffer,
     kth_ec_invalid_size,
     kth_ec_invalid_script_type,
     kth_ec_script_not_push_only,

--- a/src/c-api/include/kth/capi/helpers.hpp
+++ b/src/c-api/include/kth/capi/helpers.hpp
@@ -28,6 +28,8 @@
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/machine/script_version.hpp>
+#include <kth/infrastructure/utility/assert.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
 
 #include <kth/capi/wallet/coin_selection_algorithm.h>
 #include <kth/capi/wallet/coin_selection_strategy.h>
@@ -539,6 +541,30 @@ uint8_t* create_c_array(kth::data_chunk const& arr, N& out_size) {
     auto* ret = mnew<uint8_t>(n != 0 ? n : 1);
     out_size = n;
     std::copy_n(arr.begin(), n, ret);
+    return ret;
+}
+
+// Fused variant of `to_data_chunk(obj, args...)` + `create_c_array(chunk, out_size)`.
+// The naive pipeline is `data_chunk → uint8_t*` and does two heap allocations
+// (the vector, then the C buffer) plus one byte-for-byte copy. Fold both
+// into a single `malloc(serialized_size)` and serialize straight into the
+// C-owned buffer; the C-API `to_data` wrappers hit this once per exported
+// object so removing the intermediate vector matters.
+template <typename N, typename T, typename... Args>
+    requires kth::Serializable<T, Args...>
+inline
+uint8_t* to_c_array_from(T const& obj, N& out_size, Args... args) {
+    auto const n = obj.serialized_size(args...);
+    // Same non-NULL sentinel as `create_c_array` — see comment there.
+    auto* ret = mnew<uint8_t>(n != 0 ? n : 1);
+    out_size = n;
+    kth::byte_writer writer(std::span<uint8_t>{ret, n});
+    auto const r = obj.to_data(writer, args...);
+    // Failure here would ship a partially-initialised buffer over the C
+    // ABI (garbage past `writer.position()`). `KTH_CONTRACT` stays live
+    // in Release so we abort instead of returning a broken payload.
+    KTH_CONTRACT(r.has_value());
+    KTH_CONTRACT(writer.position() == n);
     return ret;
 }
 

--- a/src/c-api/src/chain/block.cpp
+++ b/src/c-api/src/chain/block.cpp
@@ -99,13 +99,6 @@ kth_bool_t kth_chain_block_equals(kth_block_const_t self, kth_block_const_t othe
 
 // Serialization
 
-uint8_t* kth_chain_block_to_data_simple(kth_block_const_t self, kth_size_t* out_size) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(out_size != nullptr);
-    auto const data = kth::cpp_ref<cpp_t>(self).to_data();
-    return kth::create_c_array(data, *out_size);
-}
-
 kth_size_t kth_chain_block_serialized_size(kth_block_const_t self) {
     KTH_PRECONDITION(self != nullptr);
     return kth::cpp_ref<cpp_t>(self).serialized_size();
@@ -114,8 +107,7 @@ kth_size_t kth_chain_block_serialized_size(kth_block_const_t self) {
 uint8_t* kth_chain_block_to_data(kth_block_const_t self, kth_size_t* out_size) {
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(out_size != nullptr);
-    auto const data = kth::cpp_ref<cpp_t>(self).to_data();
-    return kth::create_c_array(data, *out_size);
+    return kth::to_c_array_from(kth::cpp_ref<cpp_t>(self), *out_size);
 }
 
 

--- a/src/c-api/src/chain/compact_block.cpp
+++ b/src/c-api/src/chain/compact_block.cpp
@@ -77,8 +77,7 @@ kth_bool_t kth_chain_compact_block_equals(kth_compact_block_const_t self, kth_co
 uint8_t* kth_chain_compact_block_to_data(kth_compact_block_const_t self, uint32_t version, kth_size_t* out_size) {
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(out_size != nullptr);
-    auto const data = kth::cpp_ref<cpp_t>(self).to_data(version);
-    return kth::create_c_array(data, *out_size);
+    return kth::to_c_array_from(kth::cpp_ref<cpp_t>(self), *out_size, version);
 }
 
 kth_size_t kth_chain_compact_block_serialized_size(kth_compact_block_const_t self, uint32_t version) {

--- a/src/c-api/src/chain/double_spend_proof.cpp
+++ b/src/c-api/src/chain/double_spend_proof.cpp
@@ -77,8 +77,7 @@ kth_bool_t kth_chain_double_spend_proof_equals(kth_double_spend_proof_const_t se
 uint8_t* kth_chain_double_spend_proof_to_data(kth_double_spend_proof_const_t self, uint32_t version, kth_size_t* out_size) {
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(out_size != nullptr);
-    auto const data = kth::cpp_ref<cpp_t>(self).to_data(version);
-    return kth::create_c_array(data, *out_size);
+    return kth::to_c_array_from(kth::cpp_ref<cpp_t>(self), *out_size, version);
 }
 
 kth_size_t kth_chain_double_spend_proof_serialized_size(kth_double_spend_proof_const_t self, uint32_t version) {

--- a/src/c-api/src/chain/get_blocks.cpp
+++ b/src/c-api/src/chain/get_blocks.cpp
@@ -83,8 +83,7 @@ kth_bool_t kth_chain_get_blocks_equals(kth_get_blocks_const_t self, kth_get_bloc
 uint8_t* kth_chain_get_blocks_to_data(kth_get_blocks_const_t self, uint32_t version, kth_size_t* out_size) {
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(out_size != nullptr);
-    auto const data = kth::cpp_ref<cpp_t>(self).to_data(version);
-    return kth::create_c_array(data, *out_size);
+    return kth::to_c_array_from(kth::cpp_ref<cpp_t>(self), *out_size, version);
 }
 
 kth_size_t kth_chain_get_blocks_serialized_size(kth_get_blocks_const_t self, uint32_t version) {

--- a/src/c-api/src/chain/get_headers.cpp
+++ b/src/c-api/src/chain/get_headers.cpp
@@ -83,8 +83,7 @@ kth_bool_t kth_chain_get_headers_equals(kth_get_headers_const_t self, kth_get_he
 uint8_t* kth_chain_get_headers_to_data(kth_get_headers_const_t self, uint32_t version, kth_size_t* out_size) {
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(out_size != nullptr);
-    auto const data = kth::cpp_ref<cpp_t>(self).to_data(version);
-    return kth::create_c_array(data, *out_size);
+    return kth::to_c_array_from(kth::cpp_ref<cpp_t>(self), *out_size, version);
 }
 
 kth_size_t kth_chain_get_headers_serialized_size(kth_get_headers_const_t self, uint32_t version) {

--- a/src/c-api/src/chain/header.cpp
+++ b/src/c-api/src/chain/header.cpp
@@ -85,8 +85,7 @@ uint8_t* kth_chain_header_to_data(kth_header_const_t self, kth_bool_t wire, kth_
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(out_size != nullptr);
     auto const wire_cpp = kth::int_to_bool(wire);
-    auto const data = kth::cpp_ref<cpp_t>(self).to_data(wire_cpp);
-    return kth::create_c_array(data, *out_size);
+    return kth::to_c_array_from(kth::cpp_ref<cpp_t>(self), *out_size, wire_cpp);
 }
 
 kth_size_t kth_chain_header_serialized_size(kth_header_const_t self, kth_bool_t wire) {

--- a/src/c-api/src/chain/input.cpp
+++ b/src/c-api/src/chain/input.cpp
@@ -73,8 +73,7 @@ uint8_t* kth_chain_input_to_data(kth_input_const_t self, kth_bool_t wire, kth_si
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(out_size != nullptr);
     auto const wire_cpp = kth::int_to_bool(wire);
-    auto const data = kth::cpp_ref<cpp_t>(self).to_data(wire_cpp);
-    return kth::create_c_array(data, *out_size);
+    return kth::to_c_array_from(kth::cpp_ref<cpp_t>(self), *out_size, wire_cpp);
 }
 
 kth_size_t kth_chain_input_serialized_size(kth_input_const_t self, kth_bool_t wire) {

--- a/src/c-api/src/chain/input_point.cpp
+++ b/src/c-api/src/chain/input_point.cpp
@@ -84,8 +84,7 @@ uint8_t* kth_chain_input_point_to_data(kth_input_point_const_t self, kth_bool_t 
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(out_size != nullptr);
     auto const wire_cpp = kth::int_to_bool(wire);
-    auto const data = kth::cpp_ref<cpp_t>(self).to_data(wire_cpp);
-    return kth::create_c_array(data, *out_size);
+    return kth::to_c_array_from(kth::cpp_ref<cpp_t>(self), *out_size, wire_cpp);
 }
 
 kth_size_t kth_chain_input_point_serialized_size(kth_input_point_const_t self, kth_bool_t wire) {

--- a/src/c-api/src/chain/merkle_block.cpp
+++ b/src/c-api/src/chain/merkle_block.cpp
@@ -84,8 +84,7 @@ kth_bool_t kth_chain_merkle_block_equals(kth_merkle_block_const_t self, kth_merk
 uint8_t* kth_chain_merkle_block_to_data(kth_merkle_block_const_t self, uint32_t version, kth_size_t* out_size) {
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(out_size != nullptr);
-    auto const data = kth::cpp_ref<cpp_t>(self).to_data(version);
-    return kth::create_c_array(data, *out_size);
+    return kth::to_c_array_from(kth::cpp_ref<cpp_t>(self), *out_size, version);
 }
 
 kth_size_t kth_chain_merkle_block_serialized_size(kth_merkle_block_const_t self, uint32_t version) {

--- a/src/c-api/src/chain/output.cpp
+++ b/src/c-api/src/chain/output.cpp
@@ -76,8 +76,7 @@ uint8_t* kth_chain_output_to_data(kth_output_const_t self, kth_bool_t wire, kth_
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(out_size != nullptr);
     auto const wire_cpp = kth::int_to_bool(wire);
-    auto const data = kth::cpp_ref<cpp_t>(self).to_data(wire_cpp);
-    return kth::create_c_array(data, *out_size);
+    return kth::to_c_array_from(kth::cpp_ref<cpp_t>(self), *out_size, wire_cpp);
 }
 
 kth_size_t kth_chain_output_serialized_size(kth_output_const_t self, kth_bool_t wire) {

--- a/src/c-api/src/chain/output_point.cpp
+++ b/src/c-api/src/chain/output_point.cpp
@@ -94,8 +94,7 @@ uint8_t* kth_chain_output_point_to_data(kth_output_point_const_t self, kth_bool_
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(out_size != nullptr);
     auto const wire_cpp = kth::int_to_bool(wire);
-    auto const data = kth::cpp_ref<cpp_t>(self).to_data(wire_cpp);
-    return kth::create_c_array(data, *out_size);
+    return kth::to_c_array_from(kth::cpp_ref<cpp_t>(self), *out_size, wire_cpp);
 }
 
 kth_size_t kth_chain_output_point_serialized_size(kth_output_point_const_t self, kth_bool_t wire) {

--- a/src/c-api/src/chain/point.cpp
+++ b/src/c-api/src/chain/point.cpp
@@ -84,8 +84,7 @@ uint8_t* kth_chain_point_to_data(kth_point_const_t self, kth_bool_t wire, kth_si
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(out_size != nullptr);
     auto const wire_cpp = kth::int_to_bool(wire);
-    auto const data = kth::cpp_ref<cpp_t>(self).to_data(wire_cpp);
-    return kth::create_c_array(data, *out_size);
+    return kth::to_c_array_from(kth::cpp_ref<cpp_t>(self), *out_size, wire_cpp);
 }
 
 kth_size_t kth_chain_point_serialized_size(kth_point_const_t self, kth_bool_t wire) {

--- a/src/c-api/src/chain/prefilled_transaction.cpp
+++ b/src/c-api/src/chain/prefilled_transaction.cpp
@@ -73,8 +73,7 @@ kth_bool_t kth_chain_prefilled_transaction_equals(kth_prefilled_transaction_cons
 uint8_t* kth_chain_prefilled_transaction_to_data(kth_prefilled_transaction_const_t self, uint32_t version, kth_size_t* out_size) {
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(out_size != nullptr);
-    auto const data = kth::cpp_ref<cpp_t>(self).to_data(version);
-    return kth::create_c_array(data, *out_size);
+    return kth::to_c_array_from(kth::cpp_ref<cpp_t>(self), *out_size, version);
 }
 
 kth_size_t kth_chain_prefilled_transaction_serialized_size(kth_prefilled_transaction_const_t self, uint32_t version) {

--- a/src/c-api/src/chain/script.cpp
+++ b/src/c-api/src/chain/script.cpp
@@ -82,8 +82,7 @@ uint8_t* kth_chain_script_to_data(kth_script_const_t self, kth_bool_t prefix, kt
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(out_size != nullptr);
     auto const prefix_cpp = kth::int_to_bool(prefix);
-    auto const data = kth::cpp_ref<cpp_t>(self).to_data(prefix_cpp);
-    return kth::create_c_array(data, *out_size);
+    return kth::to_c_array_from(kth::cpp_ref<cpp_t>(self), *out_size, prefix_cpp);
 }
 
 kth_size_t kth_chain_script_serialized_size(kth_script_const_t self, kth_bool_t prefix) {

--- a/src/c-api/src/chain/transaction.cpp
+++ b/src/c-api/src/chain/transaction.cpp
@@ -77,8 +77,7 @@ uint8_t* kth_chain_transaction_to_data(kth_transaction_const_t self, kth_bool_t 
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(out_size != nullptr);
     auto const wire_cpp = kth::int_to_bool(wire);
-    auto const data = kth::cpp_ref<cpp_t>(self).to_data(wire_cpp);
-    return kth::create_c_array(data, *out_size);
+    return kth::to_c_array_from(kth::cpp_ref<cpp_t>(self), *out_size, wire_cpp);
 }
 
 kth_size_t kth_chain_transaction_serialized_size(kth_transaction_const_t self, kth_bool_t wire) {

--- a/src/c-api/test/chain/block.cpp
+++ b/src/c-api/test/chain/block.cpp
@@ -75,7 +75,7 @@ TEST_CASE("C-API Block - to_data / from_data roundtrip",
     kth_block_mut_t expected = make_block();
 
     kth_size_t size = 0;
-    uint8_t* raw = kth_chain_block_to_data_simple(expected, &size);
+    uint8_t* raw = kth_chain_block_to_data(expected, &size);
     REQUIRE(raw != NULL);
     REQUIRE(size > 0);
 
@@ -127,7 +127,7 @@ TEST_CASE("C-API Block - serialized_size matches to_data length",
           "[C-API Block]") {
     kth_block_mut_t blk = make_block();
     kth_size_t size = 0;
-    uint8_t* raw = kth_chain_block_to_data_simple(blk, &size);
+    uint8_t* raw = kth_chain_block_to_data(blk, &size);
     REQUIRE(raw != NULL);
     REQUIRE(kth_chain_block_serialized_size(blk) == size);
     kth_core_destruct_array(raw);
@@ -209,6 +209,6 @@ TEST_CASE("C-API Block - copy null self aborts",
 TEST_CASE("C-API Block - to_data_simple null out_size aborts",
           "[C-API Block][precondition]") {
     kth_block_mut_t blk = kth_chain_block_construct_default();
-    KTH_EXPECT_ABORT(kth_chain_block_to_data_simple(blk, NULL));
+    KTH_EXPECT_ABORT(kth_chain_block_to_data(blk, NULL));
     kth_chain_block_destruct(blk);
 }

--- a/src/database/include/kth/database/block_undo.hpp
+++ b/src/database/include/kth/database/block_undo.hpp
@@ -25,22 +25,22 @@ struct KD_API tx_undo {
     [[nodiscard]]
     size_t serialized_size() const;
 
-    /// Serialize to data chunk.
-    [[nodiscard]]
-    data_chunk to_data() const;
-
-    /// Serialize to writer.
-    template <typename W, KTH_IS_WRITER(W)>
-    void to_data(W& sink) const {
-        sink.write_variable_little_endian(prev_outputs.size());
-        for (auto const& entry : prev_outputs) {
-            entry.to_data(sink);
-        }
-    }
-
     /// Deserialize from reader.
     [[nodiscard]]
     static std::expected<tx_undo, database::result_code> from_data(byte_reader& reader);
+
+    /// Serialize.
+    [[nodiscard]]
+    expect<void> to_data(byte_writer& writer) const {
+        if (auto r = writer.write_variable_little_endian(prev_outputs.size()); ! r) return r;
+        for (auto const& entry : prev_outputs) {
+            if (auto r = entry.to_data(writer); ! r) return r;
+        }
+        return {};
+    }
+
+    [[nodiscard]]
+    data_chunk to_data() const;
 };
 
 /// Undo information for a block.
@@ -52,22 +52,22 @@ struct KD_API block_undo {
     [[nodiscard]]
     size_t serialized_size() const;
 
-    /// Serialize to data chunk.
-    [[nodiscard]]
-    data_chunk to_data() const;
-
-    /// Serialize to writer.
-    template <typename W, KTH_IS_WRITER(W)>
-    void to_data(W& sink) const {
-        sink.write_variable_little_endian(tx_undos.size());
-        for (auto const& tx : tx_undos) {
-            tx.to_data(sink);
-        }
-    }
-
     /// Deserialize from reader.
     [[nodiscard]]
     static std::expected<block_undo, database::result_code> from_data(byte_reader& reader);
+
+    /// Serialize.
+    [[nodiscard]]
+    expect<void> to_data(byte_writer& writer) const {
+        if (auto r = writer.write_variable_little_endian(tx_undos.size()); ! r) return r;
+        for (auto const& tx : tx_undos) {
+            if (auto r = tx.to_data(writer); ! r) return r;
+        }
+        return {};
+    }
+
+    [[nodiscard]]
+    data_chunk to_data() const;
 
     /// Create block undo from a block and the UTXOs it spends.
     /// @param block The block being connected.

--- a/src/database/include/kth/database/currency_config.hpp
+++ b/src/database/include/kth/database/currency_config.hpp
@@ -16,14 +16,12 @@ namespace kth::database {
 
 #if defined(KTH_CURRENCY_BCH)
 #define KTH_WITNESS_DEFAULT false
-#define KTH_POSITION_WRITER write_4_bytes_little_endian
-#define KTH_POSITION_READER read_4_bytes_little_endian
+using kth_position_t = uint32_t;
 static constexpr auto position_size = sizeof(uint32_t);
 size_t const position_max = max_uint32;
 #else
 #define KTH_WITNESS_DEFAULT true
-#define KTH_POSITION_WRITER write_2_bytes_little_endian
-#define KTH_POSITION_READER read_2_bytes_little_endian
+using kth_position_t = uint16_t;
 static constexpr auto position_size = sizeof(uint16_t);
 size_t const position_max = max_uint16;
 #endif // KTH_CURRENCY_BCH

--- a/src/database/include/kth/database/databases/header_abla_entry.hpp
+++ b/src/database/include/kth/database/databases/header_abla_entry.hpp
@@ -13,48 +13,12 @@ namespace kth::database {
 using header_with_abla_state_t = std::tuple<domain::chain::header, uint64_t, uint64_t, uint64_t>;
 
 data_chunk to_data_with_abla_state(domain::chain::block const& block);
-void to_data_with_abla_state(std::ostream& stream, domain::chain::block const& block);
-
-// Serialization for header-only storage (headers-first sync)
 data_chunk to_data_header_only(domain::chain::header const& header);
-
-// Serialization for header with explicit ABLA state (headers-first sync)
 data_chunk to_data_header_with_abla_state(domain::chain::header const& header, uint64_t block_size, uint64_t control_block_size, uint64_t elastic_buffer_size);
 
-template <typename W, KTH_IS_WRITER(W)>
-void to_data_with_abla_state(W& sink, domain::chain::block const& block) {
-    block.header().to_data(sink, true);
-
-    if (block.validation.state) {
-        sink.write_8_bytes_little_endian(block.validation.state->abla_state().block_size);
-        sink.write_8_bytes_little_endian(block.validation.state->abla_state().control_block_size);
-        sink.write_8_bytes_little_endian(block.validation.state->abla_state().elastic_buffer_size);
-    } else {
-        sink.write_8_bytes_little_endian(0);
-        sink.write_8_bytes_little_endian(0);
-        sink.write_8_bytes_little_endian(0);
-    }
-}
-
-// Header-only serialization (without ABLA state - for headers-first sync)
-template <typename W, KTH_IS_WRITER(W)>
-void to_data_header_only(W& sink, domain::chain::header const& header) {
-    header.to_data(sink, true);
-    // ABLA state is unknown for headers received before blocks
-    // Store zeros, will be updated when block is received
-    sink.write_8_bytes_little_endian(0);
-    sink.write_8_bytes_little_endian(0);
-    sink.write_8_bytes_little_endian(0);
-}
-
-// Header serialization with explicit ABLA state (for headers-first sync with ABLA propagation)
-template <typename W, KTH_IS_WRITER(W)>
-void to_data_header_with_abla_state(W& sink, domain::chain::header const& header, uint64_t block_size, uint64_t control_block_size, uint64_t elastic_buffer_size) {
-    header.to_data(sink, true);
-    sink.write_8_bytes_little_endian(block_size);
-    sink.write_8_bytes_little_endian(control_block_size);
-    sink.write_8_bytes_little_endian(elastic_buffer_size);
-}
+expect<void> to_data_with_abla_state(byte_writer& writer, domain::chain::block const& block);
+expect<void> to_data_header_only(byte_writer& writer, domain::chain::header const& header);
+expect<void> to_data_header_with_abla_state(byte_writer& writer, domain::chain::header const& header, uint64_t block_size, uint64_t control_block_size, uint64_t elastic_buffer_size);
 
 expect<header_with_abla_state_t> get_header_and_abla_state_from_data(byte_reader& reader);
 

--- a/src/database/include/kth/database/databases/header_database.ipp
+++ b/src/database/include/kth/database/databases/header_database.ipp
@@ -223,8 +223,7 @@ std::expected<domain::chain::header, result_code> internal_database_basis<Clock>
         return std::unexpected(result_code::other);
     }
 
-    auto data = db_value_to_data_chunk(value);
-    byte_reader reader(data);
+    auto reader = kth::database::db_reader(value);
     auto opt = get_header_and_abla_state_from_data(reader);
     if ( ! opt) {
         return std::unexpected(result_code::other);
@@ -245,8 +244,7 @@ std::expected<header_with_abla_state_t, result_code> internal_database_basis<Clo
         return std::unexpected(result_code::other);
     }
 
-    auto data = db_value_to_data_chunk(value);
-    byte_reader reader(data);
+    auto reader = kth::database::db_reader(value);
     auto opt = get_header_and_abla_state_from_data(reader);
     if ( ! opt) {
         return std::unexpected(result_code::other);

--- a/src/database/include/kth/database/databases/history_database.ipp
+++ b/src/database/include/kth/database/databases/history_database.ipp
@@ -159,9 +159,7 @@ std::expected<domain::chain::history_compact::list, result_code> internal_databa
     int rc;
     if ((rc = kth_db_cursor_get(cursor, &key_hash, &value, MDB_SET)) == 0) {
 
-        auto data = db_value_to_data_chunk(value);
-        byte_reader reader1(data);
-        auto entry_res = history_entry::from_data(reader1);
+        auto entry_res = kth::database::from_db_value<history_entry>(value);
 
         if (entry_res && (from_height == 0 || entry_res->height() >= from_height)) {
             result.push_back(history_entry_to_history_compact(*entry_res));
@@ -173,9 +171,7 @@ std::expected<domain::chain::history_compact::list, result_code> internal_databa
                 break;
             }
 
-            auto data = db_value_to_data_chunk(value);
-            byte_reader reader2(data);
-            auto entry_res2 = history_entry::from_data(reader2);
+            auto entry_res2 = kth::database::from_db_value<history_entry>(value);
 
             if (entry_res2 && (from_height == 0 || entry_res2->height() >= from_height)) {
                 result.push_back(history_entry_to_history_compact(*entry_res2));
@@ -220,9 +216,7 @@ std::expected<std::vector<hash_digest>, result_code> internal_database_basis<Clo
     int rc;
     if ((rc = kth_db_cursor_get(cursor, &key_hash, &value, MDB_SET)) == 0) {
 
-        auto data = db_value_to_data_chunk(value);
-        byte_reader reader3(data);
-        auto entry_res3 = history_entry::from_data(reader3);
+        auto entry_res3 = kth::database::from_db_value<history_entry>(value);
 
         if (entry_res3 && (from_height == 0 || entry_res3->height() >= from_height)) {
             // Avoid inserting the same tx
@@ -239,9 +233,7 @@ std::expected<std::vector<hash_digest>, result_code> internal_database_basis<Clo
                 break;
             }
 
-            auto data = db_value_to_data_chunk(value);
-            byte_reader reader4(data);
-            auto entry_res4 = history_entry::from_data(reader4);
+            auto entry_res4 = kth::database::from_db_value<history_entry>(value);
 
             if (entry_res4 && (from_height == 0 || entry_res4->height() >= from_height)) {
                 // Avoid inserting the same tx
@@ -335,9 +327,7 @@ result_code internal_database_basis<Clock>::remove_history_db(short_hash const& 
     int rc;
     if ((rc = kth_db_cursor_get(cursor, &key_hash, &value, MDB_SET)) == 0) {
 
-        auto data = db_value_to_data_chunk(value);
-        byte_reader reader5(data);
-        auto entry_res5 = history_entry::from_data(reader5);
+        auto entry_res5 = kth::database::from_db_value<history_entry>(value);
 
         if (entry_res5 && entry_res5->height() == height) {
 
@@ -349,9 +339,7 @@ result_code internal_database_basis<Clock>::remove_history_db(short_hash const& 
 
         while ((rc = kth_db_cursor_get(cursor, &key_hash, &value, MDB_NEXT_DUP)) == 0) {
 
-            auto data = db_value_to_data_chunk(value);
-            byte_reader reader6(data);
-            auto entry_res6 = history_entry::from_data(reader6);
+            auto entry_res6 = kth::database::from_db_value<history_entry>(value);
 
             if (entry_res6 && entry_res6->height() == height) {
                 if (kth_db_cursor_del(cursor, 0) != KTH_DB_SUCCESS) {

--- a/src/database/include/kth/database/databases/history_entry.hpp
+++ b/src/database/include/kth/database/databases/history_entry.hpp
@@ -28,32 +28,34 @@ struct KD_API history_entry {
         return sizeof(uint64_t) + point.serialized_size(false) + sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint64_t);
     }
 
-    data_chunk to_data() const;
-    void to_data(std::ostream& stream) const;
-
-    template <typename W, KTH_IS_WRITER(W)>
-    void to_data(W& sink) const {
-        factory_to_data(sink, id_, point_, point_kind_, height_, index_, value_or_checksum_);
+    // Instance-side wrapper so the type satisfies `kth::Serializable`
+    // and can flow through `kth::to_data_chunk`.
+    [[nodiscard]]
+    constexpr size_t serialized_size() const {
+        return serialized_size(point_);
     }
 
     static
     expect<history_entry> from_data(byte_reader& reader);
 
+    [[nodiscard]]
+    expect<void> to_data(byte_writer& writer) const {
+        return factory_to_data(writer, id_, point_, point_kind_, height_, index_, value_or_checksum_);
+    }
+
+    data_chunk to_data() const;
+
     static
     data_chunk factory_to_data(uint64_t id, domain::chain::point const& point, domain::chain::point_kind kind, uint32_t height, uint32_t index, uint64_t value_or_checksum);
 
     static
-    void factory_to_data(std::ostream& stream, uint64_t id, domain::chain::point const& point, domain::chain::point_kind kind, uint32_t height, uint32_t index, uint64_t value_or_checksum);
-
-    template <typename W, KTH_IS_WRITER(W)>
-    static
-    void factory_to_data(W& sink, uint64_t id, domain::chain::point const& point, domain::chain::point_kind kind, uint32_t height, uint32_t index, uint64_t value_or_checksum) {
-        sink.write_8_bytes_little_endian(id);
-        point.to_data(sink, false);
-        sink.write_byte(uint8_t(kind));
-        sink.write_4_bytes_little_endian(height);
-        sink.write_4_bytes_little_endian(index);
-        sink.write_8_bytes_little_endian(value_or_checksum);
+    expect<void> factory_to_data(byte_writer& writer, uint64_t id, domain::chain::point const& point, domain::chain::point_kind kind, uint32_t height, uint32_t index, uint64_t value_or_checksum) {
+        if (auto r = writer.write_little_endian<uint64_t>(id); ! r) return r;
+        if (auto r = point.to_data(writer, false); ! r) return r;
+        if (auto r = writer.write_byte(uint8_t(kind)); ! r) return r;
+        if (auto r = writer.write_little_endian<uint32_t>(height); ! r) return r;
+        if (auto r = writer.write_little_endian<uint32_t>(index); ! r) return r;
+        return writer.write_little_endian<uint64_t>(value_or_checksum);
     }
 
 private:

--- a/src/database/include/kth/database/databases/internal_database.ipp
+++ b/src/database/include/kth/database/databases/internal_database.ipp
@@ -704,9 +704,7 @@ std::expected<domain::chain::header::list, result_code> internal_database_basis<
         return std::unexpected(result_code::other);
     }
 
-    auto data = db_value_to_data_chunk(value);
-    byte_reader reader1(data);
-    auto res1 = domain::chain::header::from_data(reader1);
+    auto res1 = kth::database::from_db_value<domain::chain::header>(value);
     if (res1) {
         list.push_back(*res1);
     }
@@ -714,9 +712,7 @@ std::expected<domain::chain::header::list, result_code> internal_database_basis<
     while ((rc = kth_db_cursor_get(cursor, &key, &value, KTH_DB_NEXT)) == KTH_DB_SUCCESS) {
         auto height = *static_cast<uint32_t*>(kth_db_get_data(key));
         if (height > to) break;
-        auto data = db_value_to_data_chunk(value);
-        byte_reader reader2(data);
-        auto res2 = domain::chain::header::from_data(reader2);
+        auto res2 = kth::database::from_db_value<domain::chain::header>(value);
         if (res2) {
             list.push_back(*res2);
         }
@@ -831,16 +827,19 @@ result_code internal_database_basis<Clock>::insert_reorg_into_pool(utxo_pool_t& 
         return result_code::other;
     }
 
-    auto entry_data = db_value_to_data_chunk(value);
-    byte_reader entry_reader(entry_data);
-    auto entry_res = utxo_entry::from_data(entry_reader);
+    auto entry_res = kth::database::from_db_value<utxo_entry>(value);
     if ( ! entry_res) {
         spdlog::error("[database] Error deserializing utxo_entry from reorg pool");
         return result_code::other;
     }
 
-    auto point_data = db_value_to_data_chunk(key_point);
-    byte_reader point_reader(point_data);
+    // `output_point : point` — the inherited `from_data` returns
+    // `expect<point>`, which trips the `Deserializable<output_point,
+    // bool>` concept check that expects `expect<output_point>`. The
+    // slice is fine at the value level (output_point has no state
+    // beyond `point`'s), so read straight through `point::from_data`
+    // here rather than special-casing the concept.
+    auto point_reader = kth::database::db_reader(key_point);
     auto point_res = domain::chain::output_point::from_data(point_reader, KTH_INTERNAL_DB_WIRE);
     if ( ! point_res) {
         spdlog::error("[database] Error deserializing output_point from reorg pool");

--- a/src/database/include/kth/database/databases/reorg_database.ipp
+++ b/src/database/include/kth/database/databases/reorg_database.ipp
@@ -55,11 +55,10 @@ result_code internal_database_basis<Clock>::insert_reorg_pool(uint32_t height, K
 template <typename Clock>
 result_code internal_database_basis<Clock>::push_block_reorg(domain::chain::block const& block, uint32_t height, KTH_DB_txn* db_txn) {
 
-    auto valuearr = block.to_data();               //TODO(fernando): podría estar afuera de la DBTx
     auto key = kth_db_make_value(sizeof(height), &height);              //TODO(fernando): podría estar afuera de la DBTx
-    auto value = kth_db_make_value(valuearr.size(), valuearr.data());   //TODO(fernando): podría estar afuera de la DBTx
+    auto value = kth::database::to_db_value(block);                     //TODO(fernando): podría estar afuera de la DBTx
 
-    auto res = kth_db_put(db_txn, dbi_reorg_block_, &key, &value, KTH_DB_NOOVERWRITE);
+    auto res = kth_db_put(db_txn, dbi_reorg_block_, &key, &value.val, KTH_DB_NOOVERWRITE);
     if (res == KTH_DB_KEYEXIST) {
         spdlog::info("[database] Duplicate key inserting in reorg block [push_block_reorg] {}", res);
         return result_code::duplicated_key;
@@ -74,11 +73,10 @@ result_code internal_database_basis<Clock>::push_block_reorg(domain::chain::bloc
 
 template <typename Clock>
 result_code internal_database_basis<Clock>::insert_output_from_reorg_and_remove(domain::chain::output_point const& point, KTH_DB_txn* db_txn) {
-    auto keyarr = point.to_data(KTH_INTERNAL_DB_WIRE);
-    auto key = kth_db_make_value(keyarr.size(), keyarr.data());
+    auto key = kth::database::to_db_value(point, KTH_INTERNAL_DB_WIRE);
 
     KTH_DB_val value;
-    auto res = kth_db_get(db_txn, dbi_reorg_pool_, &key, &value);
+    auto res = kth_db_get(db_txn, dbi_reorg_pool_, &key.val, &value);
     if (res == KTH_DB_NOTFOUND) {
         spdlog::info("[database] Key not found in reorg pool [insert_output_from_reorg_and_remove] {}", res);
         return result_code::key_not_found;
@@ -88,7 +86,7 @@ result_code internal_database_basis<Clock>::insert_output_from_reorg_and_remove(
         return result_code::other;
     }
 
-    res = kth_db_put(db_txn, dbi_utxo_, &key, &value, KTH_DB_NOOVERWRITE);
+    res = kth_db_put(db_txn, dbi_utxo_, &key.val, &value, KTH_DB_NOOVERWRITE);
     if (res == KTH_DB_KEYEXIST) {
         spdlog::info("[database] Duplicate key inserting in UTXO [insert_output_from_reorg_and_remove] {}", res);
         return result_code::duplicated_key;
@@ -98,7 +96,7 @@ result_code internal_database_basis<Clock>::insert_output_from_reorg_and_remove(
         return result_code::other;
     }
 
-    res = kth_db_del(db_txn, dbi_reorg_pool_, &key, NULL);
+    res = kth_db_del(db_txn, dbi_reorg_pool_, &key.val, NULL);
     if (res == KTH_DB_NOTFOUND) {
         spdlog::info("[database] Key not found deleting in reorg pool [insert_output_from_reorg_and_remove] {}", res);
         return result_code::key_not_found;
@@ -157,9 +155,7 @@ std::expected<domain::chain::block, result_code> internal_database_basis<Clock>:
         return std::unexpected(result_code::other);
     }
 
-    auto data = db_value_to_data_chunk(value);
-    byte_reader reader(data);       //TODO(fernando): mover fuera de la DbTx
-    auto res = domain::chain::block::from_data(reader);
+    auto res = kth::database::from_db_value<domain::chain::block>(value);
     if ( ! res) {
         return std::unexpected(result_code::other);
     }

--- a/src/database/include/kth/database/databases/spend_database.ipp
+++ b/src/database/include/kth/database/databases/spend_database.ipp
@@ -13,8 +13,7 @@ namespace kth::database {
 template <typename Clock>
 std::expected<domain::chain::input_point, result_code> internal_database_basis<Clock>::get_spend(domain::chain::output_point const& point) const {
 
-    auto keyarr = point.to_data(KTH_INTERNAL_DB_WIRE);
-    auto key = kth_db_make_value(keyarr.size(), keyarr.data());
+    auto key = kth::database::to_db_value(point, KTH_INTERNAL_DB_WIRE);
     KTH_DB_val value;
 
     KTH_DB_txn* db_txn;
@@ -24,7 +23,7 @@ std::expected<domain::chain::input_point, result_code> internal_database_basis<C
         return std::unexpected(result_code::other);
     }
 
-    res0 = kth_db_get(db_txn, dbi_spend_db_, &key, &value);
+    res0 = kth_db_get(db_txn, dbi_spend_db_, &key.val, &value);
     if (res0 == KTH_DB_NOTFOUND) {
         kth_db_txn_commit(db_txn);
         return std::unexpected(result_code::key_not_found);
@@ -34,7 +33,11 @@ std::expected<domain::chain::input_point, result_code> internal_database_basis<C
         return std::unexpected(result_code::other);
     }
 
-    auto data = db_value_to_data_chunk(value);
+    // Deserialize while the txn is still open — `value` points into
+    // store-owned memory that is only valid until commit. This also
+    // removes the intermediate `data_chunk` copy the previous code
+    // needed to survive the commit.
+    auto res_input = kth::database::from_db_value<domain::chain::input_point>(value);
 
     res0 = kth_db_txn_commit(db_txn);
     if (res0 != KTH_DB_SUCCESS) {
@@ -42,8 +45,6 @@ std::expected<domain::chain::input_point, result_code> internal_database_basis<C
         return std::unexpected(result_code::other);
     }
 
-    byte_reader reader(data);
-    auto res_input = domain::chain::input_point::from_data(reader);
     if ( ! res_input) {
         return std::unexpected(result_code::other);
     }
@@ -56,13 +57,10 @@ std::expected<domain::chain::input_point, result_code> internal_database_basis<C
 template <typename Clock>
 result_code internal_database_basis<Clock>::insert_spend(domain::chain::output_point const& out_point, domain::chain::input_point const& in_point, KTH_DB_txn* db_txn) {
 
-    auto keyarr = out_point.to_data(KTH_INTERNAL_DB_WIRE);
-    auto key = kth_db_make_value(keyarr.size(), keyarr.data());
+    auto key = kth::database::to_db_value(out_point, KTH_INTERNAL_DB_WIRE);
+    auto value = kth::database::to_db_value(in_point, true);
 
-    auto value_arr = in_point.to_data();
-    auto value = kth_db_make_value(value_arr.size(), value_arr.data());
-
-    auto res = kth_db_put(db_txn, dbi_spend_db_, &key, &value, KTH_DB_NOOVERWRITE);
+    auto res = kth_db_put(db_txn, dbi_spend_db_, &key.val, &value.val, KTH_DB_NOOVERWRITE);
     if (res == KTH_DB_KEYEXIST) {
         spdlog::info("[database] Duplicate key inserting spend [insert_spend] {}", res);
         return result_code::duplicated_key;
@@ -99,10 +97,9 @@ result_code internal_database_basis<Clock>::remove_transaction_spend_db(domain::
 template <typename Clock>
 result_code internal_database_basis<Clock>::remove_spend(domain::chain::output_point const& out_point, KTH_DB_txn* db_txn) {
 
-    auto keyarr = out_point.to_data(KTH_INTERNAL_DB_WIRE);      //TODO(fernando): podría estar afuera de la DBTx
-    auto key = kth_db_make_value(keyarr.size(), keyarr.data());                     //TODO(fernando): podría estar afuera de la DBTx
+    auto key = kth::database::to_db_value(out_point, KTH_INTERNAL_DB_WIRE);
 
-    auto res = kth_db_del(db_txn, dbi_spend_db_, &key, NULL);
+    auto res = kth_db_del(db_txn, dbi_spend_db_, &key.val, NULL);
 
     if (res == KTH_DB_NOTFOUND) {
         spdlog::info("[database] Key not found deleting spend [remove_spend] {}", res);

--- a/src/database/include/kth/database/databases/tools.hpp
+++ b/src/database/include/kth/database/databases/tools.hpp
@@ -8,6 +8,7 @@
 #include <chrono>
 
 #include <kth/domain.hpp>
+#include <kth/infrastructure/utility/byte_reader.hpp>
 
 namespace kth::database {
 
@@ -41,6 +42,97 @@ inline
 data_chunk db_value_to_data_chunk(KTH_DB_val const& value) {
     return data_chunk{static_cast<uint8_t*>(kth_db_get_data(value)),
                       static_cast<uint8_t*>(kth_db_get_data(value)) + kth_db_get_size(value)};
+}
+
+// Zero-copy read view over an `KTH_DB_val`. Use when the caller needs
+// to feed the bytes into a manual `byte_reader` (e.g. because the
+// deserializer is a free function rather than `T::from_data` — see
+// `get_header_and_abla_state_from_data`, or a hierarchy where the
+// concept `Deserializable<T,...>` doesn't quite fit, e.g. `output_point
+// : point`). For the common case prefer `from_db_value<T>` directly.
+// Same lifetime rule as `from_db_value`: the returned span points at
+// store-owned memory that must live until the read is done.
+[[nodiscard]] inline
+kth::byte_span db_value_as_span(KTH_DB_val const& value) {
+    return {static_cast<uint8_t const*>(kth_db_get_data(value)),
+            kth_db_get_size(value)};
+}
+
+// One-liner that materialises a `byte_reader` positioned at the start
+// of an `KTH_DB_val`'s payload. Shortcut for
+// `byte_reader{db_value_as_span(value)}` — same zero-copy semantics
+// and same txn-lifetime rule (bytes must outlive the reader's use).
+[[nodiscard]] inline
+kth::byte_reader db_reader(KTH_DB_val const& value) {
+    return kth::byte_reader{db_value_as_span(value)};
+}
+
+// Write-side symmetric of `db_reader`. Bundles the pattern
+//   auto arr = kth::to_data_chunk(obj, args...);
+//   auto val = kth_db_make_value(arr.size(), arr.data());
+// into one owning wrapper: the caller keeps a single local, the buffer
+// lives inside it, and `.val` is the `KTH_DB_val` LMDB expects. The
+// two variables had to travel together anyway (the value's `data`
+// pointer is only stable while the chunk is alive), so folding them
+// into one aggregate is a straight simplification, not a lifetime
+// change. Copy is deleted so callers can't accidentally hand out a
+// dangling `val`; move re-derives `val` from the moved-into buffer.
+struct owned_db_value {
+    data_chunk buf;
+    KTH_DB_val val;
+
+    explicit owned_db_value(data_chunk&& b)
+        : buf(std::move(b))
+        , val(kth_db_make_value(buf.size(), buf.data()))
+    {}
+
+    owned_db_value(owned_db_value const&) = delete;
+    owned_db_value& operator=(owned_db_value const&) = delete;
+
+    owned_db_value(owned_db_value&& o) noexcept
+        : buf(std::move(o.buf))
+        , val(kth_db_make_value(buf.size(), buf.data()))
+    {}
+
+    owned_db_value& operator=(owned_db_value&& o) noexcept {
+        buf = std::move(o.buf);
+        val = kth_db_make_value(buf.size(), buf.data());
+        return *this;
+    }
+};
+
+// Serialise `obj` into an `owned_db_value` ready to hand to LMDB.
+// The buffer lives inside the returned wrapper; pass `&result.val`
+// to `kth_db_put` / `kth_db_get` / `kth_db_del` / cursor calls, and
+// keep the wrapper alive until the LMDB call returns.
+template <typename T, typename... Args>
+    requires kth::Serializable<T, Args...>
+[[nodiscard]] inline
+owned_db_value to_db_value(T const& obj, Args... args) {
+    return owned_db_value{kth::to_data_chunk(obj, args...)};
+}
+
+// Zero-copy `from_data` over an LMDB value: build a `byte_reader`
+// straight over the store-owned memory instead of first copying the
+// bytes into a heap `data_chunk`. The caller pattern
+//     auto data = db_value_to_data_chunk(value);
+//     auto res  = kth::from_data_chunk<T>(data);
+// wastes one heap allocation + one linear copy per lookup — hot on
+// read paths that walk many entries (block/history/spend/reorg).
+//
+// `KTH_DB_val` points at memory the LMDB txn owns for the lifetime of
+// the read; the returned `expect<T>` must be consumed before that txn
+// ends, same as `data_chunk` version.
+template <typename T, typename... Args>
+    requires kth::Deserializable<T, Args...>
+[[nodiscard]] inline
+expect<T> from_db_value(KTH_DB_val const& value, Args... args) {
+    kth::byte_span span{
+        static_cast<uint8_t const*>(kth_db_get_data(value)),
+        kth_db_get_size(value)
+    };
+    kth::byte_reader reader(span);
+    return T::from_data(reader, args...);
 }
 
 } // namespace kth::database

--- a/src/database/include/kth/database/databases/transaction_database.ipp
+++ b/src/database/include/kth/database/databases/transaction_database.ipp
@@ -79,9 +79,7 @@ transaction_entry internal_database_basis<Clock>::get_transaction(uint64_t id, K
         return {};
     }
 
-    auto data = db_value_to_data_chunk(value);
-    byte_reader reader(data);
-    auto entry_res = transaction_entry::from_data(reader);
+    auto entry_res = kth::database::from_db_value<transaction_entry>(value);
     if ( ! entry_res) {
         return {};
     }

--- a/src/database/include/kth/database/databases/transaction_entry.hpp
+++ b/src/database/include/kth/database/databases/transaction_entry.hpp
@@ -13,14 +13,14 @@
 namespace kth::database {
 
 
-template <typename W, KTH_IS_WRITER(W)>
-void write_position(W& serial, uint32_t position) {
-    serial.KTH_POSITION_WRITER(position);
+inline
+expect<void> write_position(byte_writer& writer, uint32_t position) {
+    return writer.write_little_endian<kth_position_t>(static_cast<kth_position_t>(position));
 }
 
-template <typename Deserializer>
-uint32_t read_position(Deserializer& deserial) {
-    return deserial.KTH_POSITION_READER();
+inline
+expect<kth_position_t> read_position(byte_reader& reader) {
+    return reader.read_little_endian<kth_position_t>();
 }
 
 struct KD_API transaction_entry {
@@ -42,37 +42,41 @@ struct KD_API transaction_entry {
     static
     size_t serialized_size(domain::chain::transaction const& tx);
 
-    data_chunk to_data() const;
-    void to_data(std::ostream& stream) const;
-
-
-    template <typename W, KTH_IS_WRITER(W)>
-    void to_data(W& sink) const {
-        factory_to_data(sink, transaction_, height_, median_time_past_, position_ );
+    // Instance-side wrapper so `transaction_entry` satisfies
+    // `kth::Serializable` and can flow through `kth::to_data_chunk`,
+    // matching the free-function member/static split we already have
+    // for `to_data`.
+    [[nodiscard]]
+    size_t serialized_size() const {
+        return serialized_size(transaction_);
     }
 
     static
     expect<transaction_entry> from_data(byte_reader& reader);
+
+    [[nodiscard]]
+    expect<void> to_data(byte_writer& writer) const {
+        return factory_to_data(writer, transaction_, height_, median_time_past_, position_);
+    }
+
+    data_chunk to_data() const;
 
     bool confirmed() const;
 
     //TODO(kth): we don't have spent information
     //bool is_spent(size_t fork_height) const;
 
+    [[nodiscard]]
+    static
+    expect<void> factory_to_data(byte_writer& writer, domain::chain::transaction const& tx, uint32_t height, uint32_t median_time_past, uint32_t position) {
+        if (auto r = tx.to_data(writer, false); ! r) return r;
+        if (auto r = writer.write_little_endian<uint32_t>(height); ! r) return r;
+        if (auto r = writer.write_little_endian<uint32_t>(median_time_past); ! r) return r;
+        return write_position(writer, position);
+    }
+
     static
     data_chunk factory_to_data(domain::chain::transaction const& tx, uint32_t height, uint32_t median_time_past, uint32_t position);
-
-    static
-    void factory_to_data(std::ostream& stream, domain::chain::transaction const& tx, uint32_t height, uint32_t median_time_past, uint32_t position);
-
-    template <typename W, KTH_IS_WRITER(W)>
-    static
-    void factory_to_data(W& sink, domain::chain::transaction const& tx, uint32_t height, uint32_t median_time_past, uint32_t position) {
-        tx.to_data(sink, false);
-        sink.write_4_bytes_little_endian(height);
-        sink.write_4_bytes_little_endian(median_time_past);
-        write_position(sink, position);
-    }
 
 private:
     void reset();

--- a/src/database/include/kth/database/databases/transaction_unconfirmed_database.ipp
+++ b/src/database/include/kth/database/databases/transaction_unconfirmed_database.ipp
@@ -40,8 +40,7 @@ transaction_unconfirmed_entry internal_database_basis<Clock>::get_transaction_un
         return {};
     }
 
-    auto data = db_value_to_data_chunk(value);
-    byte_reader reader(data);
+    auto reader = kth::database::db_reader(value);
     auto res_entry = transaction_unconfirmed_entry::from_data(reader);
     if ( ! res_entry) {
         return {};
@@ -74,16 +73,14 @@ std::expected<std::vector<transaction_unconfirmed_entry>, result_code> internal_
     int rc;
     if ((rc = kth_db_cursor_get(cursor, &key, &value, KTH_DB_NEXT)) == 0) {
 
-        auto data = db_value_to_data_chunk(value);
-        byte_reader reader1(data);
+        auto reader1 = kth::database::db_reader(value);
         auto res1 = transaction_unconfirmed_entry::from_data(reader1);
         if (res1) {
             result.push_back(*res1);
         }
 
         while ((rc = kth_db_cursor_get(cursor, &key, &value, KTH_DB_NEXT)) == 0) {
-            auto data = db_value_to_data_chunk(value);
-            byte_reader reader2(data);
+            auto reader2 = kth::database::db_reader(value);
             auto res2 = transaction_unconfirmed_entry::from_data(reader2);
             if (res2) {
                 result.push_back(*res2);

--- a/src/database/include/kth/database/databases/transaction_unconfirmed_entry.hpp
+++ b/src/database/include/kth/database/databases/transaction_unconfirmed_entry.hpp
@@ -31,31 +31,33 @@ struct KD_API transaction_unconfirmed_entry {
     static
     size_t serialized_size(domain::chain::transaction const& tx);
 
-    data_chunk to_data() const;
-    void to_data(std::ostream& stream) const;
-
-
-    template <typename W, KTH_IS_WRITER(W)>
-    void to_data(W& sink) const {
-        factory_to_data(sink, transaction_, arrival_time_, height_);
+    // Instance-side wrapper so the type satisfies `kth::Serializable`
+    // and can flow through `kth::to_data_chunk`.
+    [[nodiscard]]
+    size_t serialized_size() const {
+        return serialized_size(transaction_);
     }
 
     static
     expect<transaction_unconfirmed_entry> from_data(byte_reader& reader);
 
+    [[nodiscard]]
+    expect<void> to_data(byte_writer& writer) const {
+        return factory_to_data(writer, transaction_, arrival_time_, height_);
+    }
+
+    data_chunk to_data() const;
+
+    [[nodiscard]]
+    static
+    expect<void> factory_to_data(byte_writer& writer, domain::chain::transaction const& tx, uint32_t arrival_time, uint32_t height) {
+        if (auto r = tx.to_data(writer, false); ! r) return r;
+        if (auto r = writer.write_little_endian<uint32_t>(arrival_time); ! r) return r;
+        return writer.write_little_endian<uint32_t>(height);
+    }
+
     static
     data_chunk factory_to_data(domain::chain::transaction const& tx, uint32_t arrival_time, uint32_t height);
-
-    static
-    void factory_to_data(std::ostream& stream, domain::chain::transaction const& tx, uint32_t arrival_time, uint32_t height);
-
-    template <typename W, KTH_IS_WRITER(W)>
-    static
-    void factory_to_data(W& sink, domain::chain::transaction const& tx, uint32_t arrival_time, uint32_t height) {
-        tx.to_data(sink, false);
-        sink.write_4_bytes_little_endian(arrival_time);
-        sink.write_4_bytes_little_endian(height);
-    }
 
 private:
     void reset();

--- a/src/database/include/kth/database/databases/utxo_entry.hpp
+++ b/src/database/include/kth/database/databases/utxo_entry.hpp
@@ -26,44 +26,37 @@ struct KD_API utxo_entry {
 
     size_t serialized_size() const;
 
-    data_chunk to_data() const;
-    void to_data(std::ostream& stream) const;
-
-    template <typename W, KTH_IS_WRITER(W)>
-    void to_data(W& sink) const {
-        output_.to_data(sink, false);
-        to_data_fixed(sink, height_, median_time_past_, coinbase_);
-    }
-
     static
     expect<utxo_entry> from_data(byte_reader& reader);
+
+    [[nodiscard]]
+    expect<void> to_data(byte_writer& writer) const {
+        if (auto r = output_.to_data(writer, false); ! r) return r;
+        return to_data_fixed(writer, height_, median_time_past_, coinbase_);
+    }
+
+    data_chunk to_data() const;
+
+    [[nodiscard]]
+    static
+    expect<void> to_data_fixed(byte_writer& writer, uint32_t height, uint32_t median_time_past, bool coinbase) {
+        if (auto r = writer.write_little_endian<uint32_t>(height); ! r) return r;
+        if (auto r = writer.write_little_endian<uint32_t>(median_time_past); ! r) return r;
+        return writer.write_byte(coinbase ? 1 : 0);
+    }
 
     static
     data_chunk to_data_fixed(uint32_t height, uint32_t median_time_past, bool coinbase);
 
+    [[nodiscard]]
     static
-    void to_data_fixed(std::ostream& stream, uint32_t height, uint32_t median_time_past, bool coinbase);
-
-    template <typename W, KTH_IS_WRITER(W)>
-    static
-    void to_data_fixed(W& sink, uint32_t height, uint32_t median_time_past, bool coinbase) {
-        sink.write_4_bytes_little_endian(height);
-        sink.write_4_bytes_little_endian(median_time_past);
-        sink.write_byte(coinbase);
+    expect<void> to_data_with_fixed(byte_writer& writer, domain::chain::output const& output, data_chunk const& fixed) {
+        if (auto r = output.to_data(writer, false); ! r) return r;
+        return writer.write_bytes(fixed);
     }
 
     static
     data_chunk to_data_with_fixed(domain::chain::output const& output, data_chunk const& fixed);
-
-    static
-    void to_data_with_fixed(std::ostream& stream, domain::chain::output const& output, data_chunk const& fixed);
-
-    template <typename W, KTH_IS_WRITER(W)>
-    static
-    void to_data_with_fixed(W& sink, domain::chain::output const& output, data_chunk const& fixed) {
-        output.to_data(sink, false);
-        sink.write_bytes(fixed);
-    }
 
 private:
     void reset();

--- a/src/database/src/block_store.cpp
+++ b/src/database/src/block_store.cpp
@@ -11,9 +11,6 @@
 #include <thread>
 
 #include <spdlog/spdlog.h>
-
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
 #include <kth/infrastructure/utility/stats.hpp>
 
 namespace kth::database {
@@ -105,8 +102,7 @@ bool block_store::initialize() {
 // =============================================================================
 
 flat_file_pos block_store::save_block(domain::chain::block const& block, uint32_t height) {
-    auto const raw = block.to_data();  // wire=true (always canonical for block)
-    return save_block_raw(raw, height, block.header().timestamp());
+    return save_block_raw(kth::to_data_chunk(block), height, block.header().timestamp());
 }
 
 flat_file_pos block_store::save_block_raw(data_chunk const& raw_block, uint32_t height, uint64_t timestamp) {
@@ -168,8 +164,7 @@ block_store::read_block(flat_file_pos const& pos) const {
         return std::unexpected(raw_result.error());
     }
 
-    byte_reader reader(*raw_result);
-    auto block = domain::chain::block::from_data(reader);
+    auto block = kth::from_data_chunk<domain::chain::block>(*raw_result);
     if (!block) {
         return std::unexpected(result_code::other);
     }

--- a/src/database/src/block_undo.cpp
+++ b/src/database/src/block_undo.cpp
@@ -5,9 +5,6 @@
 #include <kth/database/block_undo.hpp>
 
 #include <kth/infrastructure/message/message_tools.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::database {
 
 // =============================================================================
@@ -23,13 +20,7 @@ size_t tx_undo::serialized_size() const {
 }
 
 data_chunk tx_undo::to_data() const {
-    data_chunk data;
-    data.reserve(serialized_size());
-    data_sink ostream(data);
-    ostream_writer sink(ostream);
-    to_data(sink);
-    ostream.flush();
-    return data;
+    return kth::to_data_chunk(*this);
 }
 
 std::expected<tx_undo, database::result_code> tx_undo::from_data(byte_reader& reader) {
@@ -65,13 +56,7 @@ size_t block_undo::serialized_size() const {
 }
 
 data_chunk block_undo::to_data() const {
-    data_chunk data;
-    data.reserve(serialized_size());
-    data_sink ostream(data);
-    ostream_writer sink(ostream);
-    to_data(sink);
-    ostream.flush();
-    return data;
+    return kth::to_data_chunk(*this);
 }
 
 std::expected<block_undo, database::result_code> block_undo::from_data(byte_reader& reader) {

--- a/src/database/src/databases/header_abla_entry.cpp
+++ b/src/database/src/databases/header_abla_entry.cpp
@@ -7,47 +7,58 @@
 #include <cstddef>
 #include <cstdint>
 
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::database {
 
+expect<void> to_data_with_abla_state(byte_writer& writer, domain::chain::block const& block) {
+    if (auto r = block.header().to_data(writer, true); ! r) return r;
+    auto const a = block.validation.state
+        ? block.validation.state->abla_state()
+        : domain::chain::abla::state{};
+    if (auto r = writer.write_little_endian<uint64_t>(a.block_size); ! r) return r;
+    if (auto r = writer.write_little_endian<uint64_t>(a.control_block_size); ! r) return r;
+    return writer.write_little_endian<uint64_t>(a.elastic_buffer_size);
+}
+
+expect<void> to_data_header_only(byte_writer& writer, domain::chain::header const& header) {
+    if (auto r = header.to_data(writer, true); ! r) return r;
+    // ABLA state is unknown for headers received before blocks
+    // Store zeros, will be updated when block is received
+    if (auto r = writer.write_little_endian<uint64_t>(0); ! r) return r;
+    if (auto r = writer.write_little_endian<uint64_t>(0); ! r) return r;
+    return writer.write_little_endian<uint64_t>(0);
+}
+
+expect<void> to_data_header_with_abla_state(byte_writer& writer, domain::chain::header const& header, uint64_t block_size, uint64_t control_block_size, uint64_t elastic_buffer_size) {
+    if (auto r = header.to_data(writer, true); ! r) return r;
+    if (auto r = writer.write_little_endian<uint64_t>(block_size); ! r) return r;
+    if (auto r = writer.write_little_endian<uint64_t>(control_block_size); ! r) return r;
+    return writer.write_little_endian<uint64_t>(elastic_buffer_size);
+}
+
 data_chunk to_data_with_abla_state(domain::chain::block const& block) {
-    data_chunk data;
     auto const size = block.header().serialized_size(true) + 8 + 8 + 8;
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data_with_abla_state(ostream, block);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
+    data_chunk data(size);
+    byte_writer writer(data);
+    auto const r = to_data_with_abla_state(writer, block);
+    KTH_ASSERT(r.has_value());
     return data;
 }
 
-void to_data_with_abla_state(std::ostream& stream, domain::chain::block const& block) {
-    ostream_writer sink(stream);
-    to_data_with_abla_state(sink, block);
-}
-
 data_chunk to_data_header_only(domain::chain::header const& header) {
-    data_chunk data;
     auto const size = header.serialized_size(true) + 8 + 8 + 8;
-    data.reserve(size);
-    data_sink ostream(data);
-    ostream_writer sink(ostream);
-    to_data_header_only(sink, header);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
+    data_chunk data(size);
+    byte_writer writer(data);
+    auto const r = to_data_header_only(writer, header);
+    KTH_ASSERT(r.has_value());
     return data;
 }
 
 data_chunk to_data_header_with_abla_state(domain::chain::header const& header, uint64_t block_size, uint64_t control_block_size, uint64_t elastic_buffer_size) {
-    data_chunk data;
     auto const size = header.serialized_size(true) + 8 + 8 + 8;
-    data.reserve(size);
-    data_sink ostream(data);
-    ostream_writer sink(ostream);
-    to_data_header_with_abla_state(sink, header, block_size, control_block_size, elastic_buffer_size);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
+    data_chunk data(size);
+    byte_writer writer(data);
+    auto const r = to_data_header_with_abla_state(writer, header, block_size, control_block_size, elastic_buffer_size);
+    KTH_ASSERT(r.has_value());
     return data;
 }
 

--- a/src/database/src/databases/history_entry.cpp
+++ b/src/database/src/databases/history_entry.cpp
@@ -7,7 +7,6 @@
 #include <cstddef>
 #include <cstdint>
 
-#include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::database {
 
@@ -61,36 +60,16 @@ expect<history_entry> history_entry::from_data(byte_reader& reader) {
 
 // static
 data_chunk history_entry::factory_to_data(uint64_t id, domain::chain::point const& point, domain::chain::point_kind kind, uint32_t height, uint32_t index, uint64_t value_or_checksum) {
-    data_chunk data;
     auto const size = serialized_size(point);
-    data.reserve(size);
-    data_sink ostream(data);
-    factory_to_data(ostream, id, point, kind, height, index, value_or_checksum);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
+    data_chunk data(size);
+    byte_writer writer(data);
+    auto const r = factory_to_data(writer, id, point, kind, height, index, value_or_checksum);
+    KTH_ASSERT(r.has_value());
     return data;
-}
-
-// static
-void history_entry::factory_to_data(std::ostream& stream, uint64_t id, domain::chain::point const& point, domain::chain::point_kind kind, uint32_t height, uint32_t index, uint64_t value_or_checksum) {
-    ostream_writer sink(stream);
-    factory_to_data(sink, id, point, kind, height, index, value_or_checksum);
 }
 
 data_chunk history_entry::to_data() const {
-    data_chunk data;
-    auto const size = serialized_size(point_);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
-
-void history_entry::to_data(std::ostream& stream) const {
-    ostream_writer sink(stream);
-    to_data(sink);
+    return kth::to_data_chunk(*this);
 }
 
 } // namespace kth::database

--- a/src/database/src/databases/transaction_entry.cpp
+++ b/src/database/src/databases/transaction_entry.cpp
@@ -8,7 +8,6 @@
 #include <cstdint>
 
 // #include <kth/infrastructure.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::database {
 
@@ -97,39 +96,15 @@ expect<transaction_entry> transaction_entry::from_data(byte_reader& reader) {
 
 // static
 data_chunk transaction_entry::factory_to_data(domain::chain::transaction const& tx, uint32_t height, uint32_t median_time_past, uint32_t position) {
-    data_chunk data;
-    auto const size = serialized_size(tx);
-    data.reserve(size);
-    data_sink ostream(data);
-    factory_to_data(ostream, tx, height, median_time_past, position);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
+    data_chunk data(serialized_size(tx));
+    byte_writer writer(data);
+    auto const r = factory_to_data(writer, tx, height, median_time_past, position);
+    KTH_ASSERT(r.has_value());
     return data;
 }
-
-// static
-void transaction_entry::factory_to_data(std::ostream& stream, domain::chain::transaction const& tx, uint32_t height, uint32_t median_time_past, uint32_t position) {
-    ostream_writer sink(stream);
-    factory_to_data(sink, tx, height, median_time_past, position);
-}
-
-// Serialization.
-//-----------------------------------------------------------------------------
 
 data_chunk transaction_entry::to_data() const {
-    data_chunk data;
-    auto const size = serialized_size(transaction_);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
-
-void transaction_entry::to_data(std::ostream& stream) const {
-    ostream_writer sink(stream);
-    to_data(sink);
+    return kth::to_data_chunk(*this);
 }
 
 // Deserialization.

--- a/src/database/src/databases/transaction_unconfirmed_entry.cpp
+++ b/src/database/src/databases/transaction_unconfirmed_entry.cpp
@@ -8,7 +8,6 @@
 #include <cstdint>
 
 // #include <kth/infrastructure.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::database {
 
@@ -78,39 +77,16 @@ expect<transaction_unconfirmed_entry> transaction_unconfirmed_entry::from_data(b
 
 // static
 data_chunk transaction_unconfirmed_entry::factory_to_data(domain::chain::transaction const& tx, uint32_t arrival_time, uint32_t height) {
-    data_chunk data;
     auto const size = serialized_size(tx);
-    data.reserve(size);
-    data_sink ostream(data);
-    factory_to_data(ostream, tx, arrival_time, height);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
+    data_chunk data(size);
+    byte_writer writer(data);
+    auto const r = factory_to_data(writer, tx, arrival_time, height);
+    KTH_ASSERT(r.has_value());
     return data;
 }
-
-// static
-void transaction_unconfirmed_entry::factory_to_data(std::ostream& stream, domain::chain::transaction const& tx, uint32_t arrival_time, uint32_t height) {
-    ostream_writer sink(stream);
-    factory_to_data(sink, tx, arrival_time, height);
-}
-
-// Serialization.
-//-----------------------------------------------------------------------------
 
 data_chunk transaction_unconfirmed_entry::to_data() const {
-    data_chunk data;
-    auto const size = serialized_size(transaction_);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
-
-void transaction_unconfirmed_entry::to_data(std::ostream& stream) const {
-    ostream_writer sink(stream);
-    to_data(sink);
+    return kth::to_data_chunk(*this);
 }
 
 } // namespace kth::database

--- a/src/database/src/databases/utxo_entry.cpp
+++ b/src/database/src/databases/utxo_entry.cpp
@@ -8,7 +8,6 @@
 #include <cstdint>
 
 // #include <kth/infrastructure.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::database {
 
@@ -64,39 +63,22 @@ size_t utxo_entry::serialized_size() const {
 
 // static
 data_chunk utxo_entry::to_data_fixed(uint32_t height, uint32_t median_time_past, bool coinbase) {
-    data_chunk data;
     auto const size = serialized_size_fixed();
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data_fixed(ostream, height, median_time_past, coinbase);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
+    data_chunk data(size);
+    byte_writer writer(data);
+    auto const r = to_data_fixed(writer, height, median_time_past, coinbase);
+    KTH_ASSERT(r.has_value());
     return data;
-}
-
-// static
-void utxo_entry::to_data_fixed(std::ostream& stream, uint32_t height, uint32_t median_time_past, bool coinbase) {
-    ostream_writer sink(stream);
-    to_data_fixed(sink, height, median_time_past, coinbase);
 }
 
 // static
 data_chunk utxo_entry::to_data_with_fixed(domain::chain::output const& output, data_chunk const& fixed) {
-    //TODO(fernando):  reuse fixed vector (do not create a new one)
-    data_chunk data;
     auto const size = output.serialized_size(false) + fixed.size();
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data_with_fixed(ostream, output, fixed);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
+    data_chunk data(size);
+    byte_writer writer(data);
+    auto const r = to_data_with_fixed(writer, output, fixed);
+    KTH_ASSERT(r.has_value());
     return data;
-}
-
-// static
-void utxo_entry::to_data_with_fixed(std::ostream& stream, domain::chain::output const& output, data_chunk const& fixed) {
-    ostream_writer sink(stream);
-    to_data_with_fixed(sink, output, fixed);
 }
 
 
@@ -133,19 +115,7 @@ expect<utxo_entry> utxo_entry::from_data(byte_reader& reader) {
 //-----------------------------------------------------------------------------
 
 data_chunk utxo_entry::to_data() const {
-    data_chunk data;
-    auto const size = serialized_size();
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
-
-void utxo_entry::to_data(std::ostream& stream) const {
-    ostream_writer sink(stream);
-    to_data(sink);
+    return kth::to_data_chunk(*this);
 }
 
 } // namespace kth::database

--- a/src/database/src/databases/utxoz_database.cpp
+++ b/src/database/src/databases/utxoz_database.cpp
@@ -180,8 +180,7 @@ std::expected<utxo_entry, result_code> utxoz_database::resolve_compact_ref(
     }
 
     // Parse the transaction
-    byte_reader reader(*raw_tx);
-    auto tx = domain::chain::transaction::from_data(reader, true);  // wire=true
+    auto tx = kth::from_data_chunk<domain::chain::transaction>(*raw_tx, true);  // wire=true
     if ( ! tx) {
         spdlog::error("[utxoz_database] resolve_compact_ref: failed to parse tx at file={} offset={}",
             ref.file_number, ref.offset);
@@ -263,9 +262,8 @@ std::vector<uint8_t> utxoz_database::entry_to_bytes(utxo_entry const& entry) {
 
 std::expected<utxo_entry, result_code> utxoz_database::bytes_to_entry(std::span<uint8_t const> bytes) {
     data_chunk data(bytes.begin(), bytes.end());
-    byte_reader reader(data);
 
-    auto entry = utxo_entry::from_data(reader);
+    auto entry = kth::from_data_chunk<utxo_entry>(data);
     if ( ! entry) {
         return std::unexpected(result_code::other);
     }

--- a/src/domain/bench/to_data/benchmarks.cpp
+++ b/src/domain/bench/to_data/benchmarks.cpp
@@ -3,12 +3,16 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 // Micro-benchmarks for `to_data(...)` across the chain types. On this
-// branch the serialization path is the legacy `data_sink` + `ostream_writer`
-// stack — every write goes through a boost::iostreams sink into a
-// growing `data_chunk`. The sibling PR #394 replaces that with
-// `byte_writer` writing into a pre-sized `data_chunk` in one shot; the
-// benchmark file over there is a straight adaptation of this one so the
-// numbers are directly comparable.
+// branch the serialization path is the new `byte_writer` API: every
+// write is bounds-checked against a caller-owned `data_chunk` sized to
+// the exact `serialized_size(...)`. The helper `kth::to_data_chunk(x,
+// args...)` (in `<kth/infrastructure/utility/byte_writer.hpp>`) folds
+// the allocate/write/return dance into one call so the callsite reads
+// like the old convenience overload.
+//
+// The parent PR #387 has the same benchmark file measuring the legacy
+// `data_sink` + `ostream_writer` stack; the two runs share fixtures
+// and are directly comparable.
 
 #define ANKERL_NANOBENCH_IMPLEMENT
 #include <nanobench.h>
@@ -27,6 +31,7 @@
 #include <kth/domain/chain/script.hpp>
 #include <kth/domain/chain/transaction.hpp>
 #include <kth/infrastructure/math/hash.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 
 using namespace kth;
@@ -123,19 +128,21 @@ block make_block(size_t tx_count, uint32_t salt) {
 }
 
 // -----------------------------------------------------------------------------
-// Legacy `to_data(...)` calls. These return a fresh `data_chunk` built by
-// the `data_sink`/`ostream_writer` stack. `doNotOptimizeAway` on the
-// result keeps the compiler from folding the whole call away.
+// `byte_writer`-backed `to_data(...)` calls via the `to_data_chunk` helper.
+// The helper allocates the buffer sized to `serialized_size(args...)`,
+// constructs a `byte_writer` over it, and returns the filled `data_chunk`
+// in one call. `doNotOptimizeAway` on the result keeps the compiler from
+// folding the whole call away.
 // -----------------------------------------------------------------------------
 
 void bench_point(Bench& b) {
     auto const p = make_point(1);
     b.run("point::to_data(wire)", [&] {
-        auto data = p.to_data(true);
+        auto data = kth::to_data_chunk(p, true);
         ankerl::nanobench::doNotOptimizeAway(data);
     });
     b.run("point::to_data(!wire)", [&] {
-        auto data = p.to_data(false);
+        auto data = kth::to_data_chunk(p, false);
         ankerl::nanobench::doNotOptimizeAway(data);
     });
 }
@@ -144,11 +151,11 @@ void bench_script(Bench& b) {
     auto const s_small = make_script(25, 2);
     auto const s_large = make_script(400, 3);
     b.run("script::to_data(prefix) [25B]", [&] {
-        auto data = s_small.to_data(true);
+        auto data = kth::to_data_chunk(s_small, true);
         ankerl::nanobench::doNotOptimizeAway(data);
     });
     b.run("script::to_data(prefix) [400B]", [&] {
-        auto data = s_large.to_data(true);
+        auto data = kth::to_data_chunk(s_large, true);
         ankerl::nanobench::doNotOptimizeAway(data);
     });
 }
@@ -156,7 +163,7 @@ void bench_script(Bench& b) {
 void bench_input(Bench& b) {
     auto const in = make_input(4);
     b.run("input::to_data(wire)", [&] {
-        auto data = in.to_data(true);
+        auto data = kth::to_data_chunk(in, true);
         ankerl::nanobench::doNotOptimizeAway(data);
     });
 }
@@ -164,7 +171,7 @@ void bench_input(Bench& b) {
 void bench_output(Bench& b) {
     auto const out = make_output(5);
     b.run("output::to_data(wire)", [&] {
-        auto data = out.to_data(true);
+        auto data = kth::to_data_chunk(out, true);
         ankerl::nanobench::doNotOptimizeAway(data);
     });
 }
@@ -173,11 +180,11 @@ void bench_transaction(Bench& b) {
     auto const tx_small = make_transaction(1, 2, 6);
     auto const tx_big = make_transaction(20, 20, 7);
     b.run("transaction::to_data(wire) [1in/2out]", [&] {
-        auto data = tx_small.to_data(true);
+        auto data = kth::to_data_chunk(tx_small, true);
         ankerl::nanobench::doNotOptimizeAway(data);
     });
     b.run("transaction::to_data(wire) [20in/20out]", [&] {
-        auto data = tx_big.to_data(true);
+        auto data = kth::to_data_chunk(tx_big, true);
         ankerl::nanobench::doNotOptimizeAway(data);
     });
 }
@@ -186,11 +193,11 @@ void bench_block(Bench& b) {
     auto const blk_small = make_block(10, 8);
     auto const blk_large = make_block(500, 9);
     b.run("block::to_data() [10 tx]", [&] {
-        auto data = blk_small.to_data();
+        auto data = kth::to_data_chunk(blk_small);
         ankerl::nanobench::doNotOptimizeAway(data);
     });
     b.run("block::to_data() [500 tx]", [&] {
-        auto data = blk_large.to_data();
+        auto data = kth::to_data_chunk(blk_large);
         ankerl::nanobench::doNotOptimizeAway(data);
     });
 }
@@ -201,7 +208,7 @@ void bench_block(Bench& b) {
 
 int main() {
     Bench bench;
-    bench.title("to_data (legacy data_sink/ostream_writer path)")
+    bench.title("to_data (byte_writer path via kth::to_data_chunk)")
          .unit("op")
          .minEpochIterations(50);
 

--- a/src/domain/include/kth/domain/chain/block.hpp
+++ b/src/domain/include/kth/domain/chain/block.hpp
@@ -25,10 +25,9 @@
 #include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/asio.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
+#include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
 
 namespace kth::domain::chain {
 
@@ -78,38 +77,20 @@ public:
     bool operator==(block const& x) const;
     bool operator!=(block const& x) const = default;
 
-    // Deserialization.
+    // Serialization.
     //-------------------------------------------------------------------------
 
     static
     expect<block> from_data(byte_reader& reader);
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    // Serialization.
-    //-------------------------------------------------------------------------
-
-    data_chunk to_data() const;
-    void to_data(data_sink& stream) const;
-
-    template <typename W>
-    void to_data(W& sink) const {
-        header_.to_data(sink, true);
-        sink.write_size_little_endian(transactions_.size());
-        auto const to = [&sink](transaction const& tx) {
-            tx.to_data(sink, true);
-        };
-        std::for_each(transactions_.begin(), transactions_.end(), to);
-    }
+    expect<void> to_data(byte_writer& writer) const;
 
     [[nodiscard]]
-    hash_list to_hashes() const;
-
-    // Properties (size, accessors).
-    //-------------------------------------------------------------------------
-
     size_t serialized_size() const;
+
+    // Properties (accessors).
+    //-------------------------------------------------------------------------
 
     chain::header& header();
 
@@ -128,6 +109,9 @@ public:
 
     [[nodiscard]]
     hash_digest hash() const;
+
+    [[nodiscard]]
+    hash_list to_hashes() const;
 
     // Utilities.
     //-------------------------------------------------------------------------
@@ -160,6 +144,9 @@ public:
 
     // Validation.
     //-------------------------------------------------------------------------
+
+    [[nodiscard]]
+    bool is_valid() const;
 
     static
     uint64_t subsidy(size_t height, bool retarget);

--- a/src/domain/include/kth/domain/chain/header_members.hpp
+++ b/src/domain/include/kth/domain/chain/header_members.hpp
@@ -13,10 +13,9 @@
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/math/hash.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
+#include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
 
 #include <kth/domain/deserialization.hpp>
 
@@ -81,38 +80,31 @@ public:
     [[nodiscard]] constexpr uint32_t bits() const { return bits_; }
     [[nodiscard]] constexpr uint32_t nonce() const { return nonce_; }
 
-    // Deserialization.
+    // Serialization.
     //-------------------------------------------------------------------------
 
     static
     expect<header> from_data(byte_reader& reader, bool wire = true);
 
     [[nodiscard]]
-    constexpr bool is_valid() const {
-        return (version_ != 0) ||
-               (previous_block_hash_ != null_hash) ||
-               (merkle_ != null_hash) ||
-               (timestamp_ != 0) ||
-               (bits_ != 0) ||
-               (nonce_ != 0);
+    expect<void> to_data(byte_writer& writer, bool wire) const {
+        (void)wire;
+        if (auto r = writer.write_little_endian<uint32_t>(version_); ! r) return r;
+        if (auto r = writer.write_hash(previous_block_hash_); ! r) return r;
+        if (auto r = writer.write_hash(merkle_); ! r) return r;
+        if (auto r = writer.write_little_endian<uint32_t>(timestamp_); ! r) return r;
+        if (auto r = writer.write_little_endian<uint32_t>(bits_); ! r) return r;
+        return writer.write_little_endian<uint32_t>(nonce_);
     }
 
-    // Serialization.
-    //-------------------------------------------------------------------------
-
     [[nodiscard]]
-    data_chunk to_data(bool wire = true) const;
-
-    void to_data(data_sink& stream, bool wire = true) const;
-
-    template <typename W>
-    void to_data(W& sink, bool wire = true) const {
-        sink.write_4_bytes_little_endian(version_);
-        sink.write_hash(previous_block_hash_);
-        sink.write_hash(merkle_);
-        sink.write_4_bytes_little_endian(timestamp_);
-        sink.write_4_bytes_little_endian(bits_);
-        sink.write_4_bytes_little_endian(nonce_);
+    constexpr bool is_valid() const {
+        return version_ != 0 ||
+               previous_block_hash_ != null_hash ||
+               merkle_ != null_hash ||
+               timestamp_ != 0 ||
+               bits_ != 0 ||
+               nonce_ != 0;
     }
 
     // Properties (size).

--- a/src/domain/include/kth/domain/chain/header_raw.hpp
+++ b/src/domain/include/kth/domain/chain/header_raw.hpp
@@ -15,11 +15,10 @@
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/math/hash.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
+#include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/endian.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
 
 #include <kth/domain/deserialization.hpp>
 
@@ -237,35 +236,24 @@ public:
         return data_;
     }
 
-    // Deserialization.
+    // Serialization.
     //-------------------------------------------------------------------------
 
     static
     expect<header> from_data(byte_reader& reader, bool wire = true);
 
     [[nodiscard]]
+    expect<void> to_data(byte_writer& writer, bool wire) const {
+        (void)wire;
+        // Write raw bytes directly - already in little-endian wire format.
+        return writer.write_bytes(std::span<uint8_t const>{data_.data(), serialized_size_wire});
+    }
+
+    [[nodiscard]]
     constexpr bool is_valid() const {
         // Check if any field is non-zero (header has been set).
         constexpr std::array<uint8_t, serialized_size_wire> zero_data{};
         return data_ != zero_data;
-    }
-
-    // Serialization.
-    //-------------------------------------------------------------------------
-
-    [[nodiscard]]
-    data_chunk to_data(bool wire = true) const;
-
-    void to_data(data_sink& stream, bool wire = true) const;
-
-    template <typename W>
-    void to_data(W& sink, bool wire = true) const {
-        // Write raw bytes directly - already in little-endian wire format.
-        sink.write_bytes(data_.data(), serialized_size_wire);
-
-        // if ( ! wire) {
-        //     sink.write_4_bytes_little_endian(median_time_past_);
-        // }
     }
 
     // Properties (size).

--- a/src/domain/include/kth/domain/chain/input.hpp
+++ b/src/domain/include/kth/domain/chain/input.hpp
@@ -18,9 +18,8 @@
 #include <kth/domain/wallet/payment_address.hpp>
 
 #include <kth/infrastructure/math/hash.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
+#include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
 
 #include <kth/domain/concepts.hpp>
 
@@ -42,33 +41,21 @@ struct KD_API input {
     friend
     constexpr bool operator==(input const&, input const&) = default;
 
-    // Deserialization.
+    // Serialization.
     //-------------------------------------------------------------------------
 
     static
     expect<input> from_data(byte_reader& reader, bool wire);
 
-    // Serialization.
-    //-------------------------------------------------------------------------
-
     [[nodiscard]]
-    data_chunk to_data(bool wire = true) const;
-
-    void to_data(data_sink& stream, bool wire = true) const;
-
-    template <typename W>
-    void to_data(W& sink, bool wire = true) const {
-        previous_output_.to_data(sink, wire);
-        script_.to_data(sink, true);
-        sink.write_4_bytes_little_endian(sequence_);
-    }
-
-    // Properties (size, accessors).
-    //-------------------------------------------------------------------------
+    expect<void> to_data(byte_writer& writer, bool wire) const;
 
     /// This accounts for wire, but does not read or write it.
     [[nodiscard]]
     size_t serialized_size(bool wire = true) const;
+
+    // Properties (accessors).
+    //-------------------------------------------------------------------------
 
     output_point& previous_output();
 

--- a/src/domain/include/kth/domain/chain/output.hpp
+++ b/src/domain/include/kth/domain/chain/output.hpp
@@ -17,9 +17,8 @@
 #include <kth/domain/chain/token_data.hpp>
 #include <kth/domain/define.hpp>
 #include <kth/domain/wallet/payment_address.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
+#include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
 
 #include <kth/domain/concepts.hpp>
 
@@ -61,50 +60,20 @@ struct KD_API output {
     friend
     bool operator!=(output const&, output const&) = default;
 
-    // Deserialization.
+    // Serialization.
     //-------------------------------------------------------------------------
 
     static
     expect<output> from_data(byte_reader& reader, bool wire = true);
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    // Serialization.
-    //-------------------------------------------------------------------------
-
-    [[nodiscard]]
-    data_chunk to_data(bool wire = true) const;
-
-    void to_data(data_sink& stream, bool wire = true) const;
-
-    template <typename W>
-    void to_data(W& sink, bool wire = true) const {
-        if ( ! wire) {
-            auto const height32 = *safe_unsigned<uint32_t>(validation.spender_height);
-            sink.write_4_bytes_little_endian(height32);
-        }
-
-        sink.write_8_bytes_little_endian(value_);
-
-        if ( ! token_data_.has_value()) {
-            script_.to_data(sink, true);
-            return;
-        }
-
-        auto const size = token::encoding::serialized_size(token_data_) + script_.serialized_size(false) + 1;
-        sink.write_variable_little_endian(size);
-
-        sink.write_byte(chain::encoding::PREFIX_BYTE);
-        token::encoding::to_data(sink, token_data_.value());
-        script_.to_data(sink, false);
-    }
-
-    // Properties (size, accessors).
-    //-------------------------------------------------------------------------
+    expect<void> to_data(byte_writer& writer, bool wire) const;
 
     [[nodiscard]]
     size_t serialized_size(bool wire = true) const;
+
+    // Properties (accessors).
+    //-------------------------------------------------------------------------
 
     [[nodiscard]]
     uint64_t value() const;
@@ -147,6 +116,9 @@ struct KD_API output {
 
     // Validation.
     //-------------------------------------------------------------------------
+
+    [[nodiscard]]
+    bool is_valid() const;
 
     [[nodiscard]]
     size_t signature_operations(bool bip141) const;

--- a/src/domain/include/kth/domain/chain/output_point.hpp
+++ b/src/domain/include/kth/domain/chain/output_point.hpp
@@ -13,8 +13,6 @@
 #include <kth/domain/chain/point.hpp>
 #include <kth/domain/chain/script.hpp>
 #include <kth/domain/define.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-
 namespace kth::domain::chain {
 
 struct KD_API output_point : point {

--- a/src/domain/include/kth/domain/chain/point.hpp
+++ b/src/domain/include/kth/domain/chain/point.hpp
@@ -18,10 +18,9 @@
 #include <kth/domain/define.hpp>
 #include <kth/domain/deserialization.hpp>
 #include <kth/infrastructure/math/hash.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
+#include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
 
 
 #include <kth/domain/concepts.hpp>
@@ -54,36 +53,29 @@ struct KD_API point {
     // ("arbitrary order to support set uniqueness").
     friend constexpr auto operator<=>(point const&, point const&) = default;
 
-    // Deserialization.
+    // Serialization.
     //-------------------------------------------------------------------------
 
     static
     expect<point> from_data(byte_reader& reader, bool wire = true);
 
+    [[nodiscard]]
+    expect<void> to_data(byte_writer& writer, bool wire) const;
+
+    [[nodiscard]]
+    static constexpr size_t satoshi_fixed_size() {
+        return hash_size + sizeof(index_);
+    }
+
+    [[nodiscard]]
+    constexpr size_t serialized_size(bool wire = true) const {
+        return wire ? point::satoshi_fixed_size() : (hash_size + sizeof(uint16_t));
+    }
+
     /// Returns a null point (coinbase input reference).
     [[nodiscard]]
     static constexpr point null() noexcept {
         return point{null_hash, null_index};
-    }
-
-    // Serialization.
-    //-------------------------------------------------------------------------
-
-    [[nodiscard]]
-    data_chunk to_data(bool wire = true) const;
-
-    void to_data(data_sink& stream, bool wire = true) const;
-
-    template <typename W>
-    void to_data(W& sink, bool wire = true) const {
-        sink.write_hash(hash_);
-
-        if (wire) {
-            sink.write_4_bytes_little_endian(index_);
-        } else {
-            KTH_ASSERT(index_ == null_index || index_ < max_uint16);
-            sink.write_2_bytes_little_endian(uint16_t(index_));
-        }
     }
 
     // Iteration (limited to store serialization).
@@ -95,18 +87,8 @@ struct KD_API point {
     [[nodiscard]]
     point_iterator end() const;
 
-    // Properties (size, accessors, cache).
+    // Properties (accessors, cache).
     //-------------------------------------------------------------------------
-
-    [[nodiscard]]
-    static constexpr size_t satoshi_fixed_size() {
-        return hash_size + sizeof(index_);
-    }
-
-    [[nodiscard]]
-    constexpr size_t serialized_size(bool wire = true) const {
-        return wire ? point::satoshi_fixed_size() : (hash_size + sizeof(uint16_t));
-    }
 
     // deprecated (unsafe)
     constexpr hash_digest& hash() {

--- a/src/domain/include/kth/domain/chain/script.hpp
+++ b/src/domain/include/kth/domain/chain/script.hpp
@@ -28,10 +28,9 @@
 #include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/machine/script_version.hpp>
 #include <kth/infrastructure/math/elliptic_curve.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
+#include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
 
 #include <kth/domain/concepts.hpp>
 
@@ -96,23 +95,8 @@ struct KD_API script {
     [[nodiscard]]
     bool is_valid_operations() const;
 
-    // Serialization.
-    //-------------------------------------------------------------------------
-
     [[nodiscard]]
-    data_chunk to_data(bool prefix) const;
-
-    void to_data(data_sink& stream, bool prefix) const;
-
-    template <typename W>
-    void to_data(W& sink, bool prefix) const {
-        // TODO(legacy): optimize by always storing the prefixed serialization.
-        if (prefix) {
-            sink.write_variable_little_endian(serialized_size(false));
-        }
-
-        sink.write_bytes(bytes_);
-    }
+    expect<void> to_data(byte_writer& writer, bool prefix) const;
 
     [[nodiscard]]
     std::string to_string(script_flags_t active_flags) const;

--- a/src/domain/include/kth/domain/chain/token_data.hpp
+++ b/src/domain/include/kth/domain/chain/token_data.hpp
@@ -24,13 +24,10 @@
 #include <kth/domain/machine/opcode.hpp>
 #include <kth/domain/machine/script_flags.hpp>
 
-#include <kth/infrastructure/utility/container_sink.hpp>
+#include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/serializer.hpp>
 #include <kth/infrastructure/utility/thread.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
 
 namespace kth::domain::chain {
 
@@ -412,40 +409,37 @@ uint8_t bitfield(token_data_t const& x) {
     return std::visit(visitor, x.data);
 }
 
-template <typename W>
-inline constexpr
-void to_data(W& sink, fungible const& x) {
-    sink.write_variable_little_endian(uint64_t(x.amount));
+inline
+expect<void> to_data(byte_writer& writer, fungible const& x) {
+    return writer.write_variable_little_endian(uint64_t(x.amount));
 }
 
-template <typename W>
-inline constexpr
-void to_data(W& sink, non_fungible const& x) {
-    if (x.commitment.empty()) return;
-
-    sink.write_size_little_endian(x.commitment.size());
-    sink.write_bytes(x.commitment);
+inline
+expect<void> to_data(byte_writer& writer, non_fungible const& x) {
+    if (x.commitment.empty()) return {};
+    if (auto r = writer.write_size_little_endian(x.commitment.size()); ! r) return r;
+    return writer.write_bytes(x.commitment);
 }
 
-template <typename W>
-inline constexpr
-void to_data(W& sink, both_kinds const& x) {
+inline
+expect<void> to_data(byte_writer& writer, both_kinds const& x) {
     // CashTokens wire format writes the NFT portion first, then the
     // fungible amount — keep that order even with the named fields.
-    to_data(sink, x.non_fungible_part);
-    to_data(sink, x.fungible_part);
+    if (auto r = to_data(writer, x.non_fungible_part); ! r) return r;
+    return to_data(writer, x.fungible_part);
 }
 
-template <typename W>
-inline constexpr
-void to_data(W& sink, token_data_t const& x) {
-    sink.write_hash(x.id);
-    sink.write_byte(bitfield(x));
+inline
+expect<void> to_data(byte_writer& writer, token_data_t const& x) {
+    if (auto r = writer.write_hash(x.id); ! r) return r;
+    if (auto r = writer.write_byte(bitfield(x)); ! r) return r;
 
-    auto const visitor = [&sink](auto&& arg) {
-        to_data(sink, arg);
+    expect<void> result;
+    auto const visitor = [&](auto&& arg) {
+        result = to_data(writer, arg);
     };
     std::visit(visitor, x.data);
+    return result;
 }
 
 inline constexpr
@@ -557,7 +551,7 @@ expect<token_data_t> from_data(byte_reader& reader) {
     return x;
 }
 
-// Non-templated entry points that adapt the templated `to_data<W>`
+// Non-templated entry points that adapt the `byte_writer`-based `to_data`
 // above to an owned `data_chunk`. Historically these lived in
 // `token_data_serialization.hpp`; consolidating them here means the
 // C-API binding generator — which parses a single header per class —
@@ -569,14 +563,10 @@ namespace detail {
 
 template <typename T>
 data_chunk to_data_impl(T const& x) {
-    data_chunk data;
-    auto const size = serialized_size(x);
-    data.reserve(size);
-    data_sink ostream(data);
-    ostream_writer sink_w(ostream);
-    to_data(sink_w, x);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
+    data_chunk data(serialized_size(x));
+    byte_writer writer(data);
+    auto const r = to_data(writer, x);
+    KTH_ASSERT(r.has_value());
     return data;
 }
 

--- a/src/domain/include/kth/domain/chain/transaction.hpp
+++ b/src/domain/include/kth/domain/chain/transaction.hpp
@@ -27,9 +27,8 @@
 #include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/math/elliptic_curve.hpp>
 #include <kth/infrastructure/math/hash.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
+#include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
 
 #include <kth/domain/concepts.hpp>
 #include <kth/domain/deserialization.hpp>
@@ -39,16 +38,18 @@ namespace kth::domain::chain {
 
 namespace detail {
 
-// Write a length-prefixed collection of inputs or outputs to the sink.
-template <class Sink, class Put>
-void write(Sink& sink, std::vector<Put> const& puts, bool wire) {
-    sink.write_variable_little_endian(puts.size());
-
-    auto const serialize = [&](const Put& put) {
-        put.to_data(sink, wire);
-    };
-
-    std::for_each(puts.begin(), puts.end(), serialize);
+// Write a length-prefixed collection of inputs or outputs to the writer.
+template <class Put>
+expect<void> write(byte_writer& writer, std::vector<Put> const& puts, bool wire) {
+    if (auto r = writer.write_variable_little_endian(puts.size()); ! r) {
+        return r;
+    }
+    for (auto const& put : puts) {
+        if (auto r = put.to_data(writer, wire); ! r) {
+            return r;
+        }
+    }
+    return {};
 }
 
 } // namespace detail
@@ -115,45 +116,20 @@ struct KD_API transaction {
     bool operator==(transaction const& x) const;
     bool operator!=(transaction const& x) const = default;
 
-    // Deserialization.
+    // Serialization.
     //-----------------------------------------------------------------------------
 
     static
     expect<transaction> from_data(byte_reader& reader, bool wire = true);
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    // Serialization.
-    //-----------------------------------------------------------------------------
-
-    [[nodiscard]]
-    data_chunk to_data(bool wire = true) const;
-
-    void to_data(data_sink& stream, bool wire = true) const;
-
-    template <typename W>
-        requires ( ! std::is_same_v<W, bool>)
-    void to_data(W& sink, bool wire = true) const {
-        if (wire) {
-            sink.write_4_bytes_little_endian(version_);
-            detail::write(sink, inputs_, wire);
-            detail::write(sink, outputs_, wire);
-            sink.write_4_bytes_little_endian(locktime_);
-        } else {
-            // Database (outputs forward) serialization.
-            detail::write(sink, outputs_, wire);
-            detail::write(sink, inputs_, wire);
-            sink.write_variable_little_endian(locktime_);
-            sink.write_variable_little_endian(version_);
-        }
-    }
-
-    // Properties (size, accessors).
-    //-----------------------------------------------------------------------------
+    expect<void> to_data(byte_writer& writer, bool wire) const;
 
     [[nodiscard]]
     size_t serialized_size(bool wire = true) const;
+
+    // Properties (accessors).
+    //-----------------------------------------------------------------------------
 
     [[nodiscard]]
     uint32_t version() const;
@@ -201,6 +177,9 @@ struct KD_API transaction {
 
     // Validation.
     //-----------------------------------------------------------------------------
+
+    [[nodiscard]]
+    bool is_valid() const;
 
     [[nodiscard]]
     uint64_t fees() const;

--- a/src/domain/include/kth/domain/chain/witness.hpp
+++ b/src/domain/include/kth/domain/chain/witness.hpp
@@ -15,11 +15,10 @@
 
 #include <kth/domain/machine/operation.hpp>
 
-#include <kth/infrastructure/utility/container_sink.hpp>
+#include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/thread.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
 
 #include <kth/domain/utils.hpp>
 #include <kth/domain/concepts.hpp>
@@ -60,45 +59,7 @@ struct KD_API witness {
     // Prefixed data assumed valid here though caller may confirm with is_valid.
 
     /// Deserialization invalidates the iterator.
-    template <typename R, KTH_IS_READER(R)>
-    bool from_data(R& source, bool prefix) {
-        reset();
-        valid_ = true;
-
-        auto const read_element = [](R& source) {
-            // Tokens encoded as variable integer prefixed byte array (bip144).
-            auto const size = source.read_size_little_endian();
-
-            // The max_script_size and max_push_data_size constants limit
-            // evaluation, but not all stacks evaluate, so use max_block_weight
-            // to guard memory allocation here.
-            if (size > max_block_weight) {
-                source.invalidate();
-                return data_chunk{};
-            }
-
-            return source.read_bytes(size);
-        };
-
-        // TODO(legacy): optimize store serialization to avoid loop, reading data directly.
-        if (prefix) {
-            // Witness prefix is an element count, not byte length (unlike script).
-            // On wire each witness is prefixed with number of elements (bip144).
-            for (auto count = source.read_size_little_endian(); count > 0; --count) {
-                stack_.push_back(read_element(source));
-            }
-        } else {
-            while ( ! source.is_exhausted()) {
-                stack_.push_back(read_element(source));
-            }
-        }
-
-        if ( ! source) {
-            reset();
-        }
-
-        return source;
-    }
+    bool from_data(byte_reader& reader, bool prefix);
 
     /// The witness deserialized ccording to count and size prefixing.
     bool is_valid() const;
@@ -106,27 +67,12 @@ struct KD_API witness {
     // Serialization.
     //-------------------------------------------------------------------------
 
+    [[nodiscard]]
     data_chunk to_data(bool prefix) const;
-    void to_data(data_sink& stream, bool prefix) const;
 
-    template <typename W>
-    void to_data(W& sink, bool prefix) const {
-        // Witness prefix is an element count, not byte length (unlike script).
-        if (prefix) {
-            sink.write_size_little_endian(stack_.size());
-        }
+    [[nodiscard]]
+    expect<void> to_data(byte_writer& writer, bool prefix) const;
 
-        auto const serialize = [&sink](data_chunk const& element) {
-            // Tokens encoded as variable integer prefixed byte array (bip144).
-            sink.write_size_little_endian(element.size());
-            sink.write_bytes(element);
-        };
-
-        // TODO(legacy): optimize store serialization to avoid loop, writing data directly.
-        std::for_each(stack_.begin(), stack_.end(), serialize);
-    }
-
-    //void to_data(writer& sink, bool prefix) const;
 
     std::string to_string() const;
 

--- a/src/domain/include/kth/domain/impl/machine/interpreter.ipp
+++ b/src/domain/include/kth/domain/impl/machine/interpreter.ipp
@@ -64,7 +64,12 @@ chain::script find_and_delete_endorsement(chain::script const& script_code, data
     pattern.insert(pattern.end(), endorsement.begin(), endorsement.end());
 
     // Serialize the script_code (without length prefix).
-    auto serialized = script_code.to_data(false);
+    data_chunk serialized(script_code.serialized_size(false));
+    {
+        byte_writer writer(serialized);
+        auto const r = script_code.to_data(writer, false);
+        KTH_ASSERT(r.has_value());
+    }
 
     // Search and remove all occurrences of the pattern (matching BCHN's byte-level FindAndDelete).
     bool found = false;
@@ -2806,7 +2811,12 @@ interpreter::result interpreter::op_utxo_bytecode(program& program) {
     data_chunk bytecode;
     if ( ! tokens_active && prevout_cache.token_data().has_value()) {
         // Pre-activation: return full serialized blob (prefix + token_data + script)
-        auto const full = prevout_cache.to_data(false);
+        data_chunk full(prevout_cache.serialized_size(false));
+        {
+            byte_writer w(full);
+            auto const r = prevout_cache.to_data(w, false);
+            KTH_ASSERT(r.has_value());
+        }
         auto const token_size = chain::token::encoding::serialized_size(prevout_cache.token_data());
         auto const script_size = prevout_cache.script().serialized_size(false);
         auto const wrapped_size = 1 + token_size + script_size;
@@ -3026,7 +3036,7 @@ interpreter::result interpreter::op_output_bytecode(program& program) {
     if ( ! tokens_active && out.token_data().has_value()) {
         // Rebuild the wrapped script: PREFIX_BYTE + token_data + script
         // Serialize the full output and strip the value (8 bytes) + varint script_size.
-        auto const full = out.to_data(false);
+        auto const full = to_data_chunk(out, false);
         // full = value(8) + varint(script_size) + prefix + token + script
         auto const token_size = chain::token::encoding::serialized_size(out.token_data());
         auto const script_size = out.script().serialized_size(false);

--- a/src/domain/include/kth/domain/impl/machine/operation.ipp
+++ b/src/domain/include/kth/domain/impl/machine/operation.ipp
@@ -135,24 +135,6 @@ data_chunk const& operation::data() const {
 // than two bytes to encode. However the four byte encoding can represent
 // a value of any size, so remains valid despite the data size limit.
 //*****************************************************************************
-// template <typename R>
-// inline
-// uint32_t operation::read_data_size(opcode code, R& source) {
-//     constexpr auto op_75 = uint8_t(opcode::push_size_75);
-
-//     switch (code) {
-//         case opcode::push_one_size:
-//             return source.read_byte();
-//         case opcode::push_two_size:
-//             return source.read_2_bytes_little_endian();
-//         case opcode::push_four_size:
-//             return source.read_4_bytes_little_endian();
-//         default:
-//             auto const byte = uint8_t(code);
-//             return byte <= op_75 ? byte : 0;
-//     }
-// }
-
 inline
 expect<uint32_t> operation::read_data_size(opcode code, byte_reader& reader) {
     constexpr auto op_75 = uint8_t(opcode::push_size_75);

--- a/src/domain/include/kth/domain/machine/operation.hpp
+++ b/src/domain/include/kth/domain/machine/operation.hpp
@@ -20,10 +20,8 @@
 
 #include <kth/domain/machine/script_pattern.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
 
 
 
@@ -71,30 +69,8 @@ struct KD_API operation {
     [[nodiscard]]
     data_chunk to_data() const;
 
-    void to_data(data_sink& stream) const;
-
-    template <typename W>
-    void to_data(W& sink) const {
-        auto const size = data_.size();
-
-        sink.write_byte(uint8_t(code_));
-
-        switch (code_) {
-            case opcode::push_one_size:
-                sink.write_byte(uint8_t(size));
-                break;
-            case opcode::push_two_size:
-                sink.write_2_bytes_little_endian(uint16_t(size));
-                break;
-            case opcode::push_four_size:
-                sink.write_4_bytes_little_endian(uint32_t(size));
-                break;
-            default:
-                break;
-        }
-
-        sink.write_bytes(data_);
-    }
+    [[nodiscard]]
+    expect<void> to_data(byte_writer& writer) const;
 
     [[nodiscard]]
     std::string to_string(script_flags_t active_flags) const;

--- a/src/domain/include/kth/domain/message/address.hpp
+++ b/src/domain/include/kth/domain/message/address.hpp
@@ -16,10 +16,7 @@
 #include <kth/domain/deserialization.hpp>
 #include <kth/infrastructure/message/network_address.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 namespace kth::domain::message {
 
 struct KD_API address {
@@ -45,20 +42,8 @@ struct KD_API address {
     expect<address> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t version, W& sink) const {
-        sink.write_variable_little_endian(addresses_.size());
-
-        for (auto const& net_address : addresses_) {
-            net_address.to_data(version, sink, true);
-        }
-    }
-
-    //void to_data(uint32_t version, writer& sink) const;
 
     [[nodiscard]]
     bool is_valid() const;

--- a/src/domain/include/kth/domain/message/addrv2.hpp
+++ b/src/domain/include/kth/domain/message/addrv2.hpp
@@ -16,10 +16,7 @@
 #include <kth/domain/deserialization.hpp>
 #include <kth/infrastructure/message/network_address.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 namespace kth::domain::message {
 
 /// BIP155 network identifiers
@@ -87,23 +84,7 @@ struct KD_API addrv2 {
     expect<addrv2> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
-
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t version, W& sink) const {
-        sink.write_variable_little_endian(addresses_.size());
-
-        for (auto const& entry : addresses_) {
-            sink.write_4_bytes_little_endian(entry.time);
-            sink.write_variable_little_endian(entry.services);
-            sink.write_byte(static_cast<uint8_t>(entry.network));
-            sink.write_variable_little_endian(entry.addr.size());
-            sink.write_bytes(entry.addr);
-            sink.write_2_bytes_big_endian(entry.port);
-        }
-    }
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     [[nodiscard]]
     bool is_valid() const;

--- a/src/domain/include/kth/domain/message/alert.hpp
+++ b/src/domain/include/kth/domain/message/alert.hpp
@@ -11,12 +11,8 @@
 
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {
@@ -48,23 +44,12 @@ struct KD_API alert {
     void set_signature(data_chunk const& value);
     void set_signature(data_chunk&& value);
 
+    [[nodiscard]]
     static
     expect<alert> from_data(byte_reader& reader, uint32_t /*version*/);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
-
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t /*version*/, W& sink) const {
-        sink.write_variable_little_endian(payload_.size());
-        sink.write_bytes(payload_);
-        sink.write_variable_little_endian(signature_.size());
-        sink.write_bytes(signature_);
-    }
-
-    //void to_data(uint32_t version, writer& sink) const;
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     [[nodiscard]]
     bool is_valid() const;

--- a/src/domain/include/kth/domain/message/alert_payload.hpp
+++ b/src/domain/include/kth/domain/message/alert_payload.hpp
@@ -11,12 +11,8 @@
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/math/elliptic_curve.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {
@@ -184,38 +180,8 @@ struct KD_API alert_payload {
     }
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t /*version*/, W& sink) const {
-        sink.write_4_bytes_little_endian(this->version_);
-        sink.write_8_bytes_little_endian(relay_until_);
-        sink.write_8_bytes_little_endian(expiration_);
-        sink.write_4_bytes_little_endian(id_);
-        sink.write_4_bytes_little_endian(cancel_);
-        sink.write_variable_little_endian(set_cancel_.size());
-
-        for (auto const& entry : set_cancel_) {
-            sink.write_4_bytes_little_endian(entry);
-}
-
-        sink.write_4_bytes_little_endian(min_version_);
-        sink.write_4_bytes_little_endian(max_version_);
-        sink.write_variable_little_endian(set_sub_version_.size());
-
-        for (auto const& entry : set_sub_version_) {
-            sink.write_string(entry);
-}
-
-        sink.write_4_bytes_little_endian(priority_);
-        sink.write_string(comment_);
-        sink.write_string(status_bar_);
-        sink.write_string(reserved_);
-    }
-
-    //void to_data(uint32_t version, writer& sink) const;
     [[nodiscard]]
     bool is_valid() const;
 

--- a/src/domain/include/kth/domain/message/block.hpp
+++ b/src/domain/include/kth/domain/message/block.hpp
@@ -16,11 +16,8 @@
 #include <kth/domain/define.hpp>
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 
 
@@ -50,9 +47,8 @@ public:
     bool operator==(block const& x) const;
     bool operator!=(block const& x) const;
 
-    // Deserialization.
+    // Serialization.
     //-------------------------------------------------------------------------
-
     static
     expect<block> from_data(byte_reader& reader, uint32_t /*version*/);
 
@@ -60,15 +56,9 @@ public:
     //-------------------------------------------------------------------------
 
 
-    data_chunk to_data(uint32_t version) const;
-    void to_data(uint32_t version, data_sink& stream) const;
+    [[nodiscard]]
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
-    template <typename W>
-    void to_data(uint32_t /*version*/, W& sink) const {
-        chain::block::to_data(sink);
-    }
-
-    //void to_data(uint32_t version, writer& sink) const;
     size_t serialized_size(uint32_t version) const;
 
 
@@ -81,19 +71,6 @@ public:
     static
     uint32_t const version_maximum;
 };
-
-//TODO(fernando): check this family of functions: to_data_header_nonce
-template <typename W>
-void to_data_header_nonce(block const& block, uint64_t nonce, W& sink) {
-    block.header().to_data(sink);
-    sink.write_8_bytes_little_endian(nonce);
-}
-// void to_data_header_nonce(block const& block, uint64_t nonce, writer& sink);
-
-// void to_data_header_nonce(block const& block, uint64_t nonce, std::ostream& stream);
-void to_data_header_nonce(block const& block, uint64_t nonce, data_sink& stream);
-
-data_chunk to_data_header_nonce(block const& block, uint64_t nonce);
 
 hash_digest hash(block const& block, uint64_t nonce);
 

--- a/src/domain/include/kth/domain/message/block_transactions.hpp
+++ b/src/domain/include/kth/domain/message/block_transactions.hpp
@@ -11,12 +11,8 @@
 #include <kth/domain/constants.hpp>
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {
@@ -59,19 +55,7 @@ struct KD_API block_transactions {
     expect<block_transactions> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
-
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t /*version*/, W& sink) const {
-        sink.write_hash(block_hash_);
-        sink.write_variable_little_endian(transactions_.size());
-
-        for (auto const& element : transactions_) {
-            element.to_data(sink, /*wire*/ true);
-        }
-    }
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     [[nodiscard]]
     bool is_valid() const;

--- a/src/domain/include/kth/domain/message/compact_block.hpp
+++ b/src/domain/include/kth/domain/message/compact_block.hpp
@@ -13,12 +13,8 @@
 #include <kth/domain/message/block.hpp>
 #include <kth/domain/message/prefilled_transaction.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {
@@ -75,33 +71,8 @@ struct KD_API compact_block {
     bool from_block(message::block const& block);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t version, W& sink) const {
-        header_.to_data(sink);
-        sink.write_8_bytes_little_endian(nonce_);
-        sink.write_variable_little_endian(short_ids_.size());
-
-        for (auto const& element : short_ids_) {
-            //sink.write_mini_hash(element);
-            uint32_t lsb = element & 0xffffffff;
-            uint16_t msb = (element >> 32) & 0xffff;
-            sink.write_4_bytes_little_endian(lsb);
-            sink.write_2_bytes_little_endian(msb);
-        }
-
-        sink.write_variable_little_endian(transactions_.size());
-
-        // NOTE: Witness flag is controlled by prefilled tx
-        for (auto const& element : transactions_) {
-            element.to_data(version, sink);
-        }
-    }
-
-    //void to_data(uint32_t version, writer& sink) const;
     [[nodiscard]]
     bool is_valid() const;
 
@@ -125,16 +96,6 @@ private:
     short_id_list short_ids_;
     prefilled_transaction::list transactions_;
 };
-
-template <typename W>
-void to_data_header_nonce(compact_block const& block, W& sink) {
-    block.header().to_data(sink);
-    sink.write_8_bytes_little_endian(block.nonce());
-}
-
-void to_data_header_nonce(compact_block const& block, data_sink& stream);
-
-data_chunk to_data_header_nonce(compact_block const& block);
 
 hash_digest hash(compact_block const& block);
 

--- a/src/domain/include/kth/domain/message/double_spend_proof.hpp
+++ b/src/domain/include/kth/domain/message/double_spend_proof.hpp
@@ -13,10 +13,8 @@
 // #include <kth/domain/message/block.hpp>
 // #include <kth/domain/message/prefilled_transaction.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
 
 
 #include <kth/domain/concepts.hpp>
@@ -86,15 +84,15 @@ struct KD_API double_spend_proof {
                 push_data.size();
         }
 
-        template <typename W>
-        void to_data(W& sink) const {
-            sink.write_4_bytes_little_endian(version);
-            sink.write_4_bytes_little_endian(out_sequence);
-            sink.write_4_bytes_little_endian(locktime);
-            sink.write_hash(prev_outs_hash);
-            sink.write_hash(sequence_hash);
-            sink.write_hash(outputs_hash);
-            sink.write_bytes(push_data);
+        [[nodiscard]]
+        expect<void> to_data(byte_writer& writer) const {
+            if (auto r = writer.write_little_endian<uint32_t>(version); ! r) return r;
+            if (auto r = writer.write_little_endian<uint32_t>(out_sequence); ! r) return r;
+            if (auto r = writer.write_little_endian<uint32_t>(locktime); ! r) return r;
+            if (auto r = writer.write_hash(prev_outs_hash); ! r) return r;
+            if (auto r = writer.write_hash(sequence_hash); ! r) return r;
+            if (auto r = writer.write_hash(outputs_hash); ! r) return r;
+            return writer.write_bytes(push_data);
         }
 
         static
@@ -128,20 +126,11 @@ struct KD_API double_spend_proof {
     spender const& spender2() const;
     void set_spender2(spender const& x);
 
-    [[nodiscard]]
-    data_chunk to_data(uint32_t /*version*/) const;
-
-    void to_data(uint32_t /*version*/, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t /*version*/, W& sink) const {
-        out_point_.to_data(sink);
-        spender1_.to_data(sink);
-        spender2_.to_data(sink);
-    }
-
     static
     expect<double_spend_proof> from_data(byte_reader& reader, uint32_t /*version*/);
+
+    [[nodiscard]]
+    expect<void> to_data(byte_writer& writer, uint32_t /*version*/) const;
 
     [[nodiscard]]
     size_t serialized_size(uint32_t /*version*/) const {

--- a/src/domain/include/kth/domain/message/fee_filter.hpp
+++ b/src/domain/include/kth/domain/message/fee_filter.hpp
@@ -12,11 +12,7 @@
 
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {
@@ -43,16 +39,8 @@ struct KD_API fee_filter {
     expect<fee_filter> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t /*version*/, W& sink) const {
-        sink.write_8_bytes_little_endian(minimum_fee_);
-    }
-
-    //void to_data(uint32_t version, writer& sink) const;
 
     [[nodiscard]]
     bool is_valid() const;

--- a/src/domain/include/kth/domain/message/filter_add.hpp
+++ b/src/domain/include/kth/domain/message/filter_add.hpp
@@ -12,12 +12,8 @@
 #include <kth/domain/constants.hpp>
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {
@@ -45,17 +41,8 @@ struct KD_API filter_add {
     expect<filter_add> from_data(byte_reader& reader, uint32_t /*version*/);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t /*version*/, W& sink) const {
-        sink.write_variable_little_endian(data_.size());
-        sink.write_bytes(data_);
-    }
-
-    //void to_data(uint32_t version, writer& sink) const;
 
     [[nodiscard]]
     bool is_valid() const;

--- a/src/domain/include/kth/domain/message/filter_clear.hpp
+++ b/src/domain/include/kth/domain/message/filter_clear.hpp
@@ -11,10 +11,8 @@
 
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
 
 
 #include <kth/domain/concepts.hpp>
@@ -40,10 +38,10 @@ struct KD_API filter_clear {
     [[nodiscard]]
     data_chunk to_data(uint32_t version) const;
 
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t /*version*/, W&  /*sink*/) const {
+    [[nodiscard]]
+    expect<void> to_data(byte_writer& /*writer*/, uint32_t /*version*/) const {
+        // filter_clear has an empty payload.
+        return {};
     }
 
     [[nodiscard]]

--- a/src/domain/include/kth/domain/message/filter_load.hpp
+++ b/src/domain/include/kth/domain/message/filter_load.hpp
@@ -12,12 +12,8 @@
 #include <kth/domain/constants.hpp>
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {
@@ -60,20 +56,8 @@ struct KD_API filter_load {
     expect<filter_load> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t /*version*/, W& sink) const {
-        sink.write_variable_little_endian(filter_.size());
-        sink.write_bytes(filter_);
-        sink.write_4_bytes_little_endian(hash_functions_);
-        sink.write_4_bytes_little_endian(tweak_);
-        sink.write_byte(flags_);
-    }
-
-    //void to_data(uint32_t version, writer& sink) const;
     [[nodiscard]]
     bool is_valid() const;
 

--- a/src/domain/include/kth/domain/message/get_address.hpp
+++ b/src/domain/include/kth/domain/message/get_address.hpp
@@ -11,10 +11,8 @@
 
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
 
 
 #include <kth/domain/concepts.hpp>
@@ -35,17 +33,11 @@ struct KD_API get_address {
     expect<get_address> from_data(byte_reader& reader, uint32_t /*version*/);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
-
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    //TODO(fernando): this function is empty!!!!!
-    template <typename W>
-    void to_data(uint32_t /*version*/, W&  /*sink*/) const {
-
+    expect<void> to_data(byte_writer& /*writer*/, uint32_t /*version*/) const {
+        //TODO(fernando): this function is empty!!!!!
+        return {};
     }
 
-    //void to_data(uint32_t version, writer& sink) const;
     [[nodiscard]]
     bool is_valid() const;
 

--- a/src/domain/include/kth/domain/message/get_block_transactions.hpp
+++ b/src/domain/include/kth/domain/message/get_block_transactions.hpp
@@ -13,12 +13,8 @@
 #include <kth/domain/deserialization.hpp>
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {
@@ -53,20 +49,8 @@ struct KD_API get_block_transactions {
     expect<get_block_transactions> from_data(byte_reader& reader, uint32_t /*version*/);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t /*version*/, W& sink) const {
-        sink.write_hash(block_hash_);
-        sink.write_variable_little_endian(indexes_.size());
-        for (auto const& element : indexes_) {
-            sink.write_variable_little_endian(element);
-        }
-    }
-
-    //void to_data(uint32_t version, writer& sink) const;
     [[nodiscard]]
     bool is_valid() const;
 

--- a/src/domain/include/kth/domain/message/get_blocks.hpp
+++ b/src/domain/include/kth/domain/message/get_blocks.hpp
@@ -16,12 +16,8 @@
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 #include <kth/domain/deserialization.hpp>
 
@@ -57,21 +53,7 @@ struct KD_API get_blocks {
     expect<get_blocks> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
-
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t version, W& sink) const {
-        sink.write_4_bytes_little_endian(version);
-        sink.write_variable_little_endian(start_hashes_.size());
-
-        for (auto const& start_hash : start_hashes_) {
-            sink.write_hash(start_hash);
-        }
-
-        sink.write_hash(stop_hash_);
-    }
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     [[nodiscard]]
     bool is_valid() const;

--- a/src/domain/include/kth/domain/message/get_data.hpp
+++ b/src/domain/include/kth/domain/message/get_data.hpp
@@ -15,7 +15,6 @@
 #include <kth/domain/message/inventory_vector.hpp>
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 
 

--- a/src/domain/include/kth/domain/message/get_headers.hpp
+++ b/src/domain/include/kth/domain/message/get_headers.hpp
@@ -12,9 +12,6 @@
 #include <kth/domain/message/get_blocks.hpp>
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-
-
 #include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {

--- a/src/domain/include/kth/domain/message/header.hpp
+++ b/src/domain/include/kth/domain/message/header.hpp
@@ -52,17 +52,8 @@ struct KD_API header : chain::header {
     expect<header> from_data(byte_reader& reader, uint32_t version);
 
     // Serialization to P2P wire (writes trailing zero byte).
-    data_chunk to_data(uint32_t version) const;
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t version, W& sink) const {
-        chain::header::to_data(sink, true);  // wire=true
-
-        if (version != version::level::canonical) {
-            sink.write_variable_little_endian(uint64_t{0});
-        }
-    }
+    [[nodiscard]]
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     size_t serialized_size(uint32_t version) const;
 };

--- a/src/domain/include/kth/domain/message/headers.hpp
+++ b/src/domain/include/kth/domain/message/headers.hpp
@@ -17,12 +17,8 @@
 #include <kth/domain/message/inventory_vector.hpp>
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {
@@ -57,20 +53,8 @@ struct KD_API headers {
     expect<headers> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t version, W& sink) const {
-        sink.write_variable_little_endian(elements_.size());
-
-        for (auto const& element : elements_) {
-            element.to_data(version, sink);
-        }
-    }
-
-    //void to_data(uint32_t version, writer& sink) const;
     [[nodiscard]]
     bool is_valid() const;
 

--- a/src/domain/include/kth/domain/message/heading.hpp
+++ b/src/domain/include/kth/domain/message/heading.hpp
@@ -16,10 +16,8 @@
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/math/checksum.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
 
 
 #include <kth/domain/concepts.hpp>
@@ -109,17 +107,18 @@ struct KD_API heading {
     [[nodiscard]]
     data_chunk to_data() const;
 
-    void to_data(data_sink& stream) const;
+    [[nodiscard]]
+    expect<void> to_data(byte_writer& writer) const;
 
-    template <typename W>
-    void to_data(W& sink) const {
-        sink.write_4_bytes_little_endian(magic_);
-        sink.write_string(command_, command_size);
-        sink.write_4_bytes_little_endian(payload_size_);
-        sink.write_4_bytes_little_endian(checksum_);
+    // Instance-side wrapper so the type satisfies `kth::Serializable`
+    // and can flow through `kth::to_data_chunk`. Headings are a fixed
+    // shape (magic + command_size + payload_size + checksum), so this
+    // just forwards to the static formula.
+    [[nodiscard]]
+    size_t serialized_size() const {
+        return satoshi_fixed_size();
     }
 
-    //void to_data(writer& sink) const;
     [[nodiscard]]
     bool is_valid() const;
 

--- a/src/domain/include/kth/domain/message/inventory.hpp
+++ b/src/domain/include/kth/domain/message/inventory.hpp
@@ -17,12 +17,8 @@
 #include <kth/domain/message/inventory_vector.hpp>
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {
@@ -53,18 +49,7 @@ struct KD_API inventory {
     expect<inventory> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
-
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t version, W& sink) const {
-        sink.write_variable_little_endian(inventories_.size());
-
-        for (auto const& inventory : inventories_) {
-            inventory.to_data(version, sink);
-        }
-    }
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     void to_hashes(hash_list& out, type_id type) const;
     void reduce(inventory_vector::list& out, type_id type) const;

--- a/src/domain/include/kth/domain/message/inventory_vector.hpp
+++ b/src/domain/include/kth/domain/message/inventory_vector.hpp
@@ -12,12 +12,8 @@
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 #include <kth/domain/deserialization.hpp>
 
@@ -85,18 +81,8 @@ struct KD_API inventory_vector {
     expect<inventory_vector> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t /*version*/, W& sink) const {
-        auto const raw_type = inventory_vector::to_number(type_);
-        sink.write_4_bytes_little_endian(raw_type);
-        sink.write_hash(hash_);
-    }
-
-    //void to_data(uint32_t version, writer& sink) const;
     [[nodiscard]]
     bool is_valid() const;
 

--- a/src/domain/include/kth/domain/message/memory_pool.hpp
+++ b/src/domain/include/kth/domain/message/memory_pool.hpp
@@ -11,10 +11,8 @@
 
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
 
 
 #include <kth/domain/concepts.hpp>
@@ -38,15 +36,10 @@ struct KD_API memory_pool {
     expect<memory_pool> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
-
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t /*version*/, W&  /*sink*/) const {
+    expect<void> to_data(byte_writer& /*writer*/, uint32_t /*version*/) const {
+        return {};
     }
 
-    //void to_data(uint32_t version, writer& sink) const;
     [[nodiscard]]
     bool is_valid() const;
 

--- a/src/domain/include/kth/domain/message/merkle_block.hpp
+++ b/src/domain/include/kth/domain/message/merkle_block.hpp
@@ -14,12 +14,8 @@
 #include <kth/domain/constants.hpp>
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {
@@ -69,27 +65,8 @@ struct KD_API merkle_block {
     expect<merkle_block> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t /*version*/, W& sink) const {
-        header_.to_data(sink);
-
-        auto const total32 = *safe_unsigned<uint32_t>(total_transactions_);
-        sink.write_4_bytes_little_endian(total32);
-        sink.write_variable_little_endian(hashes_.size());
-
-        for (auto const& hash : hashes_) {
-            sink.write_hash(hash);
-        }
-
-        sink.write_variable_little_endian(flags_.size());
-        sink.write_bytes(flags_);
-    }
-
-    //void to_data(uint32_t version, writer& sink) const;
     [[nodiscard]]
     bool is_valid() const;
 

--- a/src/domain/include/kth/domain/message/messages.hpp
+++ b/src/domain/include/kth/domain/message/messages.hpp
@@ -46,7 +46,6 @@
 #include <kth/domain/message/xversion.hpp>
 
 #include <kth/infrastructure/message/network_address.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
 
@@ -151,22 +150,13 @@ data_chunk serialize(uint32_t version, const Message& packet, uint32_t magic) {
     auto const payload_size = packet.serialized_size(version);
     auto const message_size = heading_size + payload_size;
 
-    // Unfortunately data_sink doesn't support seek, so this is a little ugly.
-    // The header requires payload size and checksum but prepends the payload.
-    // Use a stream to prevent unnecessary copying of the payload.
-    data_chunk data;
-
-    // Reserve memory for the full message.
-    data.reserve(message_size);
-
-    // Size the vector for the heading so that payload insertion will follow.
-    data.resize(heading_size);
-
-    // Insert the payload after the heading and into the reservation.
-    data_sink ostream(data);
-    packet.to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == message_size);
+    // Reserve the full message, write the payload into the tail span, then
+    // splice in the heading once we know the size and checksum.
+    data_chunk data(message_size);
+    std::span<uint8_t> payload_span{data.data() + heading_size, payload_size};
+    byte_writer payload_writer(payload_span);
+    auto const wr = packet.to_data(payload_writer, version);
+    KTH_ASSERT(wr.has_value());
 
     // Create the payload checksum without copying the buffer.
     byte_span span(data.data() + heading_size, data.data() + message_size);

--- a/src/domain/include/kth/domain/message/not_found.hpp
+++ b/src/domain/include/kth/domain/message/not_found.hpp
@@ -16,7 +16,6 @@
 #include <kth/domain/message/inventory_vector.hpp>
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 
 

--- a/src/domain/include/kth/domain/message/ping.hpp
+++ b/src/domain/include/kth/domain/message/ping.hpp
@@ -13,12 +13,8 @@
 #include <kth/domain/define.hpp>
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {
@@ -44,16 +40,7 @@ struct KD_API ping {
     static
     expect<ping> from_data(byte_reader& reader, uint32_t version);
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
-
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t version, W& sink) const {
-        if (version >= version::level::bip31) {
-            sink.write_8_bytes_little_endian(nonce_);
-        }
-    }
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     [[nodiscard]]
     bool is_valid() const;

--- a/src/domain/include/kth/domain/message/pong.hpp
+++ b/src/domain/include/kth/domain/message/pong.hpp
@@ -12,12 +12,8 @@
 
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {
@@ -45,16 +41,8 @@ struct KD_API pong {
     expect<pong> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t /*version*/, W& sink) const {
-        sink.write_8_bytes_little_endian(nonce_);
-    }
-
-    //void to_data(uint32_t version, writer& sink) const;
     [[nodiscard]]
     bool is_valid() const;
 

--- a/src/domain/include/kth/domain/message/prefilled_transaction.hpp
+++ b/src/domain/include/kth/domain/message/prefilled_transaction.hpp
@@ -11,12 +11,8 @@
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {
@@ -55,15 +51,7 @@ struct KD_API prefilled_transaction {
     expect<prefilled_transaction> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
-
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t /*version*/, W& sink) const {
-        sink.write_variable_little_endian(index_);
-        transaction_.to_data(sink, true);
-    }
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     [[nodiscard]]
     bool is_valid() const;

--- a/src/domain/include/kth/domain/message/reject.hpp
+++ b/src/domain/include/kth/domain/message/reject.hpp
@@ -14,11 +14,7 @@
 #include <kth/domain/message/block.hpp>
 #include <kth/domain/message/transaction.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {
@@ -100,21 +96,7 @@ struct KD_API reject {
     expect<reject> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
-
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t /*version*/, W& sink) const {
-        sink.write_string(message_);
-        sink.write_byte(reason_to_byte(code_));
-        sink.write_string(reason_);
-
-        if ((message_ == block::command) ||
-            (message_ == transaction::command)) {
-            sink.write_hash(data_);
-        }
-    }
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     [[nodiscard]]
     bool is_valid() const;

--- a/src/domain/include/kth/domain/message/send_addrv2.hpp
+++ b/src/domain/include/kth/domain/message/send_addrv2.hpp
@@ -11,11 +11,8 @@
 
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {
@@ -38,11 +35,7 @@ struct KD_API send_addrv2 {
     expect<send_addrv2> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
-
-    void to_data(uint32_t version, data_sink& stream) const;
-    void to_data(uint32_t version, writer& sink) const;
-
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
     [[nodiscard]]
     bool is_valid() const;
 

--- a/src/domain/include/kth/domain/message/send_compact.hpp
+++ b/src/domain/include/kth/domain/message/send_compact.hpp
@@ -11,12 +11,8 @@
 
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {
@@ -49,17 +45,8 @@ struct KD_API send_compact {
     expect<send_compact> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t /*version*/, W& sink) const {
-        sink.write_byte(uint8_t(high_bandwidth_mode_));
-        sink.write_8_bytes_little_endian(this->version_);
-    }
-
-    //void to_data(uint32_t version, writer& sink) const;
     [[nodiscard]]
     bool is_valid() const;
 

--- a/src/domain/include/kth/domain/message/send_headers.hpp
+++ b/src/domain/include/kth/domain/message/send_headers.hpp
@@ -11,12 +11,8 @@
 
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {
@@ -36,11 +32,7 @@ struct KD_API send_headers {
     expect<send_headers> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
-
-    void to_data(uint32_t version, data_sink& stream) const;
-    void to_data(uint32_t version, writer& sink) const;
-
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
     [[nodiscard]]
     bool is_valid() const;
 

--- a/src/domain/include/kth/domain/message/transaction.hpp
+++ b/src/domain/include/kth/domain/message/transaction.hpp
@@ -16,11 +16,8 @@
 #include <kth/domain/define.hpp>
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {
@@ -57,13 +54,8 @@ public:
     static
     expect<transaction> from_data(byte_reader& reader, uint32_t version);
 
-    data_chunk to_data(uint32_t version) const;
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t /*version*/, W& sink) const {
-        chain::transaction::to_data(sink, true);
-    }
+    [[nodiscard]]
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     size_t serialized_size(uint32_t version) const;
 

--- a/src/domain/include/kth/domain/message/verack.hpp
+++ b/src/domain/include/kth/domain/message/verack.hpp
@@ -11,12 +11,8 @@
 
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {
@@ -35,11 +31,7 @@ struct KD_API verack {
     expect<verack> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
-
-    void to_data(uint32_t version, data_sink& stream) const;
-    void to_data(uint32_t version, writer& sink) const;
-
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
     [[nodiscard]]
     bool is_valid() const;
 

--- a/src/domain/include/kth/domain/message/version.hpp
+++ b/src/domain/include/kth/domain/message/version.hpp
@@ -14,11 +14,7 @@
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/message/network_address.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {
@@ -221,28 +217,8 @@ struct KD_API version {
     expect<message::version> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
-    void to_data(uint32_t version, data_sink& stream) const;
-
-    template <typename W>
-    void to_data(uint32_t version, W& sink) const {
-        sink.write_4_bytes_little_endian(value_);
-        auto const effective_version = std::min(version, value_);
-        sink.write_8_bytes_little_endian(services_);
-        sink.write_8_bytes_little_endian(timestamp_);
-        address_receiver_.to_data(version, sink, false);
-        address_sender_.to_data(version, sink, false);
-        sink.write_8_bytes_little_endian(nonce_);
-        sink.write_string(user_agent_);
-        sink.write_4_bytes_little_endian(start_height_);
-
-        if (effective_version >= level::bip37) {
-            sink.write_byte(relay_ ? 1 : 0);
-        }
-    }
-
-    //void to_data(uint32_t version, writer& sink) const;
     [[nodiscard]]
     bool is_valid() const;
 

--- a/src/domain/include/kth/domain/message/xverack.hpp
+++ b/src/domain/include/kth/domain/message/xverack.hpp
@@ -11,12 +11,8 @@
 
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
-
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {
@@ -39,11 +35,7 @@ struct KD_API xverack {
     expect<xverack> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
-
-    void to_data(uint32_t version, data_sink& stream) const;
-    void to_data(uint32_t version, writer& sink) const;
-
+    expect<void> to_data(byte_writer& writer, uint32_t version) const;
     [[nodiscard]]
     bool is_valid() const;
 

--- a/src/domain/include/kth/domain/message/xversion.hpp
+++ b/src/domain/include/kth/domain/message/xversion.hpp
@@ -14,11 +14,6 @@
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/message/network_address.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
-#include <kth/infrastructure/utility/writer.hpp>
-
-
 #include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {
@@ -39,28 +34,6 @@ struct KD_API xversion {
 
     static
     expect<xversion> from_data(byte_reader& reader, uint32_t version);
-
-    // [[nodiscard]]
-    // data_chunk to_data(uint32_t version) const;
-
-    // void to_data(uint32_t version, data_sink& stream) const;
-
-    // template <typename W>
-    // void to_data(uint32_t version, W& sink) const {
-    //     sink.write_4_bytes_little_endian(value_);
-    //     auto const effective_version = std::min(version, value_);
-    //     sink.write_8_bytes_little_endian(services_);
-    //     sink.write_8_bytes_little_endian(timestamp_);
-    //     address_receiver_.to_data(version, sink, false);
-    //     address_sender_.to_data(version, sink, false);
-    //     sink.write_8_bytes_little_endian(nonce_);
-    //     sink.write_string(user_agent_);
-    //     sink.write_4_bytes_little_endian(start_height_);
-
-    //     if (effective_version >= level::bip37) {
-    //         sink.write_byte(relay_ ? 1 : 0);
-    //     }
-    // }
 
     [[nodiscard]]
     bool is_valid() const;

--- a/src/domain/src/chain/block.cpp
+++ b/src/domain/src/chain/block.cpp
@@ -35,9 +35,7 @@
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/asio.hpp>
 #include <kth/infrastructure/utility/assert.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
 
 // Bitcoin Core optimized SHA256D64 for merkle tree computation
 #include <crypto/sha256.h>
@@ -194,7 +192,7 @@ bool block::operator==(block const& x) const {
     return header_ == x.header_ && transactions_ == x.transactions_;
 }
 
-// Deserialization.
+// Serialization.
 //-----------------------------------------------------------------------------
 
 // static
@@ -215,6 +213,15 @@ expect<block> block::from_data(byte_reader& reader) {
     return res;
 }
 
+expect<void> block::to_data(byte_writer& writer) const {
+    if (auto r = header_.to_data(writer, true); ! r) return r;
+    if (auto r = writer.write_size_little_endian(transactions_.size()); ! r) return r;
+    for (auto const& tx : transactions_) {
+        if (auto r = tx.to_data(writer, true); ! r) return r;
+    }
+    return {};
+}
+
 void block::reset() {
     header_ = chain::header{};
     transactions_.clear();
@@ -223,26 +230,6 @@ void block::reset() {
 
 bool block::is_valid() const {
     return !transactions_.empty() || header_.is_valid();
-}
-
-// Serialization.
-//-----------------------------------------------------------------------------
-
-data_chunk block::to_data() const {
-    data_chunk data;
-    auto const size = serialized_size();
-
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
-
-void block::to_data(data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(sink_w);
 }
 
 hash_list block::to_hashes() const {

--- a/src/domain/src/chain/header_members.cpp
+++ b/src/domain/src/chain/header_members.cpp
@@ -17,7 +17,6 @@
 #include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/formats/base_16.hpp>
 #include <kth/infrastructure/math/hash.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::chain {
 
@@ -72,33 +71,15 @@ expect<header> header::from_data(byte_reader& reader, bool /*wire*/) {
     };
 }
 
-// Serialization.
-//-----------------------------------------------------------------------------
-
-data_chunk header::to_data(bool wire) const {
-    data_chunk data;
-    auto const size = serialized_size(wire);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(ostream, wire);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
-
-void header::to_data(data_sink& stream, bool wire) const {
-    ostream_writer sink_w(stream);
-    to_data(sink_w, wire);
-}
-
 // Hash function.
 //-----------------------------------------------------------------------------
 
 hash_digest hash(header const& hdr) {
+    auto const buf = kth::to_data_chunk(hdr, true);
 #if defined(KTH_CURRENCY_LTC)
-    auto const result = litecoin_hash(hdr.to_data());
+    auto const result = litecoin_hash(buf);
 #else
-    auto const result = bitcoin_hash(hdr.to_data());
+    auto const result = bitcoin_hash(buf);
 #endif
 
     // Track hash call statistics

--- a/src/domain/src/chain/header_raw.cpp
+++ b/src/domain/src/chain/header_raw.cpp
@@ -18,7 +18,6 @@
 #include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/formats/base_16.hpp>
 #include <kth/infrastructure/math/hash.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::chain {
 
@@ -93,25 +92,6 @@ expect<header> header::from_data(byte_reader& reader, bool _wire) {
 
 //     return header{data, *mtp};
 // }
-
-// Serialization.
-//-----------------------------------------------------------------------------
-
-data_chunk header::to_data(bool wire) const {
-    data_chunk data;
-    auto const size = serialized_size(wire);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(ostream, wire);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
-
-void header::to_data(data_sink& stream, bool wire) const {
-    ostream_writer sink_w(stream);
-    to_data(sink_w, wire);
-}
 
 // Hash function.
 //-----------------------------------------------------------------------------

--- a/src/domain/src/chain/input.cpp
+++ b/src/domain/src/chain/input.cpp
@@ -10,8 +10,6 @@
 #include <kth/domain/chain/script.hpp>
 #include <kth/domain/constants.hpp>
 #include <kth/domain/wallet/payment_address.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::chain {
 
@@ -33,7 +31,7 @@ input::input(output_point&& previous_output, chain::script&& script, uint32_t se
     , sequence_(sequence)
 {}
 
-// Deserialization.
+// Serialization.
 //-----------------------------------------------------------------------------
 
 // static
@@ -53,23 +51,14 @@ expect<input> input::from_data(byte_reader& reader, bool wire) {
     return input{std::move(*point), std::move(*script), *sequence};
 }
 
-// Serialization.
-//-----------------------------------------------------------------------------
-
-data_chunk input::to_data(bool wire) const {
-    data_chunk data;
-    auto const size = serialized_size(wire);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(ostream, wire);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
-
-void input::to_data(data_sink& stream, bool wire) const {
-    ostream_writer sink_w(stream);
-    to_data(sink_w, wire);
+expect<void> input::to_data(byte_writer& writer, bool wire) const {
+    if (auto r = previous_output_.to_data(writer, wire); ! r) {
+        return r;
+    }
+    if (auto r = script_.to_data(writer, true); ! r) {
+        return r;
+    }
+    return writer.write_little_endian<uint32_t>(sequence_);
 }
 
 // Size.

--- a/src/domain/src/chain/output.cpp
+++ b/src/domain/src/chain/output.cpp
@@ -10,8 +10,6 @@
 
 #include <kth/domain/constants.hpp>
 #include <kth/domain/wallet/payment_address.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::chain {
 
@@ -41,7 +39,7 @@ bool operator==(output const& a, output const& b) {
         && a.token_data_ == b.token_data_;
 }
 
-// Deserialization.
+// Serialization.
 //-----------------------------------------------------------------------------
 
 void output::reset() {
@@ -110,35 +108,66 @@ expect<output> output::from_data(byte_reader& reader, bool wire) {
     return result;
 }
 
-// Serialization.
-//-----------------------------------------------------------------------------
+expect<void> output::to_data(byte_writer& writer, bool wire) const {
+    auto const start = writer.position();
+    if ( ! wire) {
+        auto const height32 = *safe_unsigned<uint32_t>(validation.spender_height);
+        if (auto r = writer.write_little_endian<uint32_t>(height32); ! r) {
+            return r;
+        }
+    }
 
-data_chunk output::to_data(bool wire) const {
-    data_chunk data;
-    auto const size = serialized_size(wire);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(ostream, wire);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
+    if (auto r = writer.write_little_endian<uint64_t>(value_); ! r) {
+        return r;
+    }
 
-void output::to_data(data_sink& stream, bool wire) const {
-    ostream_writer sink_w(stream);
-    to_data(sink_w, wire);
+    if ( ! token_data_.has_value()) {
+        auto const r = script_.to_data(writer, true);
+        KTH_CONTRACT(writer.position() - start == serialized_size(wire));
+        return r;
+    }
+
+    auto const size = token::encoding::serialized_size(token_data_) + script_.serialized_size(false) + 1;
+    if (auto r = writer.write_variable_little_endian(size); ! r) {
+        return r;
+    }
+
+    if (auto r = writer.write_byte(chain::encoding::PREFIX_BYTE); ! r) {
+        return r;
+    }
+    if (auto r = token::encoding::to_data(writer, token_data_.value()); ! r) {
+        return r;
+    }
+    auto const r = script_.to_data(writer, false);
+    KTH_CONTRACT(writer.position() - start == serialized_size(wire));
+    return r;
 }
 
 // Size.
 //-----------------------------------------------------------------------------
 
 size_t output::serialized_size(bool wire) const {
-    // validation.spender_height is size_t stored as uint32_t.
-    auto const wire_size =
-        sizeof(value_) +
-        script_.serialized_size(true) +
-        token::encoding::serialized_size(token_data_) +
-        size_t(token_data_.has_value());
+    // Wire format:
+    //   value(8) + script                     (no token)
+    //   value(8) + varint(wrapper_size) + prefix_byte(1) + token + script_bytes  (with token)
+    // The tokenized branch prefixes the whole wrapper (prefix+token+script_bytes)
+    // with a single varint, NOT the bare script bytes. Using
+    // `script_.serialized_size(true)` here would embed `varint(script_bytes)`
+    // which is a different length than `varint(wrapper_size)` whenever the
+    // two values fall on opposite sides of a varint boundary (e.g. one fits
+    // in 1 byte, the other needs 3). That mismatch used to be masked by the
+    // growable `data_sink`; the fixed-size `byte_writer` truncates instead.
+    size_t wire_size;
+    if (token_data_.has_value()) {
+        auto const token_size = token::encoding::serialized_size(token_data_);
+        auto const script_size = script_.serialized_size(false);
+        auto const wrapper_size = 1 /*prefix*/ + token_size + script_size;
+        wire_size = sizeof(value_)
+                  + kth::size_variable_integer(wrapper_size)
+                  + wrapper_size;
+    } else {
+        wire_size = sizeof(value_) + script_.serialized_size(true);
+    }
 
     return (wire ? 0 : sizeof(uint32_t)) + wire_size;
 }

--- a/src/domain/src/chain/point.cpp
+++ b/src/domain/src/chain/point.cpp
@@ -9,14 +9,12 @@
 
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/assert.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::chain {
 
 constexpr auto store_point_size = std::tuple_size<point>::value;
 
-// Deserialization.
+// Serialization.
 //-----------------------------------------------------------------------------
 
 expect<point> point::from_data(byte_reader& reader, bool wire) {
@@ -43,23 +41,18 @@ expect<point> point::from_data(byte_reader& reader, bool wire) {
     return point {*hash, *index};
 }
 
-// Serialization.
-//-----------------------------------------------------------------------------
-
-data_chunk point::to_data(bool wire) const {
-    data_chunk data;
-    auto const size = serialized_size(wire);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(ostream, wire);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
-
-void point::to_data(data_sink& stream, bool wire) const {
-    ostream_writer sink_w(stream);
-    to_data(sink_w, wire);
+expect<void> point::to_data(byte_writer& writer, bool wire) const {
+    if (auto r = writer.write_hash(hash_); ! r) {
+        return r;
+    }
+    if (wire) {
+        return writer.write_little_endian<uint32_t>(index_);
+    }
+    KTH_ASSERT(index_ == null_index || index_ < max_uint16);
+    auto const compact = (index_ == null_index)
+        ? max_uint16
+        : static_cast<uint16_t>(index_);
+    return writer.write_little_endian<uint16_t>(compact);
 }
 
 // Iterator.

--- a/src/domain/src/chain/script.cpp
+++ b/src/domain/src/chain/script.cpp
@@ -32,9 +32,7 @@
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/assert.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
 #include <kth/infrastructure/utility/string.hpp>
 
 using namespace kth::domain::machine;
@@ -60,8 +58,7 @@ script::script(operation::list&& ops) {
 
 script::script(data_chunk&& encoded, bool prefix) {
     if (prefix) {
-        byte_reader reader(encoded);
-        auto obj = from_data(reader, prefix);
+        auto obj = kth::from_data_chunk<script>(encoded, prefix);
         if ( ! obj) {
             valid_ = false;
             return;
@@ -77,8 +74,7 @@ script::script(data_chunk&& encoded, bool prefix) {
 }
 
 script::script(data_chunk const& encoded, bool prefix) {
-    byte_reader reader(encoded);
-    auto obj = from_data(reader, prefix);
+    auto obj = kth::from_data_chunk<script>(encoded, prefix);
     if ( ! obj) {
         valid_ = false;
         return;
@@ -87,7 +83,7 @@ script::script(data_chunk const& encoded, bool prefix) {
     *this = std::move(obj.value());
 }
 
-// Deserialization.
+// Serialization.
 //-----------------------------------------------------------------------------
 
 // static
@@ -199,23 +195,14 @@ bool script::is_valid_operations() const {
     return ops.empty() || ops.back().is_valid();
 }
 
-// Serialization.
-//-----------------------------------------------------------------------------
-
-data_chunk script::to_data(bool prefix) const {
-    data_chunk data;
-    auto const size = serialized_size(prefix);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(ostream, prefix);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
-
-void script::to_data(data_sink& stream, bool prefix) const {
-    ostream_writer sink_w(stream);
-    to_data(sink_w, prefix);
+expect<void> script::to_data(byte_writer& writer, bool prefix) const {
+    // TODO(legacy): optimize by always storing the prefixed serialization.
+    if (prefix) {
+        if (auto r = writer.write_variable_little_endian(serialized_size(false)); ! r) {
+            return r;
+        }
+    }
+    return writer.write_bytes(bytes_);
 }
 
 std::string script::to_string(script_flags_t active_flags) const {
@@ -262,7 +249,7 @@ inline
 std::pair<hash_digest, size_t> signature_hash(transaction const& tx, uint32_t sighash_type) {
     KTH_ASSERT( ! tx.is_coinbase());
 
-    auto serialized = tx.to_data(true);
+    auto serialized = to_data_chunk(tx, true);
     extend_data(serialized, to_little_endian(sighash_type));
     return {bitcoin_hash(serialized), serialized.size()};
 }
@@ -438,12 +425,27 @@ std::pair<hash_digest, size_t> script::generate_version_0_signature_hash(
     auto const& input = tx.inputs()[input_index];
     auto const& prevout = input.previous_output().validation.cache;
     KTH_ASSERT(prevout.is_valid());
-    auto const size = preimage_size(script_code.serialized_size(true));
+    auto size = preimage_size(script_code.serialized_size(true));
+    // preimage_size() covers the fixed 11 required fields only. Two
+    // BCH-native additions to the sighash preimage (utxos hash after
+    // field 2, and per-input token data after field 5) are opt-in per
+    // sighash flag and consensus activation. When either fires the
+    // buffer must grow to cover them or the writes below silently no-op
+    // in release builds (KTH_ASSERT is compiled out), producing a
+    // truncated sighash and NULLFAIL on every downstream signature.
+#if defined(KTH_CURRENCY_BCH)
+    auto const tokens_active = is_enabled(active_flags,
+        domain::machine::script_flags::bch_tokens);
+    if (tokens_active && (sighash_type & sighash_algorithm::utxos) != 0) {
+        size += hash_size;
+    }
+    if (tokens_active && prevout.token_data().has_value()) {
+        size += 1 /*prefix*/ + chain::token::encoding::serialized_size(prevout.token_data());
+    }
+#endif
 
-    data_chunk data;
-    data.reserve(size);
-    data_sink ostream(data);
-    ostream_writer sink_w(ostream);
+    data_chunk data(size);
+    byte_writer writer(data);
 
     auto const sighash = to_sighash_enum(sighash_type);
     auto const any = (sighash_type & sighash_algorithm::anyone_can_pay) != 0;
@@ -461,55 +463,62 @@ std::pair<hash_digest, size_t> script::generate_version_0_signature_hash(
     auto const all = sighash == sighash_algorithm::all;
 #endif
 
+    auto const single_out_hash = [&]() {
+        auto const& out = tx.outputs()[input_index];
+        return bitcoin_hash(to_data_chunk(out, true));
+    };
+
+    auto const write_ok = [&](expect<void> const& r) {
+        KTH_CONTRACT(r.has_value());
+    };
+
     // 1. transaction version (4-byte little endian).
-    sink_w.write_little_endian(tx.version());
+    write_ok(writer.write_little_endian<uint32_t>(tx.version()));
 
     // 2. inpoints hash (32-byte hash).
-    sink_w.write_hash( ! any ? tx.inpoints_hash() : null_hash);
+    write_ok(writer.write_hash( ! any ? tx.inpoints_hash() : null_hash));
 
     // 3. Optional utxos hash (32-byte hash).
     if (is_enabled(active_flags, domain::machine::script_flags::bch_tokens) && utxos) {
-        sink_w.write_hash(tx.utxos_hash());
+        write_ok(writer.write_hash(tx.utxos_hash()));
     }
 
     // 4. sequences hash (32-byte hash).
-    sink_w.write_hash( ! any && all ? tx.sequences_hash() : null_hash);
+    write_ok(writer.write_hash( ! any && all ? tx.sequences_hash() : null_hash));
 
     // 5. outpoint (32-byte hash + 4-byte little endian).
-    input.previous_output().to_data(sink_w);
+    write_ok(input.previous_output().to_data(writer, true));
 
     // 6. Optional token data (variable size).
     if (is_enabled(active_flags, domain::machine::script_flags::bch_tokens) && prevout.token_data().has_value()) {
         auto const& token_data = prevout.token_data().value();
-        sink_w.write_byte(chain::encoding::PREFIX_BYTE);
-        chain::token::encoding::to_data(sink_w, token_data);
+        write_ok(writer.write_byte(chain::encoding::PREFIX_BYTE));
+        write_ok(chain::token::encoding::to_data(writer, token_data));
     }
 
     // 7. script of the input (with prefix).
-    script_code.to_data(sink_w, true);
+    write_ok(script_code.to_data(writer, true));
 
     // 8. value of the output spent by this input (8-byte little endian).
-    sink_w.write_little_endian(value);
+    write_ok(writer.write_little_endian<uint64_t>(value));
 
     // 9. sequence of the input (4-byte little endian).
-    sink_w.write_little_endian(input.sequence());
+    write_ok(writer.write_little_endian<uint32_t>(input.sequence()));
 
     // 10. outputs hash (32-byte hash).
-    sink_w.write_hash(all ?
+    write_ok(writer.write_hash(all ?
         tx.outputs_hash() :
         (single && input_index < tx.outputs().size() ?
-            bitcoin_hash(tx.outputs()[input_index].to_data()) :
-            null_hash));
+            single_out_hash() :
+            null_hash)));
 
     // 11. transaction locktime (4-byte little endian).
-    sink_w.write_little_endian(tx.locktime());
+    write_ok(writer.write_little_endian<uint32_t>(tx.locktime()));
 
     // 12. sighash type of the signature (4-byte [not 1] little endian).
-    sink_w.write_4_bytes_little_endian(sighash_type);
+    write_ok(writer.write_little_endian<uint32_t>(sighash_type));
 
-    ostream.flush();
-
-    KTH_ASSERT(data.size() == size);
+    KTH_CONTRACT(writer.position() == data.size());
     return {bitcoin_hash(data), data.size()};
 }
 

--- a/src/domain/src/chain/transaction.cpp
+++ b/src/domain/src/chain/transaction.cpp
@@ -30,10 +30,8 @@
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/collection.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/endian.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
 
 #if defined(KTH_CURRENCY_BCH)
 #include <boost/container_hash/hash.hpp>
@@ -86,7 +84,7 @@ bool transaction::is_valid() const {
     return (version_ != 0) || (locktime_ != 0) || !inputs_.empty() || !outputs_.empty();
 }
 
-// Deserialization.
+// Serialization.
 //-----------------------------------------------------------------------------
 
 // static
@@ -146,28 +144,18 @@ expect<transaction> transaction::from_data(byte_reader& reader, bool wire /*= tr
     };
 }
 
-// Serialization.
-//-----------------------------------------------------------------------------
-
-data_chunk transaction::to_data(bool wire) const {
-    data_chunk data;
-    auto const size = serialized_size(wire);
-
-    // Reserve an extra byte to prevent full reallocation in the case of
-    // generate_signature_hash extension by addition of the sighash_type.
-    data.reserve(size + sizeof(uint8_t));
-
-    data_sink ostream(data);
-    to_data(ostream, wire);
-
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
-
-void transaction::to_data(data_sink& stream, bool wire) const {
-    ostream_writer sink_w(stream);
-    to_data(sink_w, wire);
+expect<void> transaction::to_data(byte_writer& writer, bool wire) const {
+    if (wire) {
+        if (auto r = writer.write_little_endian<uint32_t>(version_); ! r) return r;
+        if (auto r = detail::write(writer, inputs_, wire); ! r) return r;
+        if (auto r = detail::write(writer, outputs_, wire); ! r) return r;
+        return writer.write_little_endian<uint32_t>(locktime_);
+    }
+    // Database (outputs forward) serialization.
+    if (auto r = detail::write(writer, outputs_, wire); ! r) return r;
+    if (auto r = detail::write(writer, inputs_, wire); ! r) return r;
+    if (auto r = writer.write_variable_little_endian(locktime_); ! r) return r;
+    return writer.write_variable_little_endian(version_);
 }
 
 // Size.
@@ -628,7 +616,7 @@ bool transaction::is_standard(script_flags_t flags) const {
 //-----------------------------------------------------------------------------
 
 hash_digest hash(transaction const& tx) {
-    return bitcoin_hash(tx.to_data(true));
+    return bitcoin_hash(kth::to_data_chunk(tx, true));
 }
 
 hash_digest outputs_hash(transaction const& tx) {
@@ -647,98 +635,70 @@ hash_digest utxos_hash(transaction const& tx) {
     return to_utxos(tx);
 }
 
-hash_digest to_outputs(transaction const& tx) {
-    auto const sum = [&](size_t total, output const& output) {
-        return total + output.serialized_size();
-    };
+namespace {
 
-    auto const& outs = tx.outputs();
-    auto size = std::accumulate(outs.begin(), outs.end(), size_t(0), sum);
-    data_chunk data;
-    data.reserve(size);
-    data_sink ostream(data);
-    ostream_writer sink_w(ostream);
-
-    auto const write = [&](output const& output) {
-        output.to_data(sink_w, true);
-    };
-
-    std::for_each(outs.begin(), outs.end(), write);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
+// Hash the concatenation of `obj.to_data(writer, wire=true)` over `range`.
+// Hoisted out of every BIP143 hash helper that used to repeat the same
+// allocate-buffer-write-loop boilerplate. `proj` extracts the inner
+// `Serializable` object from each input element.
+template <typename Range, typename Proj>
+hash_digest hash_concat(Range const& range, Proj proj) {
+    size_t size = 0;
+    for (auto const& item : range) {
+        auto const& obj = proj(item);
+        size += obj.serialized_size();
+    }
+    data_chunk data(size);
+    byte_writer writer(data);
+    for (auto const& item : range) {
+        auto const& obj = proj(item);
+        auto const r = obj.to_data(writer, true);
+        KTH_CONTRACT(r.has_value());
+    }
+    KTH_CONTRACT(writer.position() == data.size());
     return bitcoin_hash(data);
+}
+
+} // namespace
+
+hash_digest to_outputs(transaction const& tx) {
+    return hash_concat(tx.outputs(), [](output const& o) -> output const& { return o; });
 }
 
 hash_digest to_inpoints(transaction const& tx) {
-    auto const sum = [&](size_t total, input const& input) {
-        return total + input.previous_output().serialized_size();
-    };
-
-    auto const& ins = tx.inputs();
-    auto size = std::accumulate(ins.begin(), ins.end(), size_t(0), sum);
-    data_chunk data;
-    data.reserve(size);
-    data_sink ostream(data);
-    ostream_writer sink_w(ostream);
-
-    auto const write = [&](input const& input) {
-        input.previous_output().to_data(sink_w);
-    };
-
-    std::for_each(ins.begin(), ins.end(), write);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return bitcoin_hash(data);
+    return hash_concat(tx.inputs(),
+        [](input const& i) -> output_point const& { return i.previous_output(); });
 }
 
 hash_digest to_sequences(transaction const& tx) {
-    auto const sum = [&](size_t total, input const& /*input*/) {
-        return total + sizeof(uint32_t);
-    };
-
     auto const& ins = tx.inputs();
-    auto size = std::accumulate(ins.begin(), ins.end(), size_t(0), sum);
-    data_chunk data;
-    data.reserve(size);
-    data_sink ostream(data);
-    ostream_writer sink_w(ostream);
-
-    auto const write = [&](input const& input) {
-        sink_w.write_4_bytes_little_endian(input.sequence());
-    };
-
-    std::for_each(ins.begin(), ins.end(), write);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
+    auto const size = ins.size() * sizeof(uint32_t);
+    data_chunk data(size);
+    byte_writer writer(data);
+    for (auto const& i : ins) {
+        auto const r = writer.write_little_endian<uint32_t>(i.sequence());
+        KTH_CONTRACT(r.has_value());
+    }
+    KTH_CONTRACT(writer.position() == data.size());
     return bitcoin_hash(data);
 }
 
 hash_digest to_utxos(transaction const& tx) {
-    auto const sum = [&](size_t total, input const& input) {
-        auto const& prevout = input.previous_output().validation.cache;
-        auto const missing = !prevout.is_valid();
-        total += missing ? 0 : prevout.serialized_size();
-        return total;
-    };
-
     auto const& ins = tx.inputs();
-    auto const size = std::accumulate(ins.begin(), ins.end(), size_t(0), sum);
-
-    data_chunk data;
-    data.reserve(size);
-    data_sink ostream(data);
-    ostream_writer sink_w(ostream);
-
-    auto const write = [&](input const& input) {
-        auto const& prevout = input.previous_output().validation.cache;
-        auto const missing = !prevout.is_valid();
-        if (missing) return;
-        prevout.to_data(sink_w);
-    };
-
-    std::for_each(ins.begin(), ins.end(), write);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
+    size_t size = 0;
+    for (auto const& i : ins) {
+        auto const& prevout = i.previous_output().validation.cache;
+        if (prevout.is_valid()) size += prevout.serialized_size();
+    }
+    data_chunk data(size);
+    byte_writer writer(data);
+    for (auto const& i : ins) {
+        auto const& prevout = i.previous_output().validation.cache;
+        if ( ! prevout.is_valid()) continue;
+        auto const r = prevout.to_data(writer, true);
+        KTH_CONTRACT(r.has_value());
+    }
+    KTH_CONTRACT(writer.position() == data.size());
     return bitcoin_hash(data);
 }
 

--- a/src/domain/src/chain/witness.cpp
+++ b/src/domain/src/chain/witness.cpp
@@ -24,10 +24,7 @@
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/assert.hpp>
 #include <kth/infrastructure/utility/collection.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::chain {
 
 using namespace kth::domain::machine;
@@ -105,37 +102,21 @@ bool witness::is_valid() const {
 //-----------------------------------------------------------------------------
 
 data_chunk witness::to_data(bool prefix) const {
-    data_chunk data;
-    auto const size = serialized_size(prefix);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(ostream, prefix);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
+    return kth::to_data_chunk(*this, prefix);
 }
 
-void witness::to_data(data_sink& stream, bool prefix) const {
-    ostream_writer sink_w(stream);
-    to_data(sink_w, prefix);
+expect<void> witness::to_data(byte_writer& writer, bool prefix) const {
+    // Witness prefix is an element count, not byte length (unlike script).
+    if (prefix) {
+        if (auto r = writer.write_size_little_endian(stack_.size()); ! r) return r;
+    }
+    // Each element on the witness stack: varint(element.size()) || bytes (bip144).
+    for (auto const& element : stack_) {
+        if (auto r = writer.write_size_little_endian(element.size()); ! r) return r;
+        if (auto r = writer.write_bytes(element); ! r) return r;
+    }
+    return {};
 }
-
-//void witness::to_data(writer& sink, bool prefix) const
-//{
-//    // Witness prefix is an element count, not byte length (unlike script).
-//    if (prefix)
-//        sink.write_size_little_endian(stack_.size());
-//
-//    auto const serialize = [&sink](data_chunk const& element)
-//    {
-//        // Tokens encoded as variable integer prefixed byte array (bip144).
-//        sink.write_size_little_endian(element.size());
-//        sink.write_bytes(element);
-//    };
-//
-//    // TODO(legacy): optimize store serialization to avoid loop, writing data directly.
-//    std::for_each(stack_.begin(), stack_.end(), serialize);
-//}
 
 std::string witness::to_string() const {
     if ( ! valid_) {

--- a/src/domain/src/config/header.cpp
+++ b/src/domain/src/config/header.cpp
@@ -46,7 +46,7 @@ std::expected<header, std::error_code> header::from_string(std::string_view text
 }
 
 std::string header::to_string() const {
-    return kth::encode_base16(value_.to_data());
+    return kth::encode_base16(kth::to_data_chunk(value_, true));
 }
 
 } // namespace kth::domain::config

--- a/src/domain/src/config/script.cpp
+++ b/src/domain/src/config/script.cpp
@@ -50,7 +50,7 @@ script::script(script const& x)
 }
 
 data_chunk script::to_data() const {
-    return value_.to_data(false);
+    return kth::to_data_chunk(value_, false);
 }
 
 std::string script::to_string() const {

--- a/src/domain/src/config/transaction.cpp
+++ b/src/domain/src/config/transaction.cpp
@@ -50,7 +50,7 @@ std::expected<transaction, std::error_code> transaction::from_string(std::string
 }
 
 std::string transaction::to_string() const {
-    return kth::encode_base16(value_.to_data());
+    return kth::encode_base16(kth::to_data_chunk(value_, true));
 }
 
 } // namespace kth::domain::config

--- a/src/domain/src/machine/operation.cpp
+++ b/src/domain/src/machine/operation.cpp
@@ -13,9 +13,7 @@
 #include <kth/domain/machine/opcode.hpp>
 #include <kth/infrastructure/formats/base_16.hpp>
 #include <kth/infrastructure/utility/assert.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
 #include <kth/infrastructure/utility/string.hpp>
 
 namespace kth::domain::machine {
@@ -179,19 +177,31 @@ expect<operation> operation::from_data(byte_reader& reader) {
 //-----------------------------------------------------------------------------
 
 data_chunk operation::to_data() const {
-    data_chunk data;
-    auto const size = serialized_size();
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
+    return kth::to_data_chunk(*this);
 }
 
-void operation::to_data(data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(sink_w);
+expect<void> operation::to_data(byte_writer& writer) const {
+    if (auto r = writer.write_byte(uint8_t(code_)); ! r) return r;
+
+    // For explicit-size push opcodes, the size prefix (1/2/4 bytes LE)
+    // precedes the payload. Non-push opcodes only emit the opcode byte
+    // itself and any embedded data.
+    auto const size = data_.size();
+    switch (code_) {
+        case opcode::push_one_size:
+            if (auto r = writer.write_byte(uint8_t(size)); ! r) return r;
+            break;
+        case opcode::push_two_size:
+            if (auto r = writer.write_little_endian<uint16_t>(uint16_t(size)); ! r) return r;
+            break;
+        case opcode::push_four_size:
+            if (auto r = writer.write_little_endian<uint32_t>(uint32_t(size)); ! r) return r;
+            break;
+        default:
+            break;
+    }
+
+    return writer.write_bytes(data_);
 }
 
 static

--- a/src/domain/src/math/stealth.cpp
+++ b/src/domain/src/math/stealth.cpp
@@ -40,7 +40,7 @@ bool to_stealth_prefix(uint32_t& out_prefix, script const& script) {
     // A stealth filter is a leftmost substring of the stealth prefix.
     ////constexpr size_t size = binary::bits_per_block * sizeof(uint32_t);
 
-    auto const script_hash = bitcoin_hash(script.to_data(false));
+    auto const script_hash = bitcoin_hash(kth::to_data_chunk(script, false));
     out_prefix = from_little_endian_unsafe<uint32_t>(script_hash);
     return true;
 }

--- a/src/domain/src/message/address.cpp
+++ b/src/domain/src/message/address.cpp
@@ -7,10 +7,7 @@
 // #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const address::command = "addr";
@@ -75,21 +72,7 @@ expect<address> address::from_data(byte_reader& reader, uint32_t version) {
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk address::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
 
-void address::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
-}
 
 size_t address::serialized_size(uint32_t version) const {
     return infrastructure::message::variable_uint_size(addresses_.size()) +
@@ -110,6 +93,14 @@ void address::set_addresses(infrastructure::message::network_address::list const
 
 void address::set_addresses(infrastructure::message::network_address::list&& value) {
     addresses_ = std::move(value);
+}
+
+expect<void> address::to_data(byte_writer& writer, uint32_t version) const {
+    if (auto r = writer.write_variable_little_endian(addresses_.size()); ! r) return r;
+    for (auto const& net_address : addresses_) {
+        if (auto r = net_address.to_data(writer, version, true); ! r) return r;
+    }
+    return {};
 }
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/addrv2.cpp
+++ b/src/domain/src/message/addrv2.cpp
@@ -6,10 +6,7 @@
 
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 // Address sizes for each BIP155 network type
@@ -273,21 +270,7 @@ expect<addrv2> addrv2::from_data(byte_reader& reader, uint32_t version) {
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk addrv2::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
 
-void addrv2::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
-}
 
 size_t addrv2::serialized_size(uint32_t /*version*/) const {
     size_t size = infrastructure::message::variable_uint_size(addresses_.size());
@@ -302,6 +285,20 @@ size_t addrv2::serialized_size(uint32_t /*version*/) const {
     }
 
     return size;
+}
+
+expect<void> addrv2::to_data(byte_writer& writer, uint32_t version) const {
+        if (auto r = writer.write_variable_little_endian(addresses_.size()); ! r) return r;
+
+        for (auto const& entry : addresses_) {
+            if (auto r = writer.write_little_endian<uint32_t>(entry.time); ! r) return r;
+            if (auto r = writer.write_variable_little_endian(entry.services); ! r) return r;
+            if (auto r = writer.write_byte(static_cast<uint8_t>(entry.network)); ! r) return r;
+            if (auto r = writer.write_variable_little_endian(entry.addr.size()); ! r) return r;
+            if (auto r = writer.write_bytes(entry.addr); ! r) return r;
+            if (auto r = writer.write_big_endian<uint16_t>(entry.port); ! r) return r;
+        }
+        return {};
 }
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/alert.cpp
+++ b/src/domain/src/message/alert.cpp
@@ -8,10 +8,7 @@
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/assert.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const alert::command = "alert";
@@ -78,21 +75,7 @@ expect<alert> alert::from_data(byte_reader& reader, uint32_t /*version*/) {
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk alert::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
 
-void alert::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
-}
 
 size_t alert::serialized_size(uint32_t /*version*/) const {
     return infrastructure::message::variable_uint_size(payload_.size()) + payload_.size() +
@@ -129,6 +112,14 @@ void alert::set_signature(data_chunk const& value) {
 
 void alert::set_signature(data_chunk&& value) {
     signature_ = std::move(value);
+}
+
+expect<void> alert::to_data(byte_writer& writer, uint32_t version) const {
+        if (auto r = writer.write_variable_little_endian(payload_.size()); ! r) return r;
+        if (auto r = writer.write_bytes(payload_); ! r) return r;
+        if (auto r = writer.write_variable_little_endian(signature_.size()); ! r) return r;
+        if (auto r = writer.write_bytes(signature_); ! r) return r;
+        return {};
 }
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/alert_payload.cpp
+++ b/src/domain/src/message/alert_payload.cpp
@@ -7,9 +7,6 @@
 #include <kth/domain/constants.hpp>
 // #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 // Libbitcon doesn't use this.
@@ -163,21 +160,7 @@ void alert_payload::reset() {
     reserved_.shrink_to_fit();
 }
 
-data_chunk alert_payload::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
 
-void alert_payload::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
-}
 
 size_t alert_payload::serialized_size(uint32_t /*version*/) const {
     size_t size = 40u +
@@ -336,6 +319,33 @@ void alert_payload::set_reserved(std::string const& value) {
 
 void alert_payload::set_reserved(std::string&& value) {
     reserved_ = std::move(value);
+}
+
+expect<void> alert_payload::to_data(byte_writer& writer, uint32_t version) const {
+        if (auto r = writer.write_little_endian<uint32_t>(this->version_); ! r) return r;
+        if (auto r = writer.write_little_endian<uint64_t>(relay_until_); ! r) return r;
+        if (auto r = writer.write_little_endian<uint64_t>(expiration_); ! r) return r;
+        if (auto r = writer.write_little_endian<uint32_t>(id_); ! r) return r;
+        if (auto r = writer.write_little_endian<uint32_t>(cancel_); ! r) return r;
+        if (auto r = writer.write_variable_little_endian(set_cancel_.size()); ! r) return r;
+
+        for (auto const& entry : set_cancel_) {
+            if (auto r = writer.write_little_endian<uint32_t>(entry); ! r) return r;
+}
+
+        if (auto r = writer.write_little_endian<uint32_t>(min_version_); ! r) return r;
+        if (auto r = writer.write_little_endian<uint32_t>(max_version_); ! r) return r;
+        if (auto r = writer.write_variable_little_endian(set_sub_version_.size()); ! r) return r;
+
+        for (auto const& entry : set_sub_version_) {
+            if (auto r = writer.write_string(entry); ! r) return r;
+}
+
+        if (auto r = writer.write_little_endian<uint32_t>(priority_); ! r) return r;
+        if (auto r = writer.write_string(comment_); ! r) return r;
+        if (auto r = writer.write_string(status_bar_); ! r) return r;
+        if (auto r = writer.write_string(reserved_); ! r) return r;
+        return {};
 }
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/block.cpp
+++ b/src/domain/src/message/block.cpp
@@ -12,10 +12,7 @@
 #include <kth/domain/chain/header.hpp>
 #include <kth/domain/chain/transaction.hpp>
 #include <kth/domain/message/version.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
 
 namespace kth::domain::message {
 
@@ -87,44 +84,26 @@ expect<block> block::from_data(byte_reader& reader, uint32_t /*version*/) {
 
 // Witness is always serialized if present.
 // NOTE: Witness on BCH is dissabled on the chain::block class
-data_chunk block::to_data(uint32_t /*unused*/) const {
-    return chain::block::to_data();
-}
 
-void block::to_data(uint32_t /*version*/, data_sink& stream) const {
-    chain::block::to_data(stream);
-}
 
 size_t block::serialized_size(uint32_t /*unused*/) const {
     return chain::block::serialized_size();
 }
 
-// //TODO(fernando): check this family of functions: to_data_header_nonce
-// void to_data_header_nonce(block const& block, uint64_t nonce, writer& sink) {
-//     block.header().to_data(sink);
-//     sink.write_8_bytes_little_endian(nonce);
-// }
-
-// void to_data_header_nonce(block const& block, uint64_t nonce, std::ostream& stream) {
-void to_data_header_nonce(block const& block, uint64_t nonce, data_sink& stream) {
-    ostream_writer sink_w(stream);
-    to_data_header_nonce(block, nonce, sink_w);
-}
-
-data_chunk to_data_header_nonce(block const& block, uint64_t nonce) {
-    data_chunk data;
-    auto size = chain::header::satoshi_fixed_size() + sizeof(nonce);
-
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data_header_nonce(block, nonce, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
 
 hash_digest hash(block const& block, uint64_t nonce) {
-    return sha256_hash(to_data_header_nonce(block, nonce));
+    auto const size = chain::header::satoshi_fixed_size() + sizeof(nonce);
+    data_chunk buf(size);
+    byte_writer writer(buf);
+    auto const r1 = block.header().to_data(writer, true);
+    auto const r2 = writer.write_little_endian<uint64_t>(nonce);
+    KTH_ASSERT(r1.has_value() && r2.has_value());
+    return sha256_hash(buf);
+}
+
+expect<void> block::to_data(byte_writer& writer, uint32_t version) const {
+        chain::block::to_data(writer);
+        return {};
 }
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/block_transactions.cpp
+++ b/src/domain/src/message/block_transactions.cpp
@@ -8,10 +8,7 @@
 #include <kth/domain/message/version.hpp>
 #include <kth/domain/multi_crypto_support.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const block_transactions::command = "blocktxn";
@@ -75,21 +72,7 @@ expect<block_transactions> block_transactions::from_data(byte_reader& reader, ui
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk block_transactions::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
 
-void block_transactions::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
-}
 
 size_t block_transactions::serialized_size(uint32_t /*version*/) const {
     auto size = hash_size + infrastructure::message::variable_uint_size(transactions_.size());
@@ -129,5 +112,15 @@ void block_transactions::set_transactions(chain::transaction::list&& x) {
     transactions_ = std::move(x);
 }
 
+
+expect<void> block_transactions::to_data(byte_writer& writer, uint32_t version) const {
+        if (auto r = writer.write_hash(block_hash_); ! r) return r;
+        if (auto r = writer.write_variable_little_endian(transactions_.size()); ! r) return r;
+
+        for (auto const& element : transactions_) {
+            element.to_data(writer, /*wire*/ true);
+        }
+        return {};
+}
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/compact_block.cpp
+++ b/src/domain/src/message/compact_block.cpp
@@ -11,9 +11,7 @@
 #include <kth/domain/multi_crypto_support.hpp>
 #include <kth/infrastructure/math/sip_hash.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
 #include <kth/infrastructure/utility/pseudo_random_broken_do_not_use.hpp>
 
 namespace kth::domain::message {
@@ -165,23 +163,7 @@ expect<compact_block> compact_block::from_data(byte_reader& reader, uint32_t ver
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk compact_block::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
 
-void compact_block::to_data(uint32_t version, data_sink& stream) const {
-    //std::println("compact_block::to_data 2");
-
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
-}
 
 size_t compact_block::serialized_size(uint32_t version) const {
     //std::println("compact_block::serialized_size");
@@ -262,28 +244,36 @@ void compact_block::set_transactions(prefilled_transaction::list&& value) {
     transactions_ = std::move(value);
 }
 
-// void to_data_header_nonce(compact_block const& block, std::ostream& stream) {
-void to_data_header_nonce(compact_block const& block, data_sink& stream) {
-    ostream_writer sink_w(stream);
-    to_data_header_nonce(block, sink_w);
-}
-
-data_chunk to_data_header_nonce(compact_block const& block) {
-    //std::println("compact_block::to_data");
-
-    data_chunk data;
-    auto size = chain::header::satoshi_fixed_size() + sizeof(block.nonce());
-
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data_header_nonce(block, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
-
 hash_digest hash(compact_block const& block) {
-    return sha256_hash(to_data_header_nonce(block));
+    auto const size = chain::header::satoshi_fixed_size() + sizeof(block.nonce());
+    data_chunk buf(size);
+    byte_writer writer(buf);
+    auto const r1 = block.header().to_data(writer, true);
+    auto const r2 = writer.write_little_endian<uint64_t>(block.nonce());
+    KTH_ASSERT(r1.has_value() && r2.has_value());
+    return sha256_hash(buf);
+}
+
+expect<void> compact_block::to_data(byte_writer& writer, uint32_t version) const {
+        if (auto r = header_.to_data(writer, true); ! r) return r;
+        if (auto r = writer.write_little_endian<uint64_t>(nonce_); ! r) return r;
+        if (auto r = writer.write_variable_little_endian(short_ids_.size()); ! r) return r;
+
+        for (auto const& element : short_ids_) {
+            //sink.write_mini_hash(element);
+            uint32_t lsb = element & 0xffffffff;
+            uint16_t msb = (element >> 32) & 0xffff;
+            if (auto r = writer.write_little_endian<uint32_t>(lsb); ! r) return r;
+            if (auto r = writer.write_little_endian<uint16_t>(msb); ! r) return r;
+        }
+
+        if (auto r = writer.write_variable_little_endian(transactions_.size()); ! r) return r;
+
+        // NOTE: Witness flag is controlled by prefilled tx
+        for (auto const& element : transactions_) {
+            if (auto r = element.to_data(writer, version); ! r) return r;
+        }
+        return {};
 }
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/double_spend_proof.cpp
+++ b/src/domain/src/message/double_spend_proof.cpp
@@ -11,10 +11,7 @@
 #include <kth/domain/multi_crypto_support.hpp>
 #include <kth/infrastructure/math/sip_hash.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const double_spend_proof::command = "dsproof-beta";
@@ -94,24 +91,14 @@ expect<double_spend_proof> double_spend_proof::from_data(byte_reader& reader, ui
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk double_spend_proof::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
-
-void double_spend_proof::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
+expect<void> double_spend_proof::to_data(byte_writer& writer, uint32_t /*version*/) const {
+    if (auto r = out_point_.to_data(writer, true); ! r) return r;
+    if (auto r = spender1_.to_data(writer); ! r) return r;
+    return spender2_.to_data(writer);
 }
 
 hash_digest double_spend_proof::hash() const {
-    return sha256_hash(to_data(0));
+    return sha256_hash(kth::to_data_chunk(*this, uint32_t{0}));
 }
 
 [[nodiscard]]

--- a/src/domain/src/message/fee_filter.cpp
+++ b/src/domain/src/message/fee_filter.cpp
@@ -6,9 +6,6 @@
 
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/error.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const fee_filter::command = "feefilter";
@@ -59,21 +56,7 @@ expect<fee_filter> fee_filter::from_data(byte_reader& reader, uint32_t version) 
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk fee_filter::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
 
-void fee_filter::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
-}
 
 bool fee_filter::is_valid() const {
     // return !insufficient_version_;
@@ -99,6 +82,11 @@ void fee_filter::set_minimum_fee(uint64_t value) {
 
     // This is no longer a default instance, so is valid.
     insufficient_version_ = false;
+}
+
+expect<void> fee_filter::to_data(byte_writer& writer, uint32_t version) const {
+        if (auto r = writer.write_little_endian<uint64_t>(minimum_fee_); ! r) return r;
+        return {};
 }
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/filter_add.cpp
+++ b/src/domain/src/message/filter_add.cpp
@@ -8,10 +8,7 @@
 #include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/assert.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const filter_add::command = "filteradd";
@@ -70,21 +67,7 @@ expect<filter_add> filter_add::from_data(byte_reader& reader, uint32_t version) 
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk filter_add::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
 
-void filter_add::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
-}
 
 size_t filter_add::serialized_size(uint32_t /*version*/) const {
     return infrastructure::message::variable_uint_size(data_.size()) + data_.size();
@@ -104,6 +87,12 @@ void filter_add::set_data(data_chunk const& value) {
 
 void filter_add::set_data(data_chunk&& value) {
     data_ = std::move(value);
+}
+
+expect<void> filter_add::to_data(byte_writer& writer, uint32_t version) const {
+        if (auto r = writer.write_variable_little_endian(data_.size()); ! r) return r;
+        if (auto r = writer.write_bytes(data_); ! r) return r;
+        return {};
 }
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/filter_clear.cpp
+++ b/src/domain/src/message/filter_clear.cpp
@@ -5,8 +5,6 @@
 #include <kth/domain/message/filter_clear.hpp>
 
 #include <kth/domain/message/version.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::message {
 
@@ -44,19 +42,7 @@ expect<filter_clear> filter_clear::from_data(byte_reader& reader, uint32_t versi
 //-----------------------------------------------------------------------------
 
 data_chunk filter_clear::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
-
-void filter_clear::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
+    return kth::to_data_chunk(*this, version);
 }
 
 size_t filter_clear::serialized_size(uint32_t version) const {

--- a/src/domain/src/message/filter_load.cpp
+++ b/src/domain/src/message/filter_load.cpp
@@ -7,10 +7,7 @@
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/assert.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const filter_load::command = "filterload";
@@ -88,21 +85,7 @@ expect<filter_load> filter_load::from_data(byte_reader& reader, uint32_t version
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk filter_load::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
 
-void filter_load::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
-}
 
 size_t filter_load::serialized_size(uint32_t /*version*/) const {
     return 1u + 4u + 4u + infrastructure::message::variable_uint_size(filter_.size()) + filter_.size();
@@ -146,6 +129,15 @@ uint8_t filter_load::flags() const {
 
 void filter_load::set_flags(uint8_t value) {
     flags_ = value;
+}
+
+expect<void> filter_load::to_data(byte_writer& writer, uint32_t version) const {
+        if (auto r = writer.write_variable_little_endian(filter_.size()); ! r) return r;
+        if (auto r = writer.write_bytes(filter_); ! r) return r;
+        if (auto r = writer.write_little_endian<uint32_t>(hash_functions_); ! r) return r;
+        if (auto r = writer.write_little_endian<uint32_t>(tweak_); ! r) return r;
+        if (auto r = writer.write_byte(flags_); ! r) return r;
+        return {};
 }
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/get_address.cpp
+++ b/src/domain/src/message/get_address.cpp
@@ -5,9 +5,6 @@
 #include <kth/domain/message/get_address.hpp>
 
 #include <kth/domain/message/version.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const get_address::command = "getaddr";
@@ -31,21 +28,6 @@ expect<get_address> get_address::from_data(byte_reader& reader, uint32_t /*versi
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk get_address::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
-
-void get_address::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
-}
 
 size_t get_address::serialized_size(uint32_t version) const {
     return get_address::satoshi_fixed_size(version);

--- a/src/domain/src/message/get_block_transactions.cpp
+++ b/src/domain/src/message/get_block_transactions.cpp
@@ -9,10 +9,7 @@
 #include <kth/domain/message/version.hpp>
 #include <kth/domain/multi_crypto_support.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const get_block_transactions::command = "getblocktxn";
@@ -83,21 +80,7 @@ expect<get_block_transactions> get_block_transactions::from_data(byte_reader& re
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk get_block_transactions::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
 
-void get_block_transactions::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
-}
 
 size_t get_block_transactions::serialized_size(uint32_t /*version*/) const {
     auto size = hash_size + infrastructure::message::variable_uint_size(indexes_.size());
@@ -135,6 +118,15 @@ void get_block_transactions::set_indexes(std::vector<uint64_t> const& values) {
 
 void get_block_transactions::set_indexes(std::vector<uint64_t>&& values) {
     indexes_ = values;
+}
+
+expect<void> get_block_transactions::to_data(byte_writer& writer, uint32_t version) const {
+        if (auto r = writer.write_hash(block_hash_); ! r) return r;
+        if (auto r = writer.write_variable_little_endian(indexes_.size()); ! r) return r;
+        for (auto const& element : indexes_) {
+            if (auto r = writer.write_variable_little_endian(element); ! r) return r;
+        }
+        return {};
 }
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/get_blocks.cpp
+++ b/src/domain/src/message/get_blocks.cpp
@@ -6,10 +6,7 @@
 
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const get_blocks::command = "getblocks";
@@ -91,21 +88,7 @@ expect<get_blocks> get_blocks::from_data(byte_reader& reader, [[maybe_unused]] u
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk get_blocks::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
 
-void get_blocks::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
-}
 
 size_t get_blocks::serialized_size(uint32_t /*version*/) const {
     return size_t(36) + infrastructure::message::variable_uint_size(start_hashes_.size()) + hash_size * start_hashes_.size();
@@ -137,6 +120,18 @@ hash_digest const& get_blocks::stop_hash() const {
 
 void get_blocks::set_stop_hash(hash_digest const& value) {
     stop_hash_ = value;
+}
+
+expect<void> get_blocks::to_data(byte_writer& writer, uint32_t version) const {
+        if (auto r = writer.write_little_endian<uint32_t>(version); ! r) return r;
+        if (auto r = writer.write_variable_little_endian(start_hashes_.size()); ! r) return r;
+
+        for (auto const& start_hash : start_hashes_) {
+            if (auto r = writer.write_hash(start_hash); ! r) return r;
+        }
+
+        if (auto r = writer.write_hash(stop_hash_); ! r) return r;
+        return {};
 }
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/header.cpp
+++ b/src/domain/src/message/header.cpp
@@ -9,9 +9,6 @@
 
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const header::command = "headers";
@@ -51,24 +48,19 @@ expect<header> header::from_data(byte_reader& reader, uint32_t version) {
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk header::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
 
-void header::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
-}
 
 size_t header::serialized_size(uint32_t version) const {
     return satoshi_fixed_size(version);
+}
+
+expect<void> header::to_data(byte_writer& writer, uint32_t version) const {
+        chain::header::to_data(writer, true);  // wire=true
+
+        if (version != version::level::canonical) {
+            if (auto r = writer.write_variable_little_endian(uint64_t{0}); ! r) return r;
+        }
+        return {};
 }
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/headers.cpp
+++ b/src/domain/src/message/headers.cpp
@@ -14,10 +14,7 @@
 #include <kth/domain/message/inventory_vector.hpp>
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const headers::command = "headers";
@@ -86,21 +83,7 @@ expect<headers> headers::from_data(byte_reader& reader, uint32_t version) {
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk headers::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
 
-void headers::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
-}
 
 bool headers::is_sequential() const {
     if (elements_.empty()) {
@@ -160,6 +143,15 @@ void headers::set_elements(header::list const& values) {
 
 void headers::set_elements(header::list&& values) {
     elements_ = std::move(values);
+}
+
+expect<void> headers::to_data(byte_writer& writer, uint32_t version) const {
+        if (auto r = writer.write_variable_little_endian(elements_.size()); ! r) return r;
+
+        for (auto const& element : elements_) {
+            if (auto r = element.to_data(writer, version); ! r) return r;
+        }
+        return {};
 }
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/heading.cpp
+++ b/src/domain/src/message/heading.cpp
@@ -10,8 +10,7 @@
 #include <kth/domain/multi_crypto_support.hpp>
 
 #include <kth/infrastructure/message/message_tools.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
 
 namespace kth::domain::message {
 
@@ -104,19 +103,14 @@ expect<heading> heading::from_data(byte_reader& reader, uint32_t /*version*/) {
 //-----------------------------------------------------------------------------
 
 data_chunk heading::to_data() const {
-    data_chunk data;
-    auto const size = satoshi_fixed_size();
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
+    return kth::to_data_chunk(*this);
 }
 
-void heading::to_data(data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(sink_w);
+expect<void> heading::to_data(byte_writer& writer) const {
+    if (auto r = writer.write_little_endian<uint32_t>(magic_); ! r) return r;
+    if (auto r = writer.write_string_fixed(command_, command_size); ! r) return r;
+    if (auto r = writer.write_little_endian<uint32_t>(payload_size_); ! r) return r;
+    return writer.write_little_endian<uint32_t>(checksum_);
 }
 
 message_type heading::type() const {

--- a/src/domain/src/message/inventory.cpp
+++ b/src/domain/src/message/inventory.cpp
@@ -12,10 +12,7 @@
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const inventory::command = "inv";
@@ -89,21 +86,7 @@ expect<inventory> inventory::from_data(byte_reader& reader, uint32_t version) {
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk inventory::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
 
-void inventory::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
-}
 
 void inventory::to_hashes(hash_list& out, type_id type) const {
     out.reserve(inventories_.size());
@@ -155,6 +138,15 @@ void inventory::set_inventories(inventory_vector::list const& value) {
 
 void inventory::set_inventories(inventory_vector::list&& value) {
     inventories_ = std::move(value);
+}
+
+expect<void> inventory::to_data(byte_writer& writer, uint32_t version) const {
+        if (auto r = writer.write_variable_little_endian(inventories_.size()); ! r) return r;
+
+        for (auto const& inventory : inventories_) {
+            if (auto r = inventory.to_data(writer, version); ! r) return r;
+        }
+        return {};
 }
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/inventory_vector.cpp
+++ b/src/domain/src/message/inventory_vector.cpp
@@ -8,9 +8,6 @@
 #include <string>
 
 #include <kth/domain/message/inventory.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 uint32_t inventory_vector::to_number(type_id type) {
@@ -83,21 +80,7 @@ expect<inventory_vector> inventory_vector::from_data(byte_reader& reader, uint32
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk inventory_vector::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
 
-void inventory_vector::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
-}
 
 size_t inventory_vector::serialized_size(uint32_t version) const {
     return inventory_vector::satoshi_fixed_size(version);
@@ -142,6 +125,13 @@ hash_digest const& inventory_vector::hash() const {
 
 void inventory_vector::set_hash(hash_digest const& value) {
     hash_ = value;
+}
+
+expect<void> inventory_vector::to_data(byte_writer& writer, uint32_t version) const {
+        auto const raw_type = inventory_vector::to_number(type_);
+        if (auto r = writer.write_little_endian<uint32_t>(raw_type); ! r) return r;
+        if (auto r = writer.write_hash(hash_); ! r) return r;
+        return {};
 }
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/memory_pool.cpp
+++ b/src/domain/src/message/memory_pool.cpp
@@ -5,9 +5,6 @@
 #include <kth/domain/message/memory_pool.hpp>
 
 #include <kth/domain/message/version.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const memory_pool::command = "mempool";
@@ -43,22 +40,6 @@ expect<memory_pool> memory_pool::from_data(byte_reader& reader, uint32_t version
 
 // Serialization.
 //-----------------------------------------------------------------------------
-
-data_chunk memory_pool::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
-
-void memory_pool::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
-}
 
 size_t memory_pool::serialized_size(uint32_t version) const {
     return memory_pool::satoshi_fixed_size(version);

--- a/src/domain/src/message/merkle_block.cpp
+++ b/src/domain/src/message/merkle_block.cpp
@@ -10,10 +10,7 @@
 #include <kth/domain/multi_crypto_support.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/assert.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const merkle_block::command = "merkleblock";
@@ -130,21 +127,7 @@ expect<merkle_block> merkle_block::from_data(byte_reader& reader, uint32_t versi
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk merkle_block::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
 
-void merkle_block::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
-}
 
 size_t merkle_block::serialized_size(uint32_t /*version*/) const {
     return header_.serialized_size() + 4u +
@@ -202,6 +185,22 @@ void merkle_block::set_flags(data_chunk const& value) {
 
 void merkle_block::set_flags(data_chunk&& value) {
     flags_ = std::move(value);
+}
+
+expect<void> merkle_block::to_data(byte_writer& writer, uint32_t version) const {
+        if (auto r = header_.to_data(writer, true); ! r) return r;
+
+        auto const total32 = *safe_unsigned<uint32_t>(total_transactions_);
+        if (auto r = writer.write_little_endian<uint32_t>(total32); ! r) return r;
+        if (auto r = writer.write_variable_little_endian(hashes_.size()); ! r) return r;
+
+        for (auto const& hash : hashes_) {
+            if (auto r = writer.write_hash(hash); ! r) return r;
+        }
+
+        if (auto r = writer.write_variable_little_endian(flags_.size()); ! r) return r;
+        if (auto r = writer.write_bytes(flags_); ! r) return r;
+        return {};
 }
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/ping.cpp
+++ b/src/domain/src/message/ping.cpp
@@ -5,9 +5,6 @@
 #include <kth/domain/message/ping.hpp>
 
 // #include <kth/domain/message/version.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const ping::command = "ping";
@@ -52,21 +49,7 @@ expect<ping> ping::from_data(byte_reader& reader, uint32_t version) {
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk ping::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
 
-void ping::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
-}
 
 bool ping::is_valid() const {
     return valid_ || nonceless_ || nonce_ != 0;
@@ -88,6 +71,13 @@ uint64_t ping::nonce() const {
 
 void ping::set_nonce(uint64_t value) {
     nonce_ = value;
+}
+
+expect<void> ping::to_data(byte_writer& writer, uint32_t version) const {
+        if (version >= version::level::bip31) {
+            if (auto r = writer.write_little_endian<uint64_t>(nonce_); ! r) return r;
+        }
+        return {};
 }
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/pong.cpp
+++ b/src/domain/src/message/pong.cpp
@@ -5,9 +5,6 @@
 #include <kth/domain/message/pong.hpp>
 
 #include <kth/domain/message/version.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const pong::command = "pong";
@@ -47,21 +44,7 @@ expect<pong> pong::from_data(byte_reader& reader, uint32_t version) {
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk pong::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
 
-void pong::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
-}
 
 bool pong::is_valid() const {
     return valid_ || (nonce_ != 0);
@@ -82,6 +65,11 @@ uint64_t pong::nonce() const {
 
 void pong::set_nonce(uint64_t value) {
     nonce_ = value;
+}
+
+expect<void> pong::to_data(byte_writer& writer, uint32_t version) const {
+        if (auto r = writer.write_little_endian<uint64_t>(nonce_); ! r) return r;
+        return {};
 }
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/prefilled_transaction.cpp
+++ b/src/domain/src/message/prefilled_transaction.cpp
@@ -7,9 +7,6 @@
 #include <kth/domain/chain/transaction.hpp>
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 #if defined(KTH_CURRENCY_BCH)
@@ -65,21 +62,7 @@ expect<prefilled_transaction> prefilled_transaction::from_data(byte_reader& read
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk prefilled_transaction::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
 
-void prefilled_transaction::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
-}
 
 size_t prefilled_transaction::serialized_size(uint32_t /*version*/) const {
     return infrastructure::message::variable_uint_size(index_) +
@@ -108,6 +91,12 @@ void prefilled_transaction::set_transaction(chain::transaction const& tx) {
 
 void prefilled_transaction::set_transaction(chain::transaction&& tx) {
     transaction_ = std::move(tx);
+}
+
+expect<void> prefilled_transaction::to_data(byte_writer& writer, uint32_t version) const {
+        if (auto r = writer.write_variable_little_endian(index_); ! r) return r;
+        transaction_.to_data(writer, true);
+        return {};
 }
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/reject.cpp
+++ b/src/domain/src/message/reject.cpp
@@ -8,9 +8,6 @@
 #include <kth/infrastructure/message/message_tools.hpp>
 // #include <kth/domain/message/transaction.hpp>
 #include <kth/domain/message/version.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const reject::command = "reject";
@@ -130,21 +127,7 @@ expect<reject> reject::from_data(byte_reader& reader, uint32_t version) {
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk reject::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
 
-void reject::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
-}
 
 size_t reject::serialized_size(uint32_t /*version*/) const {
     size_t size = 1u + infrastructure::message::variable_uint_size(message_.size()) +
@@ -255,6 +238,18 @@ uint8_t reject::reason_to_byte(reason_code value) {
         default:
             return 0x00;
     }
+}
+
+expect<void> reject::to_data(byte_writer& writer, uint32_t version) const {
+        if (auto r = writer.write_string(message_); ! r) return r;
+        if (auto r = writer.write_byte(reason_to_byte(code_)); ! r) return r;
+        if (auto r = writer.write_string(reason_); ! r) return r;
+
+        if ((message_ == block::command) ||
+            (message_ == transaction::command)) {
+            if (auto r = writer.write_hash(data_); ! r) return r;
+        }
+        return {};
 }
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/send_addrv2.cpp
+++ b/src/domain/src/message/send_addrv2.cpp
@@ -5,9 +5,6 @@
 #include <kth/domain/message/send_addrv2.hpp>
 
 #include <kth/domain/message/version.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const send_addrv2::command = "sendaddrv2";
@@ -32,7 +29,7 @@ void send_addrv2::reset() {
     insufficient_version_ = true;
 }
 
-// Deserialization.
+// Serialization.
 //-----------------------------------------------------------------------------
 
 // static
@@ -44,26 +41,9 @@ expect<send_addrv2> send_addrv2::from_data(byte_reader& reader, uint32_t version
     return send_addrv2(insufficient_version);
 }
 
-// Serialization.
-//-----------------------------------------------------------------------------
-
-data_chunk send_addrv2::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
-
-void send_addrv2::to_data(uint32_t /*version*/, data_sink& /*stream*/) const {
+expect<void> send_addrv2::to_data(byte_writer& /*writer*/, uint32_t /*version*/) const {
     // Empty message - no payload
-}
-
-void send_addrv2::to_data(uint32_t /*version*/, writer& /*sink*/) const {
-    // Empty message - no payload
+    return {};
 }
 
 size_t send_addrv2::serialized_size(uint32_t version) const {

--- a/src/domain/src/message/send_compact.cpp
+++ b/src/domain/src/message/send_compact.cpp
@@ -7,9 +7,6 @@
 #include <cstdint>
 
 #include <kth/domain/message/version.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const send_compact::command = "sendcmpct";
@@ -69,21 +66,7 @@ expect<send_compact> send_compact::from_data(byte_reader& reader, uint32_t versi
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk send_compact::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
 
-void send_compact::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
-}
 
 size_t send_compact::serialized_size(uint32_t version) const {
     return send_compact::satoshi_fixed_size(version);
@@ -103,6 +86,12 @@ uint64_t send_compact::version() const {
 
 void send_compact::set_version(uint64_t version) {
     version_ = version;
+}
+
+expect<void> send_compact::to_data(byte_writer& writer, uint32_t version) const {
+        if (auto r = writer.write_byte(uint8_t(high_bandwidth_mode_)); ! r) return r;
+        if (auto r = writer.write_little_endian<uint64_t>(this->version_); ! r) return r;
+        return {};
 }
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/send_headers.cpp
+++ b/src/domain/src/message/send_headers.cpp
@@ -5,9 +5,6 @@
 #include <kth/domain/message/send_headers.hpp>
 
 #include <kth/domain/message/version.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const send_headers::command = "sendheaders";
@@ -32,7 +29,7 @@ void send_headers::reset() {
     insufficient_version_ = true;
 }
 
-// Deserialization.
+// Serialization.
 //-----------------------------------------------------------------------------
 
 // static
@@ -44,22 +41,8 @@ expect<send_headers> send_headers::from_data(byte_reader& reader, uint32_t versi
     return send_headers(insufficient_version);
 }
 
-// Serialization.
-//-----------------------------------------------------------------------------
-
-data_chunk send_headers::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
-
-//TODO(fernando): empty?
-void send_headers::to_data(uint32_t /*version*/, data_sink& /*stream*/) const {
+expect<void> send_headers::to_data(byte_writer& /*writer*/, uint32_t /*version*/) const {
+    return {};
 }
 
 size_t send_headers::serialized_size(uint32_t version) const {

--- a/src/domain/src/message/transaction.cpp
+++ b/src/domain/src/message/transaction.cpp
@@ -11,7 +11,6 @@
 #include <kth/domain/chain/output.hpp>
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-#include <kth/infrastructure/utility/reader.hpp>
 
 namespace kth::domain::message {
 
@@ -72,16 +71,15 @@ expect<transaction> transaction::from_data(byte_reader& reader, uint32_t version
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk transaction::to_data(uint32_t /*version*/) const {
-    return chain::transaction::to_data(true);
-}
 
-void transaction::to_data(uint32_t /*version*/, data_sink& stream) const {
-    chain::transaction::to_data(stream, true);
-}
 
 size_t transaction::serialized_size(uint32_t /*unused*/) const {
     return chain::transaction::serialized_size(true);
+}
+
+expect<void> transaction::to_data(byte_writer& writer, uint32_t version) const {
+        chain::transaction::to_data(writer, true);
+        return {};
 }
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/verack.cpp
+++ b/src/domain/src/message/verack.cpp
@@ -5,9 +5,6 @@
 #include <kth/domain/message/verack.hpp>
 
 #include <kth/domain/message/version.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const verack::command = "verack";
@@ -20,7 +17,7 @@ bool verack::is_valid() const {
 
 void verack::reset() {}
 
-// Deserialization.
+// Serialization.
 //-----------------------------------------------------------------------------
 
 // static
@@ -28,22 +25,8 @@ expect<verack> verack::from_data(byte_reader& /*reader*/, uint32_t /*version*/) 
     return verack();
 }
 
-// Serialization.
-//-----------------------------------------------------------------------------
-
-data_chunk verack::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
-
-//TODO(fernando): empty?
-void verack::to_data(uint32_t /*version*/, data_sink& /*stream*/) const {
+expect<void> verack::to_data(byte_writer& /*writer*/, uint32_t /*version*/) const {
+    return {};
 }
 
 size_t verack::serialized_size(uint32_t version) const {

--- a/src/domain/src/message/version.cpp
+++ b/src/domain/src/message/version.cpp
@@ -6,9 +6,6 @@
 
 #include <algorithm>
 #include <kth/infrastructure/message/message_tools.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const version::command = "version";
@@ -136,21 +133,7 @@ expect<message::version> version::from_data(byte_reader& reader, uint32_t versio
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk version::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
 
-void version::to_data(uint32_t version, data_sink& stream) const {
-    ostream_writer sink_w(stream);
-    to_data(version, sink_w);
-}
 
 size_t version::serialized_size(uint32_t version) const {
     auto size =
@@ -256,6 +239,23 @@ bool version::relay() const {
 
 void version::set_relay(bool relay) {
     relay_ = relay;
+}
+
+expect<void> version::to_data(byte_writer& writer, uint32_t version) const {
+        if (auto r = writer.write_little_endian<uint32_t>(value_); ! r) return r;
+        auto const effective_version = std::min(version, value_);
+        if (auto r = writer.write_little_endian<uint64_t>(services_); ! r) return r;
+        if (auto r = writer.write_little_endian<uint64_t>(timestamp_); ! r) return r;
+        if (auto r = address_receiver_.to_data(writer, version, false); ! r) return r;
+        if (auto r = address_sender_.to_data(writer, version, false); ! r) return r;
+        if (auto r = writer.write_little_endian<uint64_t>(nonce_); ! r) return r;
+        if (auto r = writer.write_string(user_agent_); ! r) return r;
+        if (auto r = writer.write_little_endian<uint32_t>(start_height_); ! r) return r;
+
+        if (effective_version >= level::bip37) {
+            if (auto r = writer.write_byte(relay_ ? 1 : 0); ! r) return r;
+        }
+        return {};
 }
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/xverack.cpp
+++ b/src/domain/src/message/xverack.cpp
@@ -5,9 +5,6 @@
 #include <kth/domain/message/xverack.hpp>
 
 #include <kth/domain/message/version.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const xverack::command = "xverack";
@@ -21,7 +18,7 @@ bool xverack::is_valid() const {
 void xverack::reset() {
 }
 
-// Deserialization.
+// Serialization.
 //-----------------------------------------------------------------------------
 
 // static
@@ -29,22 +26,9 @@ expect<xverack> xverack::from_data(byte_reader& /*reader*/, uint32_t /*version*/
     return xverack();
 }
 
-// Serialization.
-//-----------------------------------------------------------------------------
-
-data_chunk xverack::to_data(uint32_t version) const {
-    data_chunk data;
-    auto const size = serialized_size(version);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
+expect<void> xverack::to_data(byte_writer& /*writer*/, uint32_t /*version*/) const {
+    return {};
 }
-
-//TODO(fernando): empty?
-void xverack::to_data(uint32_t /*version*/, data_sink& /*stream*/) const {}
 
 size_t xverack::serialized_size(uint32_t version) const {
     return xverack::satoshi_fixed_size(version);

--- a/src/domain/src/message/xversion.cpp
+++ b/src/domain/src/message/xversion.cpp
@@ -6,9 +6,6 @@
 
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
 namespace kth::domain::message {
 
 std::string const xversion::command = "xversion";
@@ -47,17 +44,12 @@ expect<xversion> xversion::from_data(byte_reader& reader, uint32_t version) {
 //     data_chunk data;
 //     auto const size = serialized_size(version);
 //     data.reserve(size);
-//     data_sink ostream(data);
 //     to_data(version, ostream);
 //     ostream.flush();
 //     KTH_ASSERT(data.size() == size);
 //     return data;
 // }
 
-// void xversion::to_data(uint32_t version, data_sink& stream) const {
-//     ostream_writer sink_w(stream);
-//     to_data(version, sink_w);
-// }
 
 size_t xversion::serialized_size(uint32_t version) const {
     return 0;

--- a/src/domain/src/wallet/hd_private.cpp
+++ b/src/domain/src/wallet/hd_private.cpp
@@ -24,7 +24,6 @@
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/endian.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
-#include <kth/infrastructure/utility/serializer.hpp>
 
 namespace kth::domain::wallet {
 

--- a/src/domain/src/wallet/message.cpp
+++ b/src/domain/src/wallet/message.cpp
@@ -7,9 +7,8 @@
 #include <kth/domain/constants.hpp>
 #include <kth/domain/define.hpp>
 #include <kth/domain/wallet/ec_private.hpp>
-#include <kth/infrastructure/utility/container_sink.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::domain::wallet {
 
@@ -24,13 +23,16 @@ hash_digest hash_message(byte_span message) {
     // This is a specified magic prefix.
     static std::string const prefix("Bitcoin Signed Message:\n");
 
-    data_chunk data;
-    data_sink ostream(data);
-    ostream_writer sink_w(ostream);
-    sink_w.write_string(prefix);
-    sink_w.write_variable_little_endian(message.size());
-    sink_w.write_bytes(message.data(), message.size());
-    ostream.flush();
+    // Wire layout: varint(prefix.size) || prefix || varint(message.size) || message
+    auto const size = kth::size_variable_integer(prefix.size()) + prefix.size()
+                    + kth::size_variable_integer(message.size()) + message.size();
+    data_chunk data(size);
+    byte_writer writer(data);
+    auto write_ok = [](expect<void> const& r) { KTH_CONTRACT(r.has_value()); };
+    write_ok(writer.write_string(prefix));
+    write_ok(writer.write_variable_little_endian(message.size()));
+    write_ok(writer.write_bytes(message));
+    KTH_CONTRACT(writer.position() == data.size());
     return bitcoin_hash(data);
 }
 

--- a/src/domain/src/wallet/payment_address.cpp
+++ b/src/domain/src/wallet/payment_address.cpp
@@ -290,9 +290,7 @@ payment_address payment_address::from_public(ec_public const& point, uint8_t ver
 }
 
 payment_address payment_address::from_script(chain::script const& script, uint8_t version) {
-    // Working around VC++ CTP compiler break here.
-    auto const data = script.to_data(false);
-    return payment_address{bitcoin_short_hash(data), version};
+    return payment_address(bitcoin_short_hash(kth::to_data_chunk(script, false)), version);
 }
 
 // Cast operators.

--- a/src/domain/test/chain/block.cpp
+++ b/src/domain/test/chain/block.cpp
@@ -296,7 +296,7 @@ TEST_CASE("block from data genesis mainnet  success", "[block serialization]") {
     REQUIRE(genesis.header().serialized_size() == 80u);
 
     // Save genesis block.
-    auto const raw_block = genesis.to_data();
+    auto const raw_block = kth::to_data_chunk(genesis);
     REQUIRE(raw_block.size() == 285u);
 
     // Reload genesis block.
@@ -318,7 +318,7 @@ TEST_CASE("block  factory from data 2  genesis mainnet  success", "[block serial
     REQUIRE(genesis.header().serialized_size() == 80u);
 
     // Save genesis block.
-    auto const raw_block = genesis.to_data();
+    auto const raw_block = kth::to_data_chunk(genesis);
     REQUIRE(raw_block.size() == 285u);
 
     // Reload genesis block.
@@ -340,7 +340,7 @@ TEST_CASE("block  factory from data 3  genesis mainnet  success", "[block serial
     REQUIRE(genesis.header().serialized_size() == 80u);
 
     // Save genesis block.
-    data_chunk const raw_block = genesis.to_data();
+    data_chunk const raw_block = kth::to_data_chunk(genesis);
     REQUIRE(raw_block.size() == 285u);
 
     // Reload genesis block.
@@ -398,7 +398,7 @@ TEST_CASE("block  generate merkle root  block with multiple transactions  matche
     auto const& block100k = *result;
     REQUIRE(block100k.is_valid());
 
-    auto const serial = block100k.to_data();
+    auto const serial = kth::to_data_chunk(block100k);
     REQUIRE(raw == serial);
 
     auto const header = block100k.header();

--- a/src/domain/test/chain/header.cpp
+++ b/src/domain/test/chain/header.cpp
@@ -255,7 +255,7 @@ TEST_CASE("chain header from data valid input  success", "[chain header]") {
         6523454,
         68644};
 
-    auto const data = expected.to_data();
+    auto const data = kth::to_data_chunk(expected, true);
 
     byte_reader reader(data);
     auto const result_exp = chain::header::from_data(reader);
@@ -275,7 +275,7 @@ TEST_CASE("chain header  factory from data 2  valid input  success", "[chain hea
         6523454,
         68644};
 
-    auto const data = expected.to_data();
+    auto const data = kth::to_data_chunk(expected, true);
     byte_reader reader(data);
     auto const result_exp = chain::header::from_data(reader);
     REQUIRE(result_exp);
@@ -294,7 +294,7 @@ TEST_CASE("chain header  factory from data 3  valid input  success", "[chain hea
         6523454,
         68644};
 
-    auto const data = expected.to_data();
+    auto const data = kth::to_data_chunk(expected, true);
     byte_reader reader(data);
     auto const result_exp = chain::header::from_data(reader);
     REQUIRE(result_exp);

--- a/src/domain/test/chain/input.cpp
+++ b/src/domain/test/chain/input.cpp
@@ -89,7 +89,7 @@ TEST_CASE("input from data valid input  success", "[input]") {
     REQUIRE(instance.serialized_size() == valid_raw_input.size());
 
     // Re-save and compare against original.
-    auto const resave = instance.to_data();
+    auto const resave = kth::to_data_chunk(instance, true);
     REQUIRE(resave.size() == valid_raw_input.size());
     REQUIRE(resave == valid_raw_input);
 }
@@ -102,7 +102,7 @@ TEST_CASE("input  factory from data 2  valid input  success", "[input]") {
     REQUIRE(instance.serialized_size() == valid_raw_input.size());
 
     // Re-save and compare against original.
-    auto const resave = instance.to_data();
+    auto const resave = kth::to_data_chunk(instance, true);
     REQUIRE(resave.size() == valid_raw_input.size());
     REQUIRE(resave == valid_raw_input);
 }
@@ -115,7 +115,7 @@ TEST_CASE("input  factory from data 3  valid input  success", "[input]") {
     REQUIRE(instance.serialized_size() == valid_raw_input.size());
 
     // Re-save and compare against original.
-    auto const resave = instance.to_data();
+    auto const resave = kth::to_data_chunk(instance, true);
     REQUIRE(resave.size() == valid_raw_input.size());
     REQUIRE(resave == valid_raw_input);
 }

--- a/src/domain/test/chain/output.cpp
+++ b/src/domain/test/chain/output.cpp
@@ -92,7 +92,7 @@ TEST_CASE("output from data  valid input success", "[output]") {
     REQUIRE( ! instance.token_data().has_value());
 
     // Re-save and compare against original.
-    data_chunk resave = instance.to_data();
+    data_chunk resave = kth::to_data_chunk(instance, true);
     REQUIRE(resave.size() == valid_raw_output.size());
     REQUIRE(resave == valid_raw_output);
 }
@@ -107,7 +107,7 @@ TEST_CASE("output factory from data 2  valid input success", "[output]") {
     REQUIRE( ! instance.token_data().has_value());
 
     // Re-save and compare against original.
-    data_chunk resave = instance.to_data();
+    data_chunk resave = kth::to_data_chunk(instance, true);
     REQUIRE(resave.size() == valid_raw_output.size());
     REQUIRE(resave == valid_raw_output);
 }
@@ -122,7 +122,7 @@ TEST_CASE("output factory from data 3  valid input success", "[output]") {
     REQUIRE( ! instance.token_data().has_value());
 
     // Re-save and compare against original.
-    data_chunk resave = instance.to_data();
+    data_chunk resave = kth::to_data_chunk(instance, true);
     REQUIRE(resave.size() == valid_raw_output.size());
     REQUIRE(resave == valid_raw_output);
 }
@@ -272,8 +272,8 @@ TEST_CASE("output deserialization with just FT amount 1", "[output]") {
     auto const& ft = std::get<chain::fungible>(instance.token_data().value().data);
     REQUIRE(ft.amount == chain::amount_t{0x01});
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with just FT amount 252", "[output]") {
@@ -295,8 +295,8 @@ TEST_CASE("output deserialization with just FT amount 252", "[output]") {
     auto const& ft = std::get<chain::fungible>(instance.token_data().value().data);
     REQUIRE(ft.amount == chain::amount_t{252});
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with just FT amount 253", "[output]") {
@@ -318,8 +318,8 @@ TEST_CASE("output deserialization with just FT amount 253", "[output]") {
     auto const& ft = std::get<chain::fungible>(instance.token_data().value().data);
     REQUIRE(ft.amount == chain::amount_t{253});
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with just FT amount 9223372036854775807", "[output]") {
@@ -341,8 +341,8 @@ TEST_CASE("output deserialization with just FT amount 9223372036854775807", "[ou
     auto const& ft = std::get<chain::fungible>(instance.token_data().value().data);
     REQUIRE(ft.amount == chain::amount_t{9223372036854775807});
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with just immutable NFT 0-byte commitment", "[output]") {
@@ -365,8 +365,8 @@ TEST_CASE("output deserialization with just immutable NFT 0-byte commitment", "[
     REQUIRE(nft.commitment.size() == 0);
     REQUIRE(nft.capability == chain::capability_t::none); // immutable
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with both - immutable NFT 0-byte commitment - FT amount 1", "[output]") {
@@ -391,8 +391,8 @@ TEST_CASE("output deserialization with both - immutable NFT 0-byte commitment - 
     REQUIRE(nft.commitment.size() == 0);
     REQUIRE(nft.capability == chain::capability_t::none); // immutable
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with both - immutable NFT 0-byte commitment - FT amount 253", "[output]") {
@@ -417,8 +417,8 @@ TEST_CASE("output deserialization with both - immutable NFT 0-byte commitment - 
     REQUIRE(nft.commitment.size() == 0);
     REQUIRE(nft.capability == chain::capability_t::none); // immutable
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with both - immutable NFT 0-byte commitment - FT amount 9223372036854775807", "[output]") {
@@ -443,8 +443,8 @@ TEST_CASE("output deserialization with both - immutable NFT 0-byte commitment - 
     REQUIRE(nft.commitment.size() == 0);
     REQUIRE(nft.capability == chain::capability_t::none); // immutable
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with just immutable NFT 1-byte commitment", "[output]") {
@@ -468,8 +468,8 @@ TEST_CASE("output deserialization with just immutable NFT 1-byte commitment", "[
     REQUIRE(encode_base16(nft.commitment) == "cc");
     REQUIRE(nft.capability == chain::capability_t::none); // immutable
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with both - immutable NFT 1-byte commitment - FT amount 252", "[output]") {
@@ -495,8 +495,8 @@ TEST_CASE("output deserialization with both - immutable NFT 1-byte commitment - 
     REQUIRE(encode_base16(nft.commitment) == "cc");
     REQUIRE(nft.capability == chain::capability_t::none); // immutable
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with both - immutable NFT 2-byte commitment - FT amount 253", "[output]") {
@@ -522,8 +522,8 @@ TEST_CASE("output deserialization with both - immutable NFT 2-byte commitment - 
     REQUIRE(encode_base16(nft.commitment) == "cccc");
     REQUIRE(nft.capability == chain::capability_t::none); // immutable
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with both - immutable NFT 10-byte commitment - FT amount 65535", "[output]") {
@@ -549,8 +549,8 @@ TEST_CASE("output deserialization with both - immutable NFT 10-byte commitment -
     REQUIRE(encode_base16(nft.commitment) == "cccccccccccccccccccc");
     REQUIRE(nft.capability == chain::capability_t::none); // immutable
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with both - immutable NFT 40-byte commitment - FT amount 65536", "[output]") {
@@ -576,8 +576,8 @@ TEST_CASE("output deserialization with both - immutable NFT 40-byte commitment -
     REQUIRE(encode_base16(nft.commitment) == "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc");
     REQUIRE(nft.capability == chain::capability_t::none); // immutable
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with just mutable NFT 0-byte commitment", "[output]") {
@@ -600,8 +600,8 @@ TEST_CASE("output deserialization with just mutable NFT 0-byte commitment", "[ou
     REQUIRE(nft.commitment.size() == 0);
     REQUIRE(nft.capability == chain::capability_t::mut);
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with both - mutable NFT 0-byte commitment - FT amount 4294967295", "[output]") {
@@ -626,8 +626,8 @@ TEST_CASE("output deserialization with both - mutable NFT 0-byte commitment - FT
     REQUIRE(nft.commitment.size() == 0);
     REQUIRE(nft.capability == chain::capability_t::mut); // mutable
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with just mutable NFT 1-byte commitment", "[output]") {
@@ -651,8 +651,8 @@ TEST_CASE("output deserialization with just mutable NFT 1-byte commitment", "[ou
     REQUIRE(encode_base16(nft.commitment) == "cc");
     REQUIRE(nft.capability == chain::capability_t::mut); // mutable
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with both - mutable NFT 1-byte commitment - FT amount 4294967296", "[output]") {
@@ -678,8 +678,8 @@ TEST_CASE("output deserialization with both - mutable NFT 1-byte commitment - FT
     REQUIRE(encode_base16(nft.commitment) == "cc");
     REQUIRE(nft.capability == chain::capability_t::mut); // mutable
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with both - mutable NFT 2-byte commitment - FT amount 9223372036854775807", "[output]") {
@@ -705,8 +705,8 @@ TEST_CASE("output deserialization with both - mutable NFT 2-byte commitment - FT
     REQUIRE(encode_base16(nft.commitment) == "cccc");
     REQUIRE(nft.capability == chain::capability_t::mut); // mutable
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with both - mutable NFT 10-byte commitment - FT amount 1", "[output]") {
@@ -732,8 +732,8 @@ TEST_CASE("output deserialization with both - mutable NFT 10-byte commitment - F
     REQUIRE(encode_base16(nft.commitment) == "cccccccccccccccccccc");
     REQUIRE(nft.capability == chain::capability_t::mut); // mutable
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with both - mutable NFT 40-byte commitment - FT amount 252", "[output]") {
@@ -759,8 +759,8 @@ TEST_CASE("output deserialization with both - mutable NFT 40-byte commitment - F
     REQUIRE(encode_base16(nft.commitment) == "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc");
     REQUIRE(nft.capability == chain::capability_t::mut); // mutable
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with just minting NFT 0-byte commitment", "[output]") {
@@ -783,8 +783,8 @@ TEST_CASE("output deserialization with just minting NFT 0-byte commitment", "[ou
     REQUIRE(nft.commitment.size() == 0);
     REQUIRE(nft.capability == chain::capability_t::minting);
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with both - minting NFT 0-byte commitment - FT amount 253", "[output]") {
@@ -809,8 +809,8 @@ TEST_CASE("output deserialization with both - minting NFT 0-byte commitment - FT
     REQUIRE(nft.commitment.size() == 0);
     REQUIRE(nft.capability == chain::capability_t::minting); // minting
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with just minting NFT 1-byte commitment", "[output]") {
@@ -834,8 +834,8 @@ TEST_CASE("output deserialization with just minting NFT 1-byte commitment", "[ou
     REQUIRE(encode_base16(nft.commitment) == "cc");
     REQUIRE(nft.capability == chain::capability_t::minting); // minting
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with both - minting NFT 1-byte commitment - FT amount 65535", "[output]") {
@@ -861,8 +861,8 @@ TEST_CASE("output deserialization with both - minting NFT 1-byte commitment - FT
     REQUIRE(encode_base16(nft.commitment) == "cc");
     REQUIRE(nft.capability == chain::capability_t::minting); // minting
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with both - minting NFT 2-byte commitment - FT amount 65536", "[output]") {
@@ -888,8 +888,8 @@ TEST_CASE("output deserialization with both - minting NFT 2-byte commitment - FT
     REQUIRE(encode_base16(nft.commitment) == "cccc");
     REQUIRE(nft.capability == chain::capability_t::minting); // minting
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with both - minting NFT 10-byte commitment - FT amount 4294967297", "[output]") {
@@ -915,8 +915,8 @@ TEST_CASE("output deserialization with both - minting NFT 10-byte commitment - F
     REQUIRE(encode_base16(nft.commitment) == "cccccccccccccccccccc");
     REQUIRE(nft.capability == chain::capability_t::minting); // minting
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization with both - minting NFT 40-byte commitment - FT amount 9223372036854775807", "[output]") {
@@ -942,8 +942,8 @@ TEST_CASE("output deserialization with both - minting NFT 40-byte commitment - F
     REQUIRE(encode_base16(nft.commitment) == "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc");
     REQUIRE(nft.capability == chain::capability_t::minting); // minting
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a914905f933de850988603aafeeb2fd7fce61e66fe5d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 TEST_CASE("output deserialization ...", "[output]") {
@@ -965,8 +965,8 @@ TEST_CASE("output deserialization ...", "[output]") {
     auto const& ft = std::get<chain::fungible>(instance.token_data().value().data);
     REQUIRE(ft.amount == chain::amount_t{0x0a});
 
-    REQUIRE(encode_base16(instance.script().to_data(true)) == "1976a91448a5e322b29f3db7297f4dc744e30bca63a0179d88ac");
-    REQUIRE(encode_base16(instance.to_data(true)) == encode_base16(data));
+    REQUIRE(encode_base16(kth::to_data_chunk(instance.script(), true)) == "1976a91448a5e322b29f3db7297f4dc744e30bca63a0179d88ac");
+    REQUIRE(encode_base16(kth::to_data_chunk(instance, true)) == encode_base16(data));
 }
 
 // End Test Suite

--- a/src/domain/test/chain/output_point.cpp
+++ b/src/domain/test/chain/output_point.cpp
@@ -80,7 +80,7 @@ TEST_CASE("output point from data roundtrip  success", "[output point]") {
     REQUIRE(hash == initial.hash());
     REQUIRE(index == initial.index());
 
-    data_chunk output = initial.to_data();
+    data_chunk output = kth::to_data_chunk(initial, true);
     byte_reader reader(output);
     auto result_exp = chain::output_point::from_data(reader);
     REQUIRE(result_exp);
@@ -102,7 +102,7 @@ TEST_CASE("output point from data roundtrip  success 2", "[output point]") {
     REQUIRE(encode_hash(point.hash()) == "8ed5a0af151cdbc8c0c546cde29334f15b4472bba105394a1221a7f088246846");
     REQUIRE(point.index() == 0);
 
-    data_chunk output = point.to_data();
+    data_chunk output = kth::to_data_chunk(point, true);
     REQUIRE(output == data);
 }
 
@@ -120,7 +120,7 @@ TEST_CASE("output point  factory from data 2  roundtrip  success", "[output poin
     REQUIRE(encode_hash(point.hash()) == "8ed5a0af151cdbc8c0c546cde29334f15b4472bba105394a1221a7f088246846");
     REQUIRE(point.index() == 0);
 
-    data_chunk output = point.to_data();
+    data_chunk output = kth::to_data_chunk(point, true);
     REQUIRE(output == data);
 }
 
@@ -138,7 +138,7 @@ TEST_CASE("output point  factory from data 3  roundtrip  success", "[output poin
     REQUIRE(encode_hash(point.hash()) == "8ed5a0af151cdbc8c0c546cde29334f15b4472bba105394a1221a7f088246846");
     REQUIRE(point.index() == 0);
 
-    data_chunk output = point.to_data();
+    data_chunk output = kth::to_data_chunk(point, true);
     REQUIRE(output == data);
 }
 

--- a/src/domain/test/chain/point.cpp
+++ b/src/domain/test/chain/point.cpp
@@ -77,7 +77,7 @@ TEST_CASE("point from data roundtrip  success", "[point]") {
     REQUIRE(hash == initial.hash());
     REQUIRE(index == initial.index());
 
-    data_chunk output = initial.to_data();
+    data_chunk output = kth::to_data_chunk(initial, true);
     byte_reader reader(output);
     auto result_exp = chain::point::from_data(reader);
     REQUIRE(result_exp);
@@ -101,7 +101,7 @@ TEST_CASE("point from data roundtrip  success 2", "[point]") {
     REQUIRE(encode_hash(point.hash()) == "8ed5a0af151cdbc8c0c546cde29334f15b4472bba105394a1221a7f088246846");
     REQUIRE(point.index() == 0);
 
-    data_chunk output = point.to_data();
+    data_chunk output = kth::to_data_chunk(point, true);
     REQUIRE(output == raw);
 }
 

--- a/src/domain/test/chain/satoshi_words.cpp
+++ b/src/domain/test/chain/satoshi_words.cpp
@@ -21,7 +21,7 @@ TEST_CASE( "satoshi words mainnet", "[satoshi words]" ) {
 
     // Convert the input script to its raw format.
     auto const& coinbase_input = coinbase_inputs[0];
-    auto const raw_message = coinbase_input.script().to_data(false);
+    auto const raw_message = kth::to_data_chunk(coinbase_input.script(), false);
     REQUIRE(raw_message.size() > 8u);
 
     // Convert to a string after removing the 8 byte checksum.

--- a/src/domain/test/chain/script.cpp
+++ b/src/domain/test/chain/script.cpp
@@ -246,7 +246,7 @@ TEST_CASE("script from data to data roundtrips", "[script]") {
     REQUIRE(script.sigops(true) == 1u);
     REQUIRE(script.pattern() == script_pattern::pay_to_public_key_hash);
 
-    auto const roundtrip = script.to_data(false);
+    auto const roundtrip = kth::to_data_chunk(script, false);
     REQUIRE(roundtrip == normal_output_script);
 }
 
@@ -259,7 +259,7 @@ TEST_CASE("script from data to data weird roundtrips", "[script]") {
     REQUIRE(result);
     weird = std::move(*result);
 
-    auto const roundtrip_result = weird.to_data(false);
+    auto const roundtrip_result = kth::to_data_chunk(weird, false);
     REQUIRE(roundtrip_result == weird_raw_script);
 }
 

--- a/src/domain/test/chain/transaction.cpp
+++ b/src/domain/test/chain/transaction.cpp
@@ -427,10 +427,10 @@ TEST_CASE("chain transaction from data compare wire to store  success", "[None]"
         auto result = chain::transaction::from_data(reader, wire);
         REQUIRE(result);
         wire_tx = std::move(*result);
-        REQUIRE(to_chunk(tx3_wire_serialized) == wire_tx.to_data(wire));
+        REQUIRE(to_chunk(tx3_wire_serialized) == kth::to_data_chunk(wire_tx, wire));
     }
 
-    auto const get_store_text = encode_base16(wire_tx.to_data(!wire));
+    auto const get_store_text = encode_base16(kth::to_data_chunk(wire_tx, !wire));
 
     chain::transaction store_tx;
     {
@@ -438,7 +438,7 @@ TEST_CASE("chain transaction from data compare wire to store  success", "[None]"
         auto result = chain::transaction::from_data(reader, !wire);
         REQUIRE(result);
         store_tx = std::move(*result);
-        REQUIRE(to_chunk(tx3_store_serialized_v3) == store_tx.to_data(!wire));
+        REQUIRE(to_chunk(tx3_store_serialized_v3) == kth::to_data_chunk(store_tx, !wire));
     }
 
     REQUIRE(wire_tx == store_tx);
@@ -459,7 +459,7 @@ TEST_CASE("chain transaction  factory data 1  case 1  success", "[chain transact
 
     // Re-save tx and compare against original.
     REQUIRE(tx.serialized_size() == tx1.size());
-    data_chunk resave = tx.to_data();
+    data_chunk resave = kth::to_data_chunk(tx, true);
     REQUIRE(resave == to_chunk(tx1));
 }
 
@@ -477,7 +477,7 @@ TEST_CASE("chain transaction  factory data 1  case 2  success", "[chain transact
 
     // Re-save tx and compare against original.
     REQUIRE(tx.serialized_size() == tx4.size());
-    data_chunk resave = tx.to_data();
+    data_chunk resave = kth::to_data_chunk(tx, true);
     REQUIRE(resave == to_chunk(tx4));
 }
 
@@ -997,6 +997,6 @@ TEST_CASE("chain transaction  hash  block320670  success", "[chain transaction]"
     REQUIRE(result);
     chain::transaction const instance = std::move(*result);
     REQUIRE(expected == instance.hash());
-    REQUIRE(to_chunk(tx7) == instance.to_data());
+    REQUIRE(to_chunk(tx7) == kth::to_data_chunk(instance, true));
 }
 

--- a/src/domain/test/message/address.cpp
+++ b/src/domain/test/message/address.cpp
@@ -145,7 +145,7 @@ TEST_CASE("address from data roundtrip  success", "[address]") {
           "47816a40bb92bdb4e0b8256861f96a55"_base16,
           123u}});
 
-    auto const data = expected.to_data(version::level::minimum);
+    auto const data = kth::to_data_chunk(expected, version::level::minimum);
     byte_reader reader(data);
     auto const result_exp = address::from_data(reader, version::level::minimum);
     REQUIRE(result_exp);

--- a/src/domain/test/message/alert.cpp
+++ b/src/domain/test/message/alert.cpp
@@ -129,7 +129,7 @@ TEST_CASE("alert from data wiki sample  success", "[alert]") {
     REQUIRE(raw.size() == result.serialized_size(message::version::level::minimum));
     REQUIRE(result == expected);
 
-    auto const data = expected.to_data(message::version::level::minimum);
+    auto const data = kth::to_data_chunk(expected, message::version::level::minimum);
 
     REQUIRE(raw.size() == data.size());
     REQUIRE(data.size() == expected.serialized_size(message::version::level::minimum));
@@ -140,7 +140,7 @@ TEST_CASE("alert from data roundtrip  success", "[alert]") {
         {0x07, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07},
         {0x04, 0xff, 0xab, 0xcd, 0xee}};
 
-    auto const data = expected.to_data(message::version::level::minimum);
+    auto const data = kth::to_data_chunk(expected, message::version::level::minimum);
     byte_reader reader(data);
     auto const result_exp = message::alert::from_data(reader, message::version::level::minimum);
     REQUIRE(result_exp);

--- a/src/domain/test/message/alert_payload.cpp
+++ b/src/domain/test/message/alert_payload.cpp
@@ -214,7 +214,7 @@ TEST_CASE("alert payload from data wiki sample test  success", "[alert payload]"
     REQUIRE(raw.size() == result.serialized_size(message::version::level::minimum));
     REQUIRE(result == expected);
 
-    auto const data = expected.to_data(message::version::level::minimum);
+    auto const data = kth::to_data_chunk(expected, message::version::level::minimum);
 
     REQUIRE(raw.size() == data.size());
     REQUIRE(data.size() == expected.serialized_size(message::version::level::minimum));
@@ -236,7 +236,7 @@ TEST_CASE("alert payload from data roundtrip  success", "[alert payload]") {
         "My Status Bar",
         "RESERVED?"};
 
-    auto const data = expected.to_data(message::version::level::minimum);
+    auto const data = kth::to_data_chunk(expected, message::version::level::minimum);
     byte_reader reader(data);
     auto const result_exp = message::alert_payload::from_data(reader, message::version::level::minimum);
     REQUIRE(result_exp);

--- a/src/domain/test/message/block.cpp
+++ b/src/domain/test/message/block.cpp
@@ -145,7 +145,7 @@ TEST_CASE("block  factory data 1  genesis mainnet  success", "[message block]") 
     REQUIRE(genesis.header().serialized_size() == 80u);
 
     // Save genesis block.
-    auto raw_block = genesis.to_data();
+    auto raw_block = kth::to_data_chunk(genesis);
     REQUIRE(raw_block.size() == 285u);
 
     // Reload genesis block.
@@ -160,7 +160,7 @@ TEST_CASE("block  factory data 1  genesis mainnet  success", "[message block]") 
     // Verify merkle root from transactions.
     REQUIRE(block.generate_merkle_root() == genesis.header().merkle());
 
-    auto raw_reserialization = block.to_data(version::level::minimum);
+    auto raw_reserialization = kth::to_data_chunk(block, version::level::minimum);
     REQUIRE(raw_reserialization == raw_block);
     REQUIRE(raw_reserialization.size() == block.serialized_size(version::level::minimum));
 }

--- a/src/domain/test/message/block_transactions.cpp
+++ b/src/domain/test/message/block_transactions.cpp
@@ -157,7 +157,7 @@ TEST_CASE("block transactions from data insufficient version  failure", "[block 
     REQUIRE(result);
     auto expected = std::move(*result);
 
-    auto const data = expected.to_data(message::block_transactions::version_minimum);
+    auto const data = kth::to_data_chunk(expected, message::block_transactions::version_minimum);
 
     REQUIRE(raw == data);
 
@@ -199,7 +199,7 @@ TEST_CASE("block transactions from data valid input  success", "[block transacti
     REQUIRE(result_exp);
     auto expected = std::move(*result_exp);
 
-    auto const data = expected.to_data(message::block_transactions::version_minimum);
+    auto const data = kth::to_data_chunk(expected, message::block_transactions::version_minimum);
 
     REQUIRE(raw == data);
     byte_reader reader2(data);

--- a/src/domain/test/message/compact_block.cpp
+++ b/src/domain/test/message/compact_block.cpp
@@ -169,7 +169,7 @@ TEST_CASE("compact block from data insufficient version  failure", "[compact blo
     auto result_exp = message::compact_block::from_data(reader, message::compact_block::version_minimum);
     REQUIRE(result_exp);
     auto const expected = std::move(*result_exp);
-    auto const data = expected.to_data(message::compact_block::version_minimum);
+    auto const data = kth::to_data_chunk(expected, message::compact_block::version_minimum);
     REQUIRE(raw == data);
 
     byte_reader reader2(raw);
@@ -184,7 +184,7 @@ TEST_CASE("compact block from data valid input  success", "[compact block]") {
     auto result_exp = message::compact_block::from_data(reader, message::compact_block::version_minimum);
     REQUIRE(result_exp);
     auto const expected = std::move(*result_exp);
-    auto const data = expected.to_data(message::compact_block::version_minimum);
+    auto const data = kth::to_data_chunk(expected, message::compact_block::version_minimum);
     REQUIRE(raw == data);
 
     byte_reader reader2(data);

--- a/src/domain/test/message/double_spend_proof.cpp
+++ b/src/domain/test/message/double_spend_proof.cpp
@@ -249,7 +249,7 @@ TEST_CASE("double_spend_proof  serialized_size  matches to_data length", "[doubl
     // outpoint (36) + spender1 (108) + spender2 (108) = 252
     REQUIRE(size == 252u);
 
-    auto const raw = dsp.to_data(0);
+    auto const raw = kth::to_data_chunk(dsp, 0);
     REQUIRE(raw.size() == size);
 }
 

--- a/src/domain/test/message/fee_filter.cpp
+++ b/src/domain/test/message/fee_filter.cpp
@@ -48,7 +48,7 @@ TEST_CASE("fee filter from data insufficient bytes failure", "[fee filter]") {
 
 TEST_CASE("fee filter from data insufficient version failure", "[fee filter]") {
     fee_filter const expected{1};
-    auto const data = expected.to_data(fee_filter::version_maximum);
+    auto const data = kth::to_data_chunk(expected, fee_filter::version_maximum);
     byte_reader reader(data);
     auto const result = fee_filter::from_data(reader, fee_filter::version_minimum - 1);
     REQUIRE( ! result);
@@ -56,7 +56,7 @@ TEST_CASE("fee filter from data insufficient version failure", "[fee filter]") {
 
 TEST_CASE("fee filter from data roundtrip  success", "[fee filter]") {
     fee_filter const expected{123};
-    auto const data = expected.to_data(fee_filter::version_maximum);
+    auto const data = kth::to_data_chunk(expected, fee_filter::version_maximum);
     byte_reader reader(data);
     auto const result_exp = fee_filter::from_data(reader, fee_filter::version_maximum);
     REQUIRE(result_exp);

--- a/src/domain/test/message/filter_add.cpp
+++ b/src/domain/test/message/filter_add.cpp
@@ -62,7 +62,7 @@ TEST_CASE("filter add from data insufficient version  failure", "[filter add]") 
          0xc3, 0x0d, 0x6f, 0x55, 0x7d, 0x71, 0x12, 0x1a,
          0x37, 0xc0, 0xb0, 0x32, 0xf0, 0xd6, 0x6e, 0xdf}};
 
-    auto const data = expected.to_data(message::version::level::maximum);
+    auto const data = kth::to_data_chunk(expected, message::version::level::maximum);
     byte_reader reader(data);
     auto const result = message::filter_add::from_data(reader, message::version::level::minimum - 1);
     REQUIRE( ! result);
@@ -76,7 +76,7 @@ TEST_CASE("filter add from data valid input  success", "[filter add]") {
          0xc3, 0x0d, 0x6f, 0x55, 0x7d, 0x71, 0x12, 0x1a,
          0x37, 0xc0, 0xb0, 0x32, 0xf0, 0xd6, 0x6e, 0xdf}};
 
-    auto const data = expected.to_data(message::version::level::maximum);
+    auto const data = kth::to_data_chunk(expected, message::version::level::maximum);
     byte_reader reader(data);
     auto const result_exp = message::filter_add::from_data(reader, message::version::level::maximum);
     REQUIRE(result_exp);

--- a/src/domain/test/message/filter_load.cpp
+++ b/src/domain/test/message/filter_load.cpp
@@ -91,7 +91,7 @@ TEST_CASE("filter load from data insufficient version  failure", "[filter load]"
         0xab
     };
 
-    data_chunk const data = expected.to_data(message::version::level::maximum);
+    data_chunk const data = kth::to_data_chunk(expected, message::version::level::maximum);
     
     byte_reader reader(data);
     auto result = message::filter_load::from_data(reader, message::filter_load::version_minimum - 1);
@@ -105,7 +105,7 @@ TEST_CASE("filter load from data valid input  success", "[filter load]") {
         10,
         0xab};
 
-    auto const data = expected.to_data(message::version::level::maximum);
+    auto const data = kth::to_data_chunk(expected, message::version::level::maximum);
     byte_reader reader(data);
     auto const result_exp = message::filter_load::from_data(reader, message::version::level::maximum);
     REQUIRE(result_exp);

--- a/src/domain/test/message/get_address.cpp
+++ b/src/domain/test/message/get_address.cpp
@@ -11,7 +11,7 @@ using namespace kd;
 
 TEST_CASE("get address - roundtrip to data factory from data chunk", "[get address]") {
     const message::get_address expected{};
-    auto const data = expected.to_data(message::version::level::minimum);
+    auto const data = kth::to_data_chunk(expected, message::version::level::minimum);
     byte_reader reader(data);
     auto const result_exp = message::get_address::from_data(reader, message::version::level::minimum);
     REQUIRE(result_exp);

--- a/src/domain/test/message/get_block_transactions.cpp
+++ b/src/domain/test/message/get_block_transactions.cpp
@@ -74,7 +74,7 @@ TEST_CASE("get block transactions from data valid input  success", "[get block t
          37,
          44}};
 
-    auto const data = expected.to_data(message::version::level::minimum);
+    auto const data = kth::to_data_chunk(expected, message::version::level::minimum);
     byte_reader reader(data);
     auto const result_exp = message::get_block_transactions::from_data(reader, message::version::level::minimum);
     REQUIRE(result_exp);

--- a/src/domain/test/message/get_blocks.cpp
+++ b/src/domain/test/message/get_blocks.cpp
@@ -92,7 +92,7 @@ TEST_CASE("get blocks from data valid input  success", "[get blocks]") {
          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash},
         "7777777777777777777777777777777777777777777777777777777777777777"_hash};
 
-    auto const data = expected.to_data(message::version::level::minimum);
+    auto const data = kth::to_data_chunk(expected, message::version::level::minimum);
     byte_reader reader(data);
     auto const result_exp = message::get_blocks::from_data(reader, message::version::level::minimum);
     REQUIRE(result_exp);

--- a/src/domain/test/message/get_data.cpp
+++ b/src/domain/test/message/get_data.cpp
@@ -110,7 +110,7 @@ TEST_CASE("get data from data insufficient version  failure", "[get data]") {
         {inventory_vector::type_id::error,
          "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash}};
 
-    auto const raw = expected.to_data(version::level::maximum);
+    auto const raw = kth::to_data_chunk(expected, version::level::maximum);
     byte_reader reader(raw);
     auto const result = get_data::from_data(reader, get_data::version_minimum - 1);
     REQUIRE( ! result);
@@ -122,7 +122,7 @@ TEST_CASE("get data from data valid input  success", "[get data]") {
          "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash}};
 
     static auto const version = version::level::maximum;
-    auto const data = expected.to_data(version);
+    auto const data = kth::to_data_chunk(expected, version);
     byte_reader reader(data);
     auto const result_exp = get_data::from_data(reader, version);
     REQUIRE(result_exp);

--- a/src/domain/test/message/get_headers.cpp
+++ b/src/domain/test/message/get_headers.cpp
@@ -94,7 +94,7 @@ TEST_CASE("get headers from data insufficient version failure", "[get headers]")
         }, "7777777777777777777777777777777777777777777777777777777777777777"_hash
     };
 
-    auto const data = expected.to_data(message::get_headers::version_minimum);
+    auto const data = kth::to_data_chunk(expected, message::get_headers::version_minimum);
     message::get_headers instance{};
 
     byte_reader reader(data);
@@ -113,7 +113,7 @@ TEST_CASE("get headers from data valid input  success", "[get headers]") {
         }, "7777777777777777777777777777777777777777777777777777777777777777"_hash
     };
 
-    auto const data = expected.to_data(message::get_headers::version_minimum);
+    auto const data = kth::to_data_chunk(expected, message::get_headers::version_minimum);
     byte_reader reader(data);
     auto const result_exp = message::get_headers::from_data(reader, message::get_headers::version_minimum);
     REQUIRE(result_exp);

--- a/src/domain/test/message/header.cpp
+++ b/src/domain/test/message/header.cpp
@@ -125,7 +125,7 @@ TEST_CASE("message header from data valid input canonical version  no transactio
         6523454u,
         68644u};
 
-    auto const data = expected.to_data(version);
+    auto const data = kth::to_data_chunk(expected, version);
 
     byte_reader reader(data);
     auto const result_exp = message::header::from_data(reader, version);
@@ -148,7 +148,7 @@ TEST_CASE("message header from data valid input  success", "[message header]") {
         6523454u,
         68644u};
 
-    auto const data = expected.to_data(version);
+    auto const data = kth::to_data_chunk(expected, version);
 
     byte_reader reader(data);
     auto const result_exp = message::header::from_data(reader, version);

--- a/src/domain/test/message/headers.cpp
+++ b/src/domain/test/message/headers.cpp
@@ -139,7 +139,7 @@ TEST_CASE("headers from data insufficient version  failure", "[headers]") {
          6523454,
          68644}};
 
-    data_chunk const data = expected.to_data(headers::version_minimum);
+    data_chunk const data = kth::to_data_chunk(expected, headers::version_minimum);
     headers instance{};
     byte_reader reader(data);
     auto result = headers::from_data(reader, headers::version_minimum - 1);
@@ -156,7 +156,7 @@ TEST_CASE("headers from data valid input  success", "[headers]") {
          68644}};
 
     static auto const version = headers::version_minimum;
-    auto const data = expected.to_data(version);
+    auto const data = kth::to_data_chunk(expected, version);
     byte_reader reader(data);
     auto const result_exp = headers::from_data(reader, version);
     REQUIRE(result_exp);

--- a/src/domain/test/message/inventory.cpp
+++ b/src/domain/test/message/inventory.cpp
@@ -115,7 +115,7 @@ TEST_CASE("inventory from data valid input  success", "[inventory]") {
             0x37, 0xc0, 0xb0, 0x32, 0xf0, 0xd6, 0x6e, 0xdf}}}}};
 
     static auto const version = version::level::minimum;
-    auto const data = expected.to_data(version);
+    auto const data = kth::to_data_chunk(expected, version);
     byte_reader reader(data);
     auto const result_exp = inventory::from_data(reader, version);
     REQUIRE(result_exp);

--- a/src/domain/test/message/inventory_vector.cpp
+++ b/src/domain/test/message/inventory_vector.cpp
@@ -117,7 +117,7 @@ TEST_CASE("inventory vector from data  valid input  success", "[inventory vector
           0x37, 0xc0, 0xb0, 0x32, 0xf0, 0xd6, 0x6e, 0xdf}}};
 
     static auto const version = version::level::minimum;
-    auto const data = expected.to_data(version);
+    auto const data = kth::to_data_chunk(expected, version);
     byte_reader reader(data);
     auto const result_exp = inventory_vector::from_data(reader, version);
     REQUIRE(result_exp);

--- a/src/domain/test/message/memory_pool.cpp
+++ b/src/domain/test/message/memory_pool.cpp
@@ -11,7 +11,7 @@ using namespace kd;
 
 TEST_CASE("memory pool - from data insufficient version failure", "[memory pool]") {
     message::memory_pool const expected;
-    data_chunk const data = expected.to_data(message::version::level::maximum);
+    data_chunk const data = kth::to_data_chunk(expected, message::version::level::maximum);
     message::memory_pool instance{};
     byte_reader reader(data);
     auto result = message::memory_pool::from_data(reader, message::memory_pool::version_minimum - 1);
@@ -21,7 +21,7 @@ TEST_CASE("memory pool - from data insufficient version failure", "[memory pool]
 
 TEST_CASE("memory pool - roundtrip to data factory from data chunk", "[memory pool]") {
     message::memory_pool const expected{};
-    auto const data = expected.to_data(message::version::level::maximum);
+    auto const data = kth::to_data_chunk(expected, message::version::level::maximum);
     byte_reader reader(data);
     auto const result_exp = message::memory_pool::from_data(reader, message::version::level::maximum);
     REQUIRE(result_exp);

--- a/src/domain/test/message/merkle_block.cpp
+++ b/src/domain/test/message/merkle_block.cpp
@@ -131,7 +131,7 @@ TEST_CASE("from data insufficient version fails", "[merkle block]") {
         {"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash},
         {0x00}};
 
-    auto const data = expected.to_data(message::version::level::maximum);
+    auto const data = kth::to_data_chunk(expected, message::version::level::maximum);
     message::merkle_block instance{};
 
     byte_reader reader(data);
@@ -152,7 +152,7 @@ TEST_CASE("merkle block - roundtrip to data factory from data chunk", "[merkle b
         {"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash},
         {0x00}};
 
-    auto const data = expected.to_data(message::version::level::maximum);
+    auto const data = kth::to_data_chunk(expected, message::version::level::maximum);
     byte_reader reader(data);
     auto const result_exp = message::merkle_block::from_data(reader, message::version::level::maximum);
     REQUIRE(result_exp);

--- a/src/domain/test/message/not_found.cpp
+++ b/src/domain/test/message/not_found.cpp
@@ -114,7 +114,7 @@ TEST_CASE("not found from data insufficient version  failure", "[not found]") {
             0x37, 0xc0, 0xb0, 0x32, 0xf0, 0xd6, 0x6e, 0xdf}}}}};
 
     auto const version = version::level::maximum;
-    data_chunk const raw = expected.to_data(version);
+    data_chunk const raw = kth::to_data_chunk(expected, version);
     not_found instance;
     byte_reader reader(raw);
     auto result = not_found::from_data(reader, not_found::version_minimum - 1);
@@ -131,7 +131,7 @@ TEST_CASE("not found from data valid input  success", "[not found]") {
             0x37, 0xc0, 0xb0, 0x32, 0xf0, 0xd6, 0x6e, 0xdf}}}}};
 
     auto const version = version::level::maximum;
-    auto const data = expected.to_data(version);
+    auto const data = kth::to_data_chunk(expected, version);
     byte_reader reader(data);
     auto const result_exp = not_found::from_data(reader, version);
     REQUIRE(result_exp);

--- a/src/domain/test/message/ping.cpp
+++ b/src/domain/test/message/ping.cpp
@@ -57,7 +57,7 @@ TEST_CASE("ping  from data 1  minimum version  success zero nonce", "[ping]") {
     static const message::ping value{213153u};
 
     // This serializes the nonce.
-    auto const data = value.to_data(message::version::level::bip31);
+    auto const data = kth::to_data_chunk(value, message::version::level::bip31);
     REQUIRE(data.size() == 8u);
 
     // This leaves the nonce on the wire but otherwise succeeds with a zero nonce.
@@ -75,7 +75,7 @@ TEST_CASE("ping from data minimum version round trip  zero nonce", "[ping]") {
         16545612u};
 
     static auto const version = message::version::level::minimum;
-    auto const data = value.to_data(version);
+    auto const data = kth::to_data_chunk(value, version);
     byte_reader reader(data);
     auto const result_exp = message::ping::from_data(reader, version);
     REQUIRE(result_exp);
@@ -91,7 +91,7 @@ TEST_CASE("ping  from data 1  maximum version  success expected nonce", "[ping]"
         213153u};
 
     // This serializes the nonce.
-    auto const data = expected.to_data(message::version::level::bip31);
+    auto const data = kth::to_data_chunk(expected, message::version::level::bip31);
     REQUIRE(data.size() == 8u);
 
     // This leaves the nonce on the wire but otherwise succeeds with a zero nonce.
@@ -109,7 +109,7 @@ TEST_CASE("ping from data bip31 version round trip  expected nonce", "[ping]") {
         16545612u};
 
     static auto const version = message::version::level::bip31;
-    auto const data = expected.to_data(version);
+    auto const data = kth::to_data_chunk(expected, version);
     byte_reader reader(data);
     auto const result_exp = message::ping::from_data(reader, version);
     REQUIRE(result_exp);

--- a/src/domain/test/message/pong.cpp
+++ b/src/domain/test/message/pong.cpp
@@ -46,7 +46,7 @@ TEST_CASE("pong from data round trip  expected", "[pong]") {
         4306550u};
 
     static auto const version = message::version::level::minimum;
-    auto const data = expected.to_data(version);
+    auto const data = kth::to_data_chunk(expected, version);
     byte_reader reader(data);
     auto const result_exp = message::pong::from_data(reader, version);
     REQUIRE(result_exp);

--- a/src/domain/test/message/prefilled_transaction.cpp
+++ b/src/domain/test/message/prefilled_transaction.cpp
@@ -67,7 +67,7 @@ TEST_CASE("prefilled transaction from data valid input  success", "[prefilled tr
             {},
             {}});
 
-    auto const data = expected.to_data(message::version::level::minimum);
+    auto const data = kth::to_data_chunk(expected, message::version::level::minimum);
     byte_reader reader(data);
     auto const result_exp = message::prefilled_transaction::from_data(reader, message::version::level::minimum);
     REQUIRE(result_exp);

--- a/src/domain/test/message/reject.cpp
+++ b/src/domain/test/message/reject.cpp
@@ -107,7 +107,7 @@ TEST_CASE("reject from data insufficient version  failure", "[reject]") {
         reason_text,
         data);
 
-    data_chunk const raw = expected.to_data(version_maximum);
+    data_chunk const raw = kth::to_data_chunk(expected, version_maximum);
     message::reject instance{};
     byte_reader reader(raw);
     auto result = message::reject::from_data(reader, message::reject::version_minimum - 1);
@@ -121,7 +121,7 @@ TEST_CASE("reject from data code malformed  success", "[reject]") {
         reason_text,
         data);
 
-    data_chunk const raw = expected.to_data(version_maximum);
+    data_chunk const raw = kth::to_data_chunk(expected, version_maximum);
     message::reject instance{};
     byte_reader reader(raw);
     auto result = message::reject::from_data(reader, message::reject::version_minimum);
@@ -137,7 +137,7 @@ TEST_CASE("reject from data code invalid  success", "[reject]") {
         reason_text,
         data);
 
-    data_chunk const raw = expected.to_data(version_maximum);
+    data_chunk const raw = kth::to_data_chunk(expected, version_maximum);
     message::reject instance{};
 
     byte_reader reader(raw);
@@ -154,7 +154,7 @@ TEST_CASE("reject from data code obsolete  success", "[reject]") {
         reason_text,
         data);
 
-    data_chunk const raw = expected.to_data(version_maximum);
+    data_chunk const raw = kth::to_data_chunk(expected, version_maximum);
     message::reject instance{};
     byte_reader reader(raw);
     auto result = message::reject::from_data(reader, message::reject::version_minimum);
@@ -170,7 +170,7 @@ TEST_CASE("reject from data code duplicate  success", "[reject]") {
         reason_text,
         data);
 
-    data_chunk const raw = expected.to_data(version_maximum);
+    data_chunk const raw = kth::to_data_chunk(expected, version_maximum);
     message::reject instance{};
     byte_reader reader(raw);
     auto result = message::reject::from_data(reader, message::reject::version_minimum);
@@ -186,7 +186,7 @@ TEST_CASE("reject from data code nonstandard  success", "[reject]") {
         reason_text,
         data);
 
-    data_chunk const raw = expected.to_data(version_maximum);
+    data_chunk const raw = kth::to_data_chunk(expected, version_maximum);
     message::reject instance{};
     byte_reader reader(raw);
     auto result = message::reject::from_data(reader, message::reject::version_minimum);
@@ -202,7 +202,7 @@ TEST_CASE("reject from data code dust  success", "[reject]") {
         reason_text,
         data);
 
-    data_chunk const raw = expected.to_data(version_maximum);
+    data_chunk const raw = kth::to_data_chunk(expected, version_maximum);
     message::reject instance{};
     byte_reader reader(raw);
     auto result = message::reject::from_data(reader, message::reject::version_minimum);
@@ -218,7 +218,7 @@ TEST_CASE("reject from data code insufficient fee  success", "[reject]") {
         reason_text,
         data);
 
-    data_chunk const raw = expected.to_data(version_maximum);
+    data_chunk const raw = kth::to_data_chunk(expected, version_maximum);
     message::reject instance{};
     byte_reader reader(raw);
     auto result = message::reject::from_data(reader, message::reject::version_minimum);
@@ -234,7 +234,7 @@ TEST_CASE("reject from data code checkpoint  success", "[reject]") {
         reason_text,
         data);
 
-    data_chunk const raw = expected.to_data(version_maximum);
+    data_chunk const raw = kth::to_data_chunk(expected, version_maximum);
     message::reject instance{};
 
     byte_reader reader(raw);
@@ -251,7 +251,7 @@ TEST_CASE("reject from data code undefined  success", "[reject]") {
         reason_text,
         data);
 
-    data_chunk const raw = expected.to_data(version_maximum);
+    data_chunk const raw = kth::to_data_chunk(expected, version_maximum);
     message::reject instance{};
 
     byte_reader reader(raw);
@@ -268,7 +268,7 @@ TEST_CASE("reject from data valid input  success", "[reject]") {
         reason_text,
         data);
 
-    auto const data = expected.to_data(version_maximum);
+    auto const data = kth::to_data_chunk(expected, version_maximum);
     byte_reader reader(data);
     auto const result_exp = message::reject::from_data(reader, version_maximum);
     REQUIRE(result_exp);

--- a/src/domain/test/message/send_compact.cpp
+++ b/src/domain/test/message/send_compact.cpp
@@ -42,7 +42,7 @@ TEST_CASE("send compact  constructor 4  always  equals params", "[send compact]"
 
 TEST_CASE("send compact from data valid input  success", "[send compact]") {
     const message::send_compact expected{true, 164};
-    auto const data = expected.to_data(message::send_compact::version_minimum);
+    auto const data = kth::to_data_chunk(expected, message::send_compact::version_minimum);
     byte_reader reader(data);
     auto const result_exp = message::send_compact::from_data(reader, message::send_compact::version_minimum);
     REQUIRE(result_exp);
@@ -67,7 +67,7 @@ TEST_CASE("send compact  from data 1  invalid mode byte  failure", "[send compac
 
 TEST_CASE("send compact  from data 1  insufficient version  failure", "[send compact]") {
     const message::send_compact expected{true, 257};
-    data_chunk raw_data = expected.to_data(message::send_compact::version_minimum);
+    data_chunk raw_data = kth::to_data_chunk(expected, message::send_compact::version_minimum);
     message::send_compact msg;
     byte_reader reader(raw_data);
     auto exp_result = message::send_compact::from_data(reader, message::send_compact::version_minimum - 1);

--- a/src/domain/test/message/send_headers.cpp
+++ b/src/domain/test/message/send_headers.cpp
@@ -11,7 +11,7 @@ using namespace kd;
 
 TEST_CASE("send headers - roundtrip to data factory from data chunk", "[send headers]") {
     const message::send_headers expected{};
-    auto const data = expected.to_data(message::version::level::maximum);
+    auto const data = kth::to_data_chunk(expected, message::version::level::maximum);
     byte_reader reader(data);
     auto const result_exp = message::send_headers::from_data(reader, message::version::level::maximum);
     REQUIRE(result_exp);

--- a/src/domain/test/message/transaction.cpp
+++ b/src/domain/test/message/transaction.cpp
@@ -184,7 +184,7 @@ TEST_CASE("message transaction from data case 1 valid data  success", "[message 
 
     // Re-save tx and compare against original.
     REQUIRE(tx.serialized_size(version::level::minimum) == raw_tx.size());
-    data_chunk resave = tx.to_data(version::level::minimum);
+    data_chunk resave = kth::to_data_chunk(tx, version::level::minimum);
     REQUIRE(resave == raw_tx);
 }
 
@@ -202,7 +202,7 @@ TEST_CASE("message transaction from data case 2 valid data  success", "[message 
 
     // Re-save tx and compare against original.
     REQUIRE(tx.serialized_size(version::level::minimum) == raw_tx.size());
-    data_chunk resave = tx.to_data(version::level::minimum);
+    data_chunk resave = kth::to_data_chunk(tx, version::level::minimum);
     REQUIRE(resave == raw_tx);
 }
 

--- a/src/domain/test/message/verack.cpp
+++ b/src/domain/test/message/verack.cpp
@@ -11,7 +11,7 @@ using namespace kd;
 
 TEST_CASE("verack - roundtrip to data factory from data chunk", "[verack]") {
     const message::verack expected{};
-    auto const data = expected.to_data(message::version::level::minimum);
+    auto const data = kth::to_data_chunk(expected, message::version::level::minimum);
     byte_reader reader(data);
     auto const result_exp = message::verack::from_data(reader, message::version::level::minimum);
     REQUIRE(result_exp);

--- a/src/domain/test/message/version.cpp
+++ b/src/domain/test/message/version.cpp
@@ -274,7 +274,7 @@ TEST_CASE("version from data mismatched sender services invalid", "[version]") {
         100u,
         false);
 
-    auto const data = expected.to_data(version_maximum);
+    auto const data = kth::to_data_chunk(expected, version_maximum);
     byte_reader reader(data);
     auto const result_exp = message::version::from_data(reader, version_maximum);
     REQUIRE(result_exp);
@@ -305,7 +305,7 @@ TEST_CASE("version from data version meets bip37  success", "[version]") {
         100u,
         true};
 
-    auto const data = expected.to_data(version_maximum);
+    auto const data = kth::to_data_chunk(expected, version_maximum);
     byte_reader reader(data);
     auto const result_exp = message::version::from_data(reader, version_maximum);
     REQUIRE(result_exp);
@@ -334,7 +334,7 @@ TEST_CASE("version from data valid input  success", "[version]") {
         100u,
         true};
 
-    auto const data = expected.to_data(version_maximum);
+    auto const data = kth::to_data_chunk(expected, version_maximum);
     byte_reader reader(data);
     auto const result_exp = message::version::from_data(reader, version_maximum);
     REQUIRE(result_exp);
@@ -362,7 +362,7 @@ TEST_CASE("version from data tolerates trailing bytes  success", "[version]") {
          351u},
         13626u, "my agent", 100u, true};
 
-    auto data = expected.to_data(version_maximum);
+    auto data = kth::to_data_chunk(expected, version_maximum);
     data.insert(data.end(), {0xde, 0xad, 0xbe, 0xef, 0x00, 0x01, 0x02, 0x03});
 
     byte_reader reader(data);

--- a/src/domain/test/test_helpers.hpp
+++ b/src/domain/test/test_helpers.hpp
@@ -15,12 +15,14 @@
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/message/network_address.hpp>
 
-// Pretty printing operators for domain-specific types
+// Pretty printing operators for domain-specific types. All print via
+// `kth::to_data_chunk(x, args...)` so they stay in sync with the
+// byte_writer-based serialization API.
 namespace kth::infrastructure::message {
 
 inline
 std::ostream& operator<<(std::ostream& os, network_address const& x) {
-    os << encode_base16(x.to_data(kth::domain::message::version::level::minimum, false));
+    os << encode_base16(kth::to_data_chunk(x, kth::domain::message::version::level::minimum, false));
     return os;
 }
 
@@ -30,19 +32,19 @@ namespace kth::domain::chain {
 
 inline
 std::ostream& operator<<(std::ostream& os, input const& x) {
-    os << encode_base16(x.to_data());
+    os << encode_base16(kth::to_data_chunk(x, true));
     return os;
 }
 
 inline
 std::ostream& operator<<(std::ostream& os, output const& x) {
-    os << encode_base16(x.to_data());
+    os << encode_base16(kth::to_data_chunk(x, true));
     return os;
 }
 
 inline
 std::ostream& operator<<(std::ostream& os, transaction const& x) {
-    os << encode_base16(x.to_data());
+    os << encode_base16(kth::to_data_chunk(x, true));
     return os;
 }
 
@@ -52,7 +54,7 @@ namespace kth::domain::message {
 
 inline
 std::ostream& operator<<(std::ostream& os, prefilled_transaction const& x) {
-    os << encode_base16(x.to_data(version::level::minimum));
+    os << encode_base16(kth::to_data_chunk(x, version::level::minimum));
     return os;
 }
 

--- a/src/infrastructure/CMakeLists.txt
+++ b/src/infrastructure/CMakeLists.txt
@@ -361,6 +361,7 @@ set(kth_headers
     include/kth/infrastructure/utility/atomic.hpp
     include/kth/infrastructure/utility/binary.hpp
     include/kth/infrastructure/utility/byte_reader.hpp
+    include/kth/infrastructure/utility/byte_writer.hpp
     include/kth/infrastructure/utility/collection.hpp
     include/kth/infrastructure/utility/color.hpp
     include/kth/infrastructure/utility/conditional_lock.hpp
@@ -671,6 +672,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     test/utility/operators.cpp
     test/utility/serializer.cpp
     test/utility/byte_reader.cpp
+    test/utility/byte_writer.cpp
     test/utility/thread.cpp
     test/utility/threadpool.cpp
     test/utility/coroutine_smoke_test.cpp

--- a/src/infrastructure/include/kth/infrastructure.hpp
+++ b/src/infrastructure/include/kth/infrastructure.hpp
@@ -116,6 +116,8 @@
 #include <kth/infrastructure/utility/threadpool.hpp>
 #include <kth/infrastructure/utility/timer.hpp>
 #include <kth/infrastructure/utility/track.hpp>
+#include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/infrastructure/utility/writer.hpp>
 
 // #include <kth/infrastructure/wallet/message.hpp>

--- a/src/infrastructure/include/kth/infrastructure/error.hpp
+++ b/src/infrastructure/include/kth/infrastructure/error.hpp
@@ -267,6 +267,7 @@ enum error_code_t {
     // Domain object serialization/deserialization
     read_past_end_of_buffer,
     skip_past_end_of_buffer,
+    write_past_end_of_buffer,
     invalid_size,
     invalid_script_type,
     script_not_push_only,

--- a/src/infrastructure/include/kth/infrastructure/message/network_address.hpp
+++ b/src/infrastructure/include/kth/infrastructure/message/network_address.hpp
@@ -11,6 +11,7 @@
 
 #include <kth/infrastructure/define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/writer.hpp>
@@ -59,21 +60,8 @@ struct KI_API network_address {
     static
     expect<network_address> from_data(byte_reader& reader, uint32_t version, bool with_timestamp);
 
-    data_chunk to_data(uint32_t version, bool with_timestamp) const;
-    // void to_data(uint32_t version, std::ostream& stream, bool with_timestamp) const;
-    void to_data(uint32_t version, data_sink& stream, bool with_timestamp) const;
-
-    // void to_data(uint32_t version, writer& sink, bool with_timestamp) const;
-    template <typename W>
-    void to_data(uint32_t version, W& sink, bool with_timestamp) const {
-        if (with_timestamp) {
-            sink.write_4_bytes_little_endian(timestamp_);
-        }
-
-        sink.write_8_bytes_little_endian(services_);
-        sink.write_bytes(ip_.data(), ip_.size());
-        sink.write_2_bytes_big_endian(port_);
-    }
+    [[nodiscard]]
+    expect<void> to_data(byte_writer& writer, uint32_t version, bool with_timestamp) const;
 
     bool is_valid() const;
     bool is_routable() const;

--- a/src/infrastructure/include/kth/infrastructure/utility/assert.hpp
+++ b/src/infrastructure/include/kth/infrastructure/utility/assert.hpp
@@ -16,6 +16,15 @@
     #define DEBUG_ONLY(expression) expression
 #endif
 
+// `KTH_CONTRACT` is intended for contract checks whose violation would
+// corrupt observable output (sighash preimage, signature verification,
+// consensus-critical serialization). Unlike `KTH_ASSERT`, it stays live
+// in Release builds — a failure aborts the process instead of silently
+// letting a broken hash / signature / block reach the network. Use it
+// only for cheap, provably-should-hold predicates on the write path.
+#include <cstdlib>
+#define KTH_CONTRACT(expression) do { if ( ! (expression)) std::abort(); } while (0)
+
 // This is used to prevent bogus compiler warnings about unused variables.
 #define UNUSED(expression) (void)(expression)
 

--- a/src/infrastructure/include/kth/infrastructure/utility/byte_reader.hpp
+++ b/src/infrastructure/include/kth/infrastructure/utility/byte_reader.hpp
@@ -248,6 +248,24 @@ private:
     size_t position_;
 };
 
+// Anything with a `static expect<T> from_data(byte_reader&, args...)` factory.
+// Symmetric to `Serializable` in byte_writer.hpp.
+template <typename T, typename... Args>
+concept Deserializable = requires(byte_reader& r, Args... args) {
+    { T::from_data(r, args...) } -> std::same_as<expect<T>>;
+};
+
+// Build a `byte_reader` over `data` and invoke `T::from_data(reader, args...)`.
+// Replaces the boilerplate of constructing a reader at every call site that
+// already holds a `data_chunk` (or any contiguous byte range).
+template <typename T, typename Range, typename... Args>
+    requires Deserializable<T, Args...>
+[[nodiscard]] inline
+expect<T> from_data_chunk(Range const& data, Args... args) {
+    byte_reader reader(byte_span{data});
+    return T::from_data(reader, args...);
+}
+
 } // namespace kth
 
 #endif // KTH_INFRASTRUCTURE_BYTES_READER_HPP

--- a/src/infrastructure/include/kth/infrastructure/utility/byte_writer.hpp
+++ b/src/infrastructure/include/kth/infrastructure/utility/byte_writer.hpp
@@ -1,0 +1,235 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_INFRASTRUCTURE_BYTES_WRITER_HPP
+#define KTH_INFRASTRUCTURE_BYTES_WRITER_HPP
+
+#include <cstdint>
+#include <cstring>
+#include <expected>
+#include <span>
+#include <string>
+
+#include <kth/infrastructure/concepts.hpp>
+#include <kth/infrastructure/constants.hpp>
+#include <kth/infrastructure/error.hpp>
+#include <kth/infrastructure/math/hash.hpp>
+#include <kth/infrastructure/utility/data.hpp>
+#include <kth/infrastructure/utility/endian.hpp>
+
+namespace kth {
+
+// Symmetric counterpart to `byte_reader`: writes the on-wire (or store)
+// byte representation of domain values into a caller-owned buffer.
+// The buffer must be pre-sized to the exact serialization length the
+// caller intends to emit (use `T::serialized_size(...)`). Every write
+// is bounds-checked and returns `expect<void>` so partial writes never
+// silently overflow.
+struct byte_writer {
+    constexpr explicit
+    byte_writer(std::span<uint8_t> buffer)
+        : buffer_(buffer)
+        , position_(0)
+    {}
+
+    [[nodiscard]] constexpr
+    size_t buffer_size() const { return buffer_.size(); }
+
+    [[nodiscard]] constexpr
+    std::span<uint8_t> buffer() const { return buffer_; }
+
+    [[nodiscard]] constexpr
+    size_t remaining_size() const { return buffer_.size() - position_; }
+
+    [[nodiscard]] constexpr
+    size_t position() const { return position_; }
+
+    [[nodiscard]] constexpr
+    bool is_exhausted() const { return position_ >= buffer_.size(); }
+
+    // Bounds-check the next `count` bytes without risking arithmetic
+    // overflow. The naive `position_ + count > buffer_.size()` wraps when
+    // `count` is a caller-supplied size close to `size_t` max, silently
+    // passing the check before a `memcpy` that would run past the buffer.
+    // Comparing `count` against `buffer_.size() - position_` keeps the
+    // arithmetic bounded to values already known to fit in the buffer.
+    [[nodiscard]] constexpr
+    bool can_write(size_t count) const {
+        return position_ <= buffer_.size()
+            && count <= buffer_.size() - position_;
+    }
+
+    constexpr
+    void reset() { position_ = 0; }
+
+    constexpr
+    void unsafe_write_byte(uint8_t b) {
+        buffer_[position_++] = b;
+    }
+
+    [[nodiscard]] constexpr
+    expect<void> write_byte(uint8_t b) {
+        if ( ! can_write(1)) {
+            return std::unexpected(error::write_past_end_of_buffer);
+        }
+        unsafe_write_byte(b);
+        return {};
+    }
+
+    [[nodiscard]]
+    expect<void> write_bytes(std::span<uint8_t const> bytes) {
+        if ( ! can_write(bytes.size())) {
+            return std::unexpected(error::write_past_end_of_buffer);
+        }
+        std::memcpy(buffer_.data() + position_, bytes.data(), bytes.size());
+        position_ += bytes.size();
+        return {};
+    }
+
+    template <size_t N>
+    [[nodiscard]]
+    expect<void> write_array(std::array<uint8_t, N> const& a) {
+        if ( ! can_write(N)) {
+            return std::unexpected(error::write_past_end_of_buffer);
+        }
+        std::memcpy(buffer_.data() + position_, a.data(), N);
+        position_ += N;
+        return {};
+    }
+
+    template <std::integral I>
+    [[nodiscard]]
+    expect<void> write_little_endian(I value) {
+        if ( ! can_write(sizeof(I))) {
+            return std::unexpected(error::write_past_end_of_buffer);
+        }
+        // Route the write through `to_little_endian` so the byte
+        // order on the wire is fixed regardless of host endianness.
+        // A raw `memcpy(&value, ...)` would emit host-native order,
+        // which reverses the payload on big-endian targets.
+        auto const bytes = to_little_endian(static_cast<std::make_unsigned_t<I>>(value));
+        std::memcpy(buffer_.data() + position_, bytes.data(), sizeof(I));
+        position_ += sizeof(I);
+        return {};
+    }
+
+    template <std::integral I>
+    [[nodiscard]] constexpr
+    expect<void> write_big_endian(I value) {
+        if ( ! can_write(sizeof(I))) {
+            return std::unexpected(error::write_past_end_of_buffer);
+        }
+        for (size_t i = sizeof(I); i > 0; --i) {
+            buffer_[position_++] = static_cast<uint8_t>(value >> ((i - 1) * 8));
+        }
+        return {};
+    }
+
+    template <trivially_copyable T>
+    [[nodiscard]]
+    expect<void> write_packed(T const& value) {
+        if ( ! can_write(sizeof(T))) {
+            return std::unexpected(error::write_past_end_of_buffer);
+        }
+        std::memcpy(buffer_.data() + position_, &value, sizeof(T));
+        position_ += sizeof(T);
+        return {};
+    }
+
+    [[nodiscard]]
+    expect<void> write_variable_little_endian(uint64_t value) {
+        if (value < varint_two_bytes) {
+            return write_byte(static_cast<uint8_t>(value));
+        }
+        if (value <= 0xffffull) {
+            if (auto r = write_byte(varint_two_bytes); ! r) return r;
+            return write_little_endian<uint16_t>(static_cast<uint16_t>(value));
+        }
+        if (value <= 0xffffffffull) {
+            if (auto r = write_byte(varint_four_bytes); ! r) return r;
+            return write_little_endian<uint32_t>(static_cast<uint32_t>(value));
+        }
+        if (auto r = write_byte(varint_eight_bytes); ! r) return r;
+        return write_little_endian<uint64_t>(value);
+    }
+
+    [[nodiscard]]
+    expect<void> write_size_little_endian(size_t value) {
+        return write_variable_little_endian(static_cast<uint64_t>(value));
+    }
+
+    [[nodiscard]]
+    expect<void> write_hash(hash_digest const& hash) {
+        return write_array(hash);
+    }
+
+    // Writes a variable-length-prefixed string (canonical encoding):
+    //   size (varint) | bytes
+    [[nodiscard]]
+    expect<void> write_string(std::string const& value) {
+        if (auto r = write_size_little_endian(value.size()); ! r) return r;
+        return write_bytes(std::span{
+            reinterpret_cast<uint8_t const*>(value.data()), value.size()
+        });
+    }
+
+    // Writes a fixed-size string padded with `string_terminator` to the
+    // requested length. Truncates silently if `value` is longer than `size`.
+    // Mirrors `byte_reader::read_string(size_t)`.
+    [[nodiscard]]
+    expect<void> write_string_fixed(std::string const& value, size_t size) {
+        if ( ! can_write(size)) {
+            return std::unexpected(error::write_past_end_of_buffer);
+        }
+        auto const copy = std::min(value.size(), size);
+        std::memcpy(buffer_.data() + position_, value.data(), copy);
+        if (copy < size) {
+            std::memset(buffer_.data() + position_ + copy, string_terminator, size - copy);
+        }
+        position_ += size;
+        return {};
+    }
+
+private:
+    std::span<uint8_t> buffer_;
+    size_t position_;
+};
+
+// Size of the variable-length integer (varint) wire encoding for `value`.
+// Mirrors what `byte_writer::write_variable_little_endian` produces. Used by
+// every `serialized_size(...)` that includes a length-prefixed field.
+inline constexpr
+size_t size_variable_integer(uint64_t value) {
+    if (value < varint_two_bytes) return 1;
+    if (value <= max_uint16) return 3;
+    if (value <= max_uint32) return 5;
+    return 9;
+}
+
+// Anything that knows how to write itself into a `byte_writer` and report its
+// own wire size. The same parameter pack must serve both calls.
+template <typename T, typename... Args>
+concept Serializable = requires(T const& t, byte_writer& w, Args... args) {
+    { t.serialized_size(args...) } -> std::convertible_to<size_t>;
+    { t.to_data(w, args...) };
+};
+
+// Allocate a `data_chunk` sized to `obj.serialized_size(args...)`, write
+// `obj.to_data(writer, args...)` into it, and return the buffer. Replaces the
+// per-class `data_chunk to_data(...) const` convenience wrappers that all
+// reimplemented the same allocate/write/return dance.
+template <typename T, typename... Args>
+    requires Serializable<T, Args...>
+[[nodiscard]] inline
+data_chunk to_data_chunk(T const& obj, Args... args) {
+    data_chunk buf(obj.serialized_size(args...));
+    byte_writer writer(buf);
+    auto const r = obj.to_data(writer, args...);
+    KTH_ASSERT(r.has_value());
+    return buf;
+}
+
+} // namespace kth
+
+#endif // KTH_INFRASTRUCTURE_BYTES_WRITER_HPP

--- a/src/infrastructure/include/kth/infrastructure/utility/serializer.hpp
+++ b/src/infrastructure/include/kth/infrastructure/utility/serializer.hpp
@@ -18,22 +18,6 @@
 
 namespace kth {
 
-inline constexpr
-size_t size_variable_integer(uint64_t value) {
-    if (value < varint_two_bytes) {
-        return 1;
-    }
-    if (value <= max_uint16) {
-        return 3;
-    }
-
-    if (value <= max_uint32) {
-        return 5;
-    }
-
-    return 9;
-}
-
 /// Writer to wrap arbitrary iterator.
 template <typename Iterator>
 class serializer

--- a/src/infrastructure/src/error.cpp
+++ b/src/infrastructure/src/error.cpp
@@ -255,7 +255,12 @@ std::string error_category_impl::message(int ev) const noexcept {
         { error::impossible_encoding, "impossible encoding" },
         { error::invalid_split_range, "invalid split range" },
         { error::invalid_number_encoding, "invalid number encoding" },
-        { error::operand_size_mismatch, "operand size mismatch" }
+        { error::operand_size_mismatch, "operand size mismatch" },
+
+        // Domain object serialization/deserialization
+        { error::read_past_end_of_buffer, "read past end of buffer" },
+        { error::skip_past_end_of_buffer, "skip past end of buffer" },
+        { error::write_past_end_of_buffer, "write past end of buffer" }
     };
 
     auto const message = messages.find(ev);

--- a/src/infrastructure/src/message/network_address.cpp
+++ b/src/infrastructure/src/message/network_address.cpp
@@ -7,8 +7,6 @@
 #include <algorithm>
 #include <cstdint>
 
-#include <kth/infrastructure/utility/container_sink.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
 
 namespace kth::infrastructure::message {
 
@@ -185,20 +183,13 @@ expect<network_address> network_address::from_data(byte_reader& reader, uint32_t
     return network_address(timestamp, *services, ip_addr, *port);
 }
 
-data_chunk network_address::to_data(uint32_t version, bool with_timestamp) const {
-    data_chunk data;
-    auto const size = serialized_size(version, with_timestamp);
-    data.reserve(size);
-    data_sink ostream(data);
-    to_data(version, ostream, with_timestamp);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
-
-void network_address::to_data(uint32_t version, data_sink& stream, bool with_timestamp) const {
-    ostream_writer sink(stream);
-    to_data(version, sink, with_timestamp);
+expect<void> network_address::to_data(byte_writer& writer, uint32_t /*version*/, bool with_timestamp) const {
+    if (with_timestamp) {
+        if (auto r = writer.write_little_endian<uint32_t>(timestamp_); ! r) return r;
+    }
+    if (auto r = writer.write_little_endian<uint64_t>(services_); ! r) return r;
+    if (auto r = writer.write_bytes(std::span<uint8_t const>{ip_.data(), ip_.size()}); ! r) return r;
+    return writer.write_big_endian<uint16_t>(port_);
 }
 
 size_t network_address::serialized_size(uint32_t version, bool with_timestamp) const {

--- a/src/infrastructure/test/network_address.cpp
+++ b/src/infrastructure/test/network_address.cpp
@@ -109,7 +109,7 @@ TEST_CASE("network address  from data 1  without timestamp  success", "[network 
         123u
     };
 
-    auto const data = expected.to_data(version_level_minimum, false);
+    auto const data = kth::to_data_chunk(expected, version_level_minimum, false);
     byte_reader reader(data);
     auto const result = network_address::from_data(reader, version_level_minimum, false);
 
@@ -127,7 +127,7 @@ TEST_CASE("network address  from data 2  without timestamp  success", "[network 
         123u
     };
 
-    auto const data = expected.to_data(version_level_minimum, false);
+    auto const data = kth::to_data_chunk(expected, version_level_minimum, false);
     byte_reader reader(data);
     auto const result = network_address::from_data(reader, version_level_minimum, false);
 
@@ -145,7 +145,7 @@ TEST_CASE("network address  from data 3  without timestamp  success", "[network 
         123u
     };
 
-    auto const data = expected.to_data(version_level_minimum, false);
+    auto const data = kth::to_data_chunk(expected, version_level_minimum, false);
     byte_reader reader(data);
     auto const result = network_address::from_data(reader, version_level_minimum, false);
 
@@ -163,7 +163,7 @@ TEST_CASE("network address  from data 1  with timestamp  success", "[network add
         123u
     };
 
-    auto const data = expected.to_data(version_level_minimum, true);
+    auto const data = kth::to_data_chunk(expected, version_level_minimum, true);
     byte_reader reader(data);
     auto const result = network_address::from_data(reader, version_level_minimum, true);
 
@@ -181,7 +181,7 @@ TEST_CASE("network address  from data 2  with timestamp  success", "[network add
         123u
     };
 
-    auto const data = expected.to_data(version_level_minimum, true);
+    auto const data = kth::to_data_chunk(expected, version_level_minimum, true);
     byte_reader reader(data);
     auto const result = network_address::from_data(reader, version_level_minimum, true);
 
@@ -199,7 +199,7 @@ TEST_CASE("network address  from data 3  with timestamp  success", "[network add
         123u
     };
 
-    auto const data = expected.to_data(version_level_minimum, true);
+    auto const data = kth::to_data_chunk(expected, version_level_minimum, true);
     byte_reader reader(data);
     auto const result = network_address::from_data(reader, version_level_minimum, true);
 

--- a/src/infrastructure/test/utility/byte_writer.cpp
+++ b/src/infrastructure/test/utility/byte_writer.cpp
@@ -1,0 +1,291 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <kth/infrastructure.hpp>
+
+using namespace kth;
+using namespace kth::infrastructure;
+
+// Start Test Suite: byte_writer tests
+
+TEST_CASE("byte_writer - empty buffer is exhausted", "[byte_writer tests]") {
+    data_chunk buffer{};
+    byte_writer writer(buffer);
+    REQUIRE(writer.is_exhausted());
+    REQUIRE(writer.position() == 0u);
+    REQUIRE(writer.remaining_size() == 0u);
+}
+
+TEST_CASE("byte_writer - non-empty buffer starts at position 0", "[byte_writer tests]") {
+    data_chunk buffer(8u);
+    byte_writer writer(buffer);
+    REQUIRE( ! writer.is_exhausted());
+    REQUIRE(writer.position() == 0u);
+    REQUIRE(writer.remaining_size() == 8u);
+}
+
+TEST_CASE("byte_writer - write_byte advances position", "[byte_writer tests]") {
+    data_chunk buffer(2u);
+    byte_writer writer(buffer);
+
+    REQUIRE(writer.write_byte(0xAA).has_value());
+    REQUIRE(writer.position() == 1u);
+    REQUIRE(buffer[0] == 0xAA);
+
+    REQUIRE(writer.write_byte(0xBB).has_value());
+    REQUIRE(writer.position() == 2u);
+    REQUIRE(buffer[1] == 0xBB);
+    REQUIRE(writer.is_exhausted());
+}
+
+TEST_CASE("byte_writer - write_byte past end returns error", "[byte_writer tests]") {
+    data_chunk buffer(1u);
+    byte_writer writer(buffer);
+
+    REQUIRE(writer.write_byte(0xAA).has_value());
+    auto const result = writer.write_byte(0xBB);
+    REQUIRE( ! result.has_value());
+    REQUIRE(result.error() == error::write_past_end_of_buffer);
+    REQUIRE(writer.position() == 1u);
+}
+
+TEST_CASE("byte_writer - write_bytes copies span", "[byte_writer tests]") {
+    data_chunk buffer(4u);
+    byte_writer writer(buffer);
+
+    data_chunk const payload{0x11, 0x22, 0x33};
+    REQUIRE(writer.write_bytes(payload).has_value());
+    REQUIRE(writer.position() == 3u);
+    REQUIRE(buffer[0] == 0x11);
+    REQUIRE(buffer[1] == 0x22);
+    REQUIRE(buffer[2] == 0x33);
+}
+
+TEST_CASE("byte_writer - write_bytes past end returns error and does not partial-write", "[byte_writer tests]") {
+    data_chunk buffer(2u);
+    byte_writer writer(buffer);
+    data_chunk const payload{0x11, 0x22, 0x33};
+
+    auto const result = writer.write_bytes(payload);
+    REQUIRE( ! result.has_value());
+    REQUIRE(result.error() == error::write_past_end_of_buffer);
+    REQUIRE(writer.position() == 0u);
+}
+
+TEST_CASE("byte_writer - write_little_endian uint32 produces canonical bytes", "[byte_writer tests]") {
+    data_chunk buffer(4u);
+    byte_writer writer(buffer);
+
+    REQUIRE(writer.write_little_endian<uint32_t>(0x12345678u).has_value());
+    REQUIRE(buffer[0] == 0x78);
+    REQUIRE(buffer[1] == 0x56);
+    REQUIRE(buffer[2] == 0x34);
+    REQUIRE(buffer[3] == 0x12);
+}
+
+TEST_CASE("byte_writer - write_little_endian round-trips with read_little_endian", "[byte_writer tests]") {
+    data_chunk buffer(8u);
+    byte_writer writer(buffer);
+    REQUIRE(writer.write_little_endian<uint64_t>(0x0123456789ABCDEFull).has_value());
+
+    byte_reader reader(buffer);
+    auto const back = reader.read_little_endian<uint64_t>();
+    REQUIRE(back.has_value());
+    REQUIRE(*back == 0x0123456789ABCDEFull);
+}
+
+TEST_CASE("byte_writer - write_big_endian round-trips", "[byte_writer tests]") {
+    data_chunk buffer(4u);
+    byte_writer writer(buffer);
+    REQUIRE(writer.write_big_endian<uint32_t>(0xCAFEBABEu).has_value());
+    REQUIRE(buffer[0] == 0xCA);
+    REQUIRE(buffer[1] == 0xFE);
+    REQUIRE(buffer[2] == 0xBA);
+    REQUIRE(buffer[3] == 0xBE);
+}
+
+TEST_CASE("byte_writer - write_variable_little_endian single byte form", "[byte_writer tests]") {
+    data_chunk buffer(1u);
+    byte_writer writer(buffer);
+    REQUIRE(writer.write_variable_little_endian(0xFCu).has_value());
+    REQUIRE(writer.position() == 1u);
+    REQUIRE(buffer[0] == 0xFC);
+}
+
+TEST_CASE("byte_writer - write_variable_little_endian two byte form", "[byte_writer tests]") {
+    data_chunk buffer(3u);
+    byte_writer writer(buffer);
+    REQUIRE(writer.write_variable_little_endian(0x1234u).has_value());
+    REQUIRE(writer.position() == 3u);
+    REQUIRE(buffer[0] == 0xFD);
+    REQUIRE(buffer[1] == 0x34);
+    REQUIRE(buffer[2] == 0x12);
+}
+
+TEST_CASE("byte_writer - write_variable_little_endian four byte form", "[byte_writer tests]") {
+    data_chunk buffer(5u);
+    byte_writer writer(buffer);
+    REQUIRE(writer.write_variable_little_endian(0x12345678ull).has_value());
+    REQUIRE(writer.position() == 5u);
+    REQUIRE(buffer[0] == 0xFE);
+    REQUIRE(buffer[1] == 0x78);
+    REQUIRE(buffer[2] == 0x56);
+    REQUIRE(buffer[3] == 0x34);
+    REQUIRE(buffer[4] == 0x12);
+}
+
+TEST_CASE("byte_writer - write_variable_little_endian eight byte form", "[byte_writer tests]") {
+    data_chunk buffer(9u);
+    byte_writer writer(buffer);
+    REQUIRE(writer.write_variable_little_endian(0xDEADBEEFCAFEBABEull).has_value());
+    REQUIRE(writer.position() == 9u);
+    REQUIRE(buffer[0] == 0xFF);
+    REQUIRE(buffer[1] == 0xBE);
+    REQUIRE(buffer[2] == 0xBA);
+    REQUIRE(buffer[3] == 0xFE);
+    REQUIRE(buffer[4] == 0xCA);
+    REQUIRE(buffer[5] == 0xEF);
+    REQUIRE(buffer[6] == 0xBE);
+    REQUIRE(buffer[7] == 0xAD);
+    REQUIRE(buffer[8] == 0xDE);
+}
+
+TEST_CASE("byte_writer - write_variable round-trips through byte_reader", "[byte_writer tests]") {
+    SECTION("small (1 byte)") {
+        data_chunk buffer(1u);
+        byte_writer writer(buffer);
+        REQUIRE(writer.write_variable_little_endian(42u).has_value());
+        byte_reader reader(buffer);
+        auto const back = reader.read_variable_little_endian();
+        REQUIRE(back.has_value());
+        REQUIRE(*back == 42u);
+    }
+    SECTION("medium (3 bytes)") {
+        data_chunk buffer(3u);
+        byte_writer writer(buffer);
+        REQUIRE(writer.write_variable_little_endian(0xFFFFu).has_value());
+        byte_reader reader(buffer);
+        auto const back = reader.read_variable_little_endian();
+        REQUIRE(back.has_value());
+        REQUIRE(*back == 0xFFFFu);
+    }
+    SECTION("large (9 bytes)") {
+        data_chunk buffer(9u);
+        byte_writer writer(buffer);
+        REQUIRE(writer.write_variable_little_endian(0x100000000ull).has_value());
+        byte_reader reader(buffer);
+        auto const back = reader.read_variable_little_endian();
+        REQUIRE(back.has_value());
+        REQUIRE(*back == 0x100000000ull);
+    }
+}
+
+TEST_CASE("byte_writer - write_size_little_endian delegates to variable encoding", "[byte_writer tests]") {
+    data_chunk buffer(3u);
+    byte_writer writer(buffer);
+    REQUIRE(writer.write_size_little_endian(size_t{0x0100u}).has_value());
+    REQUIRE(buffer[0] == 0xFD);
+    REQUIRE(buffer[1] == 0x00);
+    REQUIRE(buffer[2] == 0x01);
+}
+
+TEST_CASE("byte_writer - write_array uses memcpy and advances", "[byte_writer tests]") {
+    data_chunk buffer(4u);
+    byte_writer writer(buffer);
+    std::array<uint8_t, 3> const a{0xDE, 0xAD, 0xBE};
+    REQUIRE(writer.write_array(a).has_value());
+    REQUIRE(writer.position() == 3u);
+    REQUIRE(buffer[0] == 0xDE);
+    REQUIRE(buffer[1] == 0xAD);
+    REQUIRE(buffer[2] == 0xBE);
+}
+
+TEST_CASE("byte_writer - write_hash writes the digest verbatim", "[byte_writer tests]") {
+    hash_digest hash{};
+    for (size_t i = 0; i < hash.size(); ++i) {
+        hash[i] = static_cast<uint8_t>(i);
+    }
+    data_chunk buffer(hash_size);
+    byte_writer writer(buffer);
+    REQUIRE(writer.write_hash(hash).has_value());
+    REQUIRE(writer.position() == hash_size);
+    for (size_t i = 0; i < hash.size(); ++i) {
+        REQUIRE(buffer[i] == static_cast<uint8_t>(i));
+    }
+}
+
+TEST_CASE("byte_writer - write_string writes varint length then bytes", "[byte_writer tests]") {
+    std::string const value = "hello";
+    data_chunk buffer(1u + value.size());
+    byte_writer writer(buffer);
+
+    REQUIRE(writer.write_string(value).has_value());
+    REQUIRE(writer.position() == buffer.size());
+    REQUIRE(buffer[0] == 5u);
+    REQUIRE(buffer[1] == 'h');
+    REQUIRE(buffer[2] == 'e');
+    REQUIRE(buffer[3] == 'l');
+    REQUIRE(buffer[4] == 'l');
+    REQUIRE(buffer[5] == 'o');
+}
+
+TEST_CASE("byte_writer - write_string round-trips through byte_reader", "[byte_writer tests]") {
+    std::string const value = "knuth";
+    data_chunk buffer(1u + value.size());
+    byte_writer writer(buffer);
+    REQUIRE(writer.write_string(value).has_value());
+
+    byte_reader reader(buffer);
+    auto const back = reader.read_string();
+    REQUIRE(back.has_value());
+    REQUIRE(*back == value);
+}
+
+TEST_CASE("byte_writer - write_string_fixed pads with terminator", "[byte_writer tests]") {
+    data_chunk buffer(8u);
+    byte_writer writer(buffer);
+    REQUIRE(writer.write_string_fixed("abc", 8u).has_value());
+    REQUIRE(writer.position() == 8u);
+    REQUIRE(buffer[0] == 'a');
+    REQUIRE(buffer[1] == 'b');
+    REQUIRE(buffer[2] == 'c');
+    REQUIRE(buffer[3] == 0x00);
+    REQUIRE(buffer[4] == 0x00);
+    REQUIRE(buffer[5] == 0x00);
+    REQUIRE(buffer[6] == 0x00);
+    REQUIRE(buffer[7] == 0x00);
+}
+
+TEST_CASE("byte_writer - write_string_fixed truncates over-length input", "[byte_writer tests]") {
+    data_chunk buffer(3u);
+    byte_writer writer(buffer);
+    REQUIRE(writer.write_string_fixed("hello", 3u).has_value());
+    REQUIRE(writer.position() == 3u);
+    REQUIRE(buffer[0] == 'h');
+    REQUIRE(buffer[1] == 'e');
+    REQUIRE(buffer[2] == 'l');
+}
+
+TEST_CASE("byte_writer - reset returns position to start", "[byte_writer tests]") {
+    data_chunk buffer(4u);
+    byte_writer writer(buffer);
+    REQUIRE(writer.write_byte(0xAA).has_value());
+    REQUIRE(writer.write_byte(0xBB).has_value());
+    REQUIRE(writer.position() == 2u);
+    writer.reset();
+    REQUIRE(writer.position() == 0u);
+    REQUIRE( ! writer.is_exhausted());
+}
+
+TEST_CASE("byte_writer - unsafe_write_byte writes without bounds-check", "[byte_writer tests]") {
+    data_chunk buffer(2u);
+    byte_writer writer(buffer);
+    writer.unsafe_write_byte(0x11);
+    writer.unsafe_write_byte(0x22);
+    REQUIRE(writer.position() == 2u);
+    REQUIRE(buffer[0] == 0x11);
+    REQUIRE(buffer[1] == 0x22);
+}

--- a/src/network/test/protocols_coro.cpp
+++ b/src/network/test/protocols_coro.cpp
@@ -217,7 +217,7 @@ TEST_CASE("perform_handshake success", "[protocols_coro]") {
     remote_version.set_user_agent("/RemotePeer:1.0/");
     remote_version.set_start_height(50000);
 
-    auto version_payload = remote_version.to_data(70015);
+    auto version_payload = kth::to_data_chunk(remote_version, 70015);
     auto version_msg = build_message_proto("version", version_payload, settings.identifier);
     ::asio::write(client, ::asio::buffer(version_msg), read_ec);
     REQUIRE(!read_ec);
@@ -304,7 +304,7 @@ TEST_CASE("perform_handshake rejects low version peer", "[protocols_coro]") {
     remote_version.set_user_agent("/OldPeer:0.1/");
     remote_version.set_start_height(50000);
 
-    auto version_payload = remote_version.to_data(31402);
+    auto version_payload = kth::to_data_chunk(remote_version, 31402);
     auto version_msg = build_message_proto("version", version_payload, settings.identifier);
     ::asio::write(client, ::asio::buffer(version_msg), read_ec);
 
@@ -336,7 +336,7 @@ TEST_CASE("run_ping_pong responds to ping", "[protocols_coro]") {
 
     // Send a ping from client
     domain::message::ping ping{123456789};
-    auto ping_payload = ping.to_data(70015);
+    auto ping_payload = kth::to_data_chunk(ping, 70015);
     auto ping_msg = build_message_proto("ping", ping_payload, settings.identifier);
 
     std::error_code write_ec;


### PR DESCRIPTION
## Goal

Mirror the `from_data` refactor on the serialization side. Old path:

1. allocate a `data_chunk`,
2. wrap it in a `boost::iostreams` `data_sink` (= `container_sink<vector, uint8_t, char>`),
3. wrap that in `ostream_writer`,
4. call a `template <typename W> void to_data(W& sink, ...)` that pushes one byte at a time through the stream stack.

New path:

1. caller pre-sizes a `data_chunk` to `T::serialized_size(...)`,
2. wraps it in a `byte_writer` (symmetric to `byte_reader` — same buffer model, same `expect<void>` error contract),
3. `T::to_data(byte_writer& w, ...)` writes straight into the buffer.

No streams, no virtual dispatch through iostream layers, no implicit allocation growth, all overflows surface as `error::write_past_end_of_buffer` instead of silent corruption.

## What ships in this PR

Single squashed commit that:

### Infrastructure

- `src/infrastructure/include/kth/infrastructure/utility/byte_writer.hpp` — the writer itself (`can_write` overflow-safe bounds check, `write_little_endian` routed through `to_little_endian` so wire bytes are host-endianness-independent, `to_data_chunk<T>(obj, args...)` fused-allocate-and-write helper).
- `src/infrastructure/include/kth/infrastructure/error.hpp` — new `error::write_past_end_of_buffer` enum value.
- `src/infrastructure/include/kth/infrastructure/utility/assert.hpp` — new `KTH_CONTRACT(expr)` macro (Release-live `assert`) for contract checks whose violation would corrupt observable output (sighash preimage, block/tx bytes). `KTH_ASSERT` stays no-op in Release; `KTH_CONTRACT` aborts.
- `src/infrastructure/test/utility/byte_writer.cpp` — unit coverage of every write path + round-trip against `byte_reader`.

### Domain migration

Every chain / message / machine / wallet type's `to_data` migrated:

- `chain::` — block, header, input, output, output_point, point, script, transaction, witness (SegWit-gated, migrated on principle).
- `message::` — address, alert, alert_payload, block, block_transactions, compact_block, double_spend_proof, fee_filter, filter_add, filter_clear, filter_load, get_address, get_block_transactions, get_blocks, get_data, get_headers, headers, heading, inventory, memory_pool, merkle_block, not_found, ping, pong, prefilled_transaction, reject, send_addrv2, send_compact, send_headers, transaction, verack, version, xverack.
- `machine::` — operation.
- `wallet::` — `hash_message` (BSM prefix hashing) rewritten to `byte_writer`.
- Every `data_chunk to_data(...) const` collapses to `return kth::to_data_chunk(*this, args...);`.

### `output::serialized_size` correctness fix

The tokenized-output branch used to compute `varint(script_bytes)` while `to_data` wrote `varint(wrapper_size)` — those are different values whenever they fall on opposite sides of a varint boundary. That mismatch was invisible in master because the growable `data_sink` absorbed the drift; the new fixed-size `byte_writer` truncates instead. Fixed the formula to match the write.

### `generate_version_0_signature_hash` correctness fix

`preimage_size()` was hand-summing only the required 11 fields and missed the BCH-native additions (utxos hash after field 2, per-input token data after field 5). When either fired, the sighash buffer was too small; writes past the end returned `unexpected(write_past_end_of_buffer)`, `KTH_ASSERT` was compiled out in Release, and the sighash was hashed over zero-padded bytes — `NULLFAIL` on every downstream signature. Formula now covers both optional fields; `write_ok` wrappers on the sighash path use `KTH_CONTRACT` so a future drift aborts instead of shipping bad bytes.

### Database call-site refactor

- `kth::database::from_db_value<T>(value, args...)` — zero-copy `T::from_data(byte_reader{db_value_as_span(value)}, args...)` skipping the intermediate `data_chunk` copy. Applied to 17 read sites in history/reorg/internal/transaction/spend/transaction_unconfirmed/header/utxo databases.
- `kth::database::db_reader(value) → byte_reader` — one-line shortcut for the manual span → reader path (5 sites in header_database + transaction_unconfirmed_database).
- `kth::database::db_value_as_span(value) → byte_span` — zero-copy view for the (small) set of sites that need to feed a free-function deserializer.
- `kth::database::owned_db_value` + `to_db_value<T>(obj, args...)` — write-side symmetric of `db_reader`. Bundles `data_chunk + KTH_DB_val` into one owning wrapper so callers don't juggle two locals; used across spend / reorg databases.

### C-API generator + regeneration

- Generator now preserves the existing header's declaration order to keep regenerated diffs minimal (only real API changes show up, not libclang iteration reshuffles).
- Generator emits `kth::to_c_array_from(kth::cpp_ref<cpp_t>(self), *out_size, args...)` for `to_data` exports — fused single-malloc-and-write helper replacing the old `to_data_chunk(...) + create_c_array(...)` two-malloc-and-copy path. Applied to 15 chain types.
- Generator uses the aliased `<name>_cpp` local when the C→C++ conversion isn't the identity, so the `to_data`-emitted body no longer runs `int_to_bool(wire)` twice per call.
- Regenerated every affected header/impl with the new order + fused helper.

### Old-style cleanup

- Deleted every `void to_data(data_sink&, ...)` overload and every `template<W> void to_data(W& sink, ...)` template from the domain, database, blockchain, node, network, and c-api trees.
- Deleted stale `#include <kth/infrastructure/utility/{reader,writer,container_sink,ostream_writer,serializer}.hpp>` in the ~25 files where the class name isn't referenced anymore.
- Legacy classes (`data_sink`, `ostream_writer`, `container_sink`, `writer`, `reader`, `serializer`, `deserializer`, `data_source`) still live in `src/infrastructure/**` because a handful of callers outside this PR's scope (network wire types, `png.cpp`) still use them — follow-up in #404.

## Follow-ups tracked separately

- **#400** — change `to_data_chunk` signature from `data_chunk` to `expect<data_chunk>` so serialization failures propagate instead of being swallowed by the Release-no-op assert. Big scope — ripples through ~180 call sites.
- **#401** — audit every `KTH_ASSERT` site in the write path and reclassify each as debug-only or `KTH_CONTRACT`. Same class of bug as the sighash regression above; do it once, everywhere.
- **#402** — audit database reachability + benchmark keep-txn-open (from `from_db_value`) vs copy-early on the read path. Depends on knowing which databases still carry meaningful data.
- **#403** — sweep `[[nodiscard]]` onto every `T::from_data(...)` declaration across domain/database. Mechanical, ~40 headers.
- **#404** — delete the legacy `data_sink` / `ostream_writer` / `writer` / `reader` / `serializer` / `deserializer` / `data_source` classes once the remaining P2P wire and PNG callers are migrated.

## Test plan

- [x] Local build green
- [x] Local `ctest -j8`: **5407/5407** tests pass
- [x] Local IBD smoke test on a fresh chain-data directory — see labruna baseline established alongside this PR
- [ ] CI green on the final squashed commit