### PR TITLE
ci: apply ccache path-agnostic env to Linux Build step

### DIFF
--- a/.github/workflows/build-with-container.yml
+++ b/.github/workflows/build-with-container.yml
@@ -168,6 +168,26 @@ jobs:
         # the finding on the job.
         continue-on-error: ${{ inputs.advisory }}
         working-directory: .
+        env:
+          # Without these, ccache hashes absolute paths, the compiler
+          # binary's mtime, and the working directory into every
+          # translation-unit key. The container-runner's paths and mtimes
+          # shift between runs, so ~80% of files fell through to a "miss"
+          # even when a warm cache had been restored (measured: 18% hits
+          # in a real Linux Build & Test run, ~80 min build). Same fix
+          # already applied to the macOS caller (build-without-container.yml).
+          #
+          # - `BASEDIR`: rewrite workspace paths to be relative before hashing.
+          # - `NOHASHDIR`: don't hash the CWD at all — it changes per run.
+          # - `COMPILERCHECK=content`: key off the compiler binary's SHA,
+          #   not its mtime + path.
+          # - `SLOPPINESS`: ignore benign per-run drift (system-header
+          #   timestamps, __TIME__/__DATE__, locale sensitivity, PCH,
+          #   include-file ctime/mtime).
+          CCACHE_BASEDIR: ${{ github.workspace }}
+          CCACHE_COMPILERCHECK: content
+          CCACHE_NOHASHDIR: "true"
+          CCACHE_SLOPPINESS: pch_defines,time_macros,locale,system_headers,include_file_mtime,include_file_ctime
         run: |
           # Prepare sanitizer flags
           SANITIZER_FLAGS=""


### PR DESCRIPTION
## Symptom

Linux \`Build & Test\` on a recent PR run: **80 min in the \`🔨 Build\` step alone**, of an 83 min job. macOS Build & Test finished in 40 min. Tests take ~2 min total; the whole cost is the C++ compile.

## Diagnosis

ccache **restored** its cache successfully but showed:

    Hits:              205 / 1089 (18.82%)
    Misses:            884 / 1089 (81.18%)

The macOS caller (\`build-without-container.yml\`) already sets:

- \`CCACHE_BASEDIR: \${{ github.workspace }}\` — rewrite absolute paths to relative before hashing
- \`CCACHE_NOHASHDIR: true\` — drop the working directory from the hash
- \`CCACHE_COMPILERCHECK: content\` — key off the compiler binary's SHA, not its mtime + path
- \`CCACHE_SLOPPINESS: pch_defines,time_macros,locale,system_headers,include_file_mtime,include_file_ctime\`

The Linux caller (\`build-with-container.yml\`) had **none** of them. So ccache was hashing container-runner paths, compiler mtime, and the workspace directory into every translation-unit key. Everything except the ~205 files that happened to land at identical paths missed and re-compiled from scratch under \`-O3\`.

## Fix

Add the same four env vars to the Linux \`🔨 Build\` step.

## Expected effect

Hit rate should jump from ~18% to the ~80%+ that macOS gets, cutting the Build step by ~40–60 min on runs where the ccache is warm. First run after merge still misses (populates the cache); every subsequent PR benefits.

## Test plan

- [ ] After merge: open a trivial follow-up PR. Linux Build & Test job duration drops vs. the numbers above.
- [ ] ccache \`--show-stats\` at the end of the Build step reports hit rate >70%.