### PR TITLE
ci: cut wall-clock by gating builds on deps + stabilizing ccache keys

### DIFF
--- a/.github/workflows/build-with-container.yml
+++ b/.github/workflows/build-with-container.yml
@@ -144,7 +144,10 @@ jobs:
           # cache restored into a non-sanitizer build (or vice-versa)
           # produces ~0 hits. The explicit suffix on both branches keeps
           # `restore-keys`' prefix match from leaking between families.
-          key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-${{ github.sha }}
+          # Key is per-day so the cache rotates without being commit-pinned
+          # (which guaranteed a miss + restore-keys fallback every run).
+          # Within the same day the primary key hits, so saves are no-ops.
+          key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-${{ hashFiles('conanfile.py') }}
           restore-keys: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-
 
       - name: 🔨 Build
@@ -225,7 +228,7 @@ jobs:
                  -DCMAKE_BUILD_TYPE=Release \
                  $CCACHE_OPT
 
-            cmake --build --preset conan-release -j4
+            cmake --build --preset conan-release -j"$(nproc)"
 
             if command -v ccache &>/dev/null; then
               ccache --show-stats
@@ -262,7 +265,7 @@ jobs:
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: /github/home/.cache/ccache
-          key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-${{ github.sha }}
+          key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-${{ hashFiles('conanfile.py') }}
 
       - name: 📊 Build summary
         if: always()

--- a/.github/workflows/build-without-container.yml
+++ b/.github/workflows/build-without-container.yml
@@ -126,7 +126,7 @@ jobs:
           path: ~/Library/Caches/ccache
           # Two disjoint cache families ('sanitizers' / 'clean') so the
           # restore-keys' prefix match can't leak across families.
-          key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-${{ github.sha }}
+          key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-${{ hashFiles('conanfile.py') }}
           restore-keys: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-
 
       - name: 🔨 Build
@@ -218,7 +218,7 @@ jobs:
                  -DCMAKE_BUILD_TYPE=Release \
                  $CCACHE_OPT
 
-            cmake --build --preset conan-release -j4
+            cmake --build --preset conan-release -j"$(sysctl -n hw.ncpu 2>/dev/null || nproc)"
 
             if command -v ccache &>/dev/null; then
               ccache --show-stats

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -275,7 +275,11 @@ jobs:
       conan-password: ${{ secrets.CONAN_3_PASSWORD }}
 
   build-with-container:
-    needs: [setup, generate-matrix]
+    # Wait for the deps job to push prebuilt packages to the conan remote.
+    # Without this `needs:` edge, `conan install --build=missing` here races
+    # the deps build and ends up rebuilding heavy packages (boost, utxoz,
+    # etc.) from source — adds ~5 min on Linux, ~20 min on macOS.
+    needs: [setup, generate-matrix, build-deps-with-container]
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
@@ -300,7 +304,7 @@ jobs:
       CONAN_PASSWORD: ${{ secrets.CONAN_3_PASSWORD }}
 
   build-with-container-sanitizers:
-    needs: [setup, generate-matrix]
+    needs: [setup, generate-matrix, build-deps-with-container]
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
@@ -325,7 +329,10 @@ jobs:
       CONAN_PASSWORD: ${{ secrets.CONAN_3_PASSWORD }}
 
   build-without-container:
-    needs: [setup, generate-matrix]
+    # Wait for the macOS deps build to populate the conan remote. Hosted
+    # macOS runners are slow (~30 min) when forced to rebuild deps from
+    # source — gating on the deps job pays for itself many times over.
+    needs: [setup, generate-matrix, build-deps-without-container]
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}


### PR DESCRIPTION
## Summary

Three coordinated GHA workflow tweaks identified by an end-to-end profiling pass over a recent main.yml run:

- **Gate builds on deps job**. `build-with-container` and `build-without-container` now have `needs: [build-deps-...]` edges. Previously they raced the deps job; when the build kicked off first, `conan install --build=missing` rebuilt heavy packages (boost, utxoz, ...) from source. On macOS hosted runners we observed the `Build` step exceed 30 min while the deps job was still running.
- **Stabilize ccache primary key**. Replaced \`\${{ github.sha }}\` with \`hashFiles('conanfile.py')\`. The per-commit key was guaranteed to miss every run and only ever recovered via the \`restore-keys\` fallback. The new key is stable until conan deps change, so the primary cache actually hits between runs and ccache stays warm.
- **Use full core count**. Dropped \`-j4\` in \`cmake --build\` for \`\$(nproc)\` on Linux and \`\$(sysctl -n hw.ncpu || nproc)\` on macOS. macos-26 ARM runners ship with 6 cores; ubuntu-24.04 with 4.

## Expected impact

Order of magnitude rough savings (per the profiling):
- macOS Build & Test: ~20-30 min on first build of a dep change
- Linux Build & Test: ~3-5 min on first build of a dep change
- All builds: incremental ccache hits no longer get blown away by per-commit primary key

## Test plan

- [ ] CI runs on this PR; macOS Build & Test job duration drops vs. recent runs.
- [ ] Linux Build & Test cache hit rate visible in ccache stats output.