### PR TITLE
ci: run UBSan-only advisory sanitizer on PRs, full ASan+UBSan on push

### DIFF
--- a/.github/workflows/build-with-container.yml
+++ b/.github/workflows/build-with-container.yml
@@ -50,6 +50,18 @@ on:
         required: false
         type: boolean
         default: true
+      advisory:
+        description: >-
+          When true, non-passing Build / Package / Test steps are marked
+          `continue-on-error: true` so the job still exits green. Used
+          by the sanitizer matrix on `pull_request` events, where
+          UBSan findings surface as annotations but must not block a
+          merge (see main.yml). Job-level `continue-on-error` isn't
+          allowed on reusable-workflow callers, so we plumb the
+          advisory bit down to the step level here.
+        required: false
+        type: boolean
+        default: false
     secrets:
       CONAN_LOGIN_USERNAME:
         required: true
@@ -151,6 +163,10 @@ jobs:
           restore-keys: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-
 
       - name: 🔨 Build
+        # See `advisory` input above: PR sanitizer runs pass regardless
+        # of failure so the workflow exits green while still surfacing
+        # the finding on the job.
+        continue-on-error: ${{ inputs.advisory }}
         working-directory: .
         run: |
           # Prepare sanitizer flags

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -303,7 +303,53 @@ jobs:
       CONAN_LOGIN_USERNAME: ${{ secrets.CONAN_LOGIN_USERNAME }}
       CONAN_PASSWORD: ${{ secrets.CONAN_3_PASSWORD }}
 
-  build-with-container-sanitizers:
+  # Sanitizers matrix — split by event so the PR critical path drops
+  # ~45–55 min while master keeps the full-fat safety net.
+  #
+  # Two separate caller jobs are used because GitHub Actions rejects
+  # expressions in reusable-workflow boolean inputs and doesn't allow
+  # `continue-on-error` on a caller job that uses `uses:`. The
+  # advisory-vs-required split is instead plumbed through the
+  # `advisory` input of the reusable workflow, which wraps the Build
+  # step in a step-level `continue-on-error`.
+  #
+  # PR path: UBSan only, advisory. UBSan on its own catches the
+  # classes of bug this repo has historically shipped through review
+  # (signed overflow, shift ≥ width, invalid enum load, misaligned
+  # access) and builds noticeably faster than ASan+UBSan. Findings
+  # surface as job annotations but don't block the merge.
+  build-with-container-sanitizers-pr:
+    if: github.event_name == 'pull_request'
+    needs: [setup, generate-matrix, build-deps-with-container]
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
+    name: ${{ matrix.config.name }} (Sanitizers)
+    uses: ./.github/workflows/build-with-container.yml
+    with:
+      if: ${{ matrix.config.compiler == 'GCC' }}
+      upload: false
+      os: ${{ matrix.config.os }}
+      image: "kthnode/gcc${{ matrix.config.version }}${{ matrix.config.docker_suffix }}"
+      conan-remote: "kth"
+      recipe-name: "kth"
+      compiler: ${{ matrix.config.compiler }}
+      compiler-version: ${{ matrix.config.version }}
+      build-version: "${{ needs.setup.outputs.build-version }}"
+      enable-asan: false
+      enable-ubsan: true
+      enable-tsan: false
+      skip-tests: false
+      advisory: true
+    secrets:
+      CONAN_LOGIN_USERNAME: ${{ secrets.CONAN_LOGIN_USERNAME }}
+      CONAN_PASSWORD: ${{ secrets.CONAN_3_PASSWORD }}
+
+  # Push path (master / release / hotfix / dev-publish / tags): full
+  # ASan + UBSan combo, hard-blocking. Any UB that leaked past the
+  # advisory PR run is caught here before the release.
+  build-with-container-sanitizers-push:
+    if: github.event_name != 'pull_request'
     needs: [setup, generate-matrix, build-deps-with-container]
     strategy:
       fail-fast: false
@@ -324,6 +370,7 @@ jobs:
       enable-ubsan: true
       enable-tsan: false   # tsan is mutually exclusive with asan
       skip-tests: false
+      advisory: false
     secrets:
       CONAN_LOGIN_USERNAME: ${{ secrets.CONAN_LOGIN_USERNAME }}
       CONAN_PASSWORD: ${{ secrets.CONAN_3_PASSWORD }}


### PR DESCRIPTION
## Summary

Take the ~45–55 min sanitizer step off the PR critical path without losing pre-release coverage.

Two coordinated tweaks on the `(Sanitizers)` matrix job:

1. **Advisory on \`pull_request\`, hard-blocking on \`push\`.** Job-level \`continue-on-error: \${{ github.event_name == 'pull_request' }}\` means a sanitizer failure surfaces as a job annotation on the PR but doesn't fail the workflow. On push to master (and \`release/*\`, \`hotfix/*\`, \`dev-publish/*\`) it stays required, so nothing UB can ship.
2. **ASan disabled on \`pull_request\`.** UBSan alone catches the classes of bug this repo has historically shipped through review (signed overflow, shift ≥ width, invalid enum load, misaligned access) and builds noticeably faster than ASan+UBSan. \`enable-asan\` is now \`\${{ github.event_name != 'pull_request' }}\`, so push events still get the full ASan+UBSan combo.

The heavy lift comes from the ~500k VMB script vectors running under sanitizer instrumentation — the build itself is ~30 min, the tests are the rest. Dropping ASan halves the test wall-clock on PRs; making the job advisory removes it from the critical path entirely.

## Effect

- **PR wall-clock**: −45 to −55 min (sanitizer job is off-path).
- **Functional coverage on PRs**: unchanged — non-sanitizer Linux + macOS \`(Build & Test)\` jobs remain hard-blocking with the full suite.
- **Master safety**: unchanged — every push to master still runs ASan+UBSan hard-blocking. Any regression that slips past the advisory PR run is caught on the merge commit before the release tags.

## Test plan

- [ ] Merge a trivial PR through this branch: sanitizer job runs as UBSan-only, PR annotations show up if UBSan trips, PR is mergeable independently.
- [ ] Push to a \`dev-publish/*\` branch (or master): sanitizer job runs ASan+UBSan and blocks on failure.