### PR TITLE
ci: unstick ccache save (0% hit rate → real cache reuse)

### DIFF
--- a/.github/workflows/build-with-container.yml
+++ b/.github/workflows/build-with-container.yml
@@ -151,15 +151,26 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: /github/home/.cache/ccache
-          # Two disjoint cache families: 'sanitizers' and 'clean'.
-          # Sanitizer flags change every compile command, so a sanitizer
-          # cache restored into a non-sanitizer build (or vice-versa)
-          # produces ~0 hits. The explicit suffix on both branches keeps
-          # `restore-keys`' prefix match from leaking between families.
-          # Key is per-day so the cache rotates without being commit-pinned
-          # (which guaranteed a miss + restore-keys fallback every run).
-          # Within the same day the primary key hits, so saves are no-ops.
-          key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-${{ hashFiles('conanfile.py') }}
+          # Two disjoint cache families: 'sanitizers' and 'clean'. Sanitizer
+          # flags change every compile command, so a sanitizer cache
+          # restored into a non-sanitizer build (or vice-versa) produces
+          # ~0 hits. The explicit suffix keeps `restore-keys`' prefix
+          # match from leaking between families.
+          #
+          # The primary key ends in `${{ github.run_id }}` so it is
+          # guaranteed *not* to be an exact restore hit — this is
+          # deliberate. Previously the key ended in
+          # `hashFiles('conanfile.py')`, which almost never changed
+          # between runs, so the sibling save step (gated on
+          # `cache-hit != 'true'`) was always skipped and the on-disk
+          # cache stayed pinned to whatever the first run wrote
+          # (Hits: 0 / 1090 = 0.00% on master's Linux Build & Test).
+          # With the run_id-suffixed key, restore always falls through
+          # to `restore-keys` and picks the most-recently-saved family
+          # member; the save step below then writes back the freshly
+          # populated cache. GHA's LRU eviction keeps total per-repo
+          # cache under the 10 GB cap.
+          key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-${{ github.run_id }}
           restore-keys: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-
 
       - name: 🔨 Build
@@ -296,12 +307,20 @@ jobs:
           key: ${{ steps.restore-conan.outputs.cache-primary-key }}
 
       - name: 🗄️ Save ccache
+        # Save on every non-upload run. The old gate
+        # `cache-hit != 'true'` skipped saves for every run whose
+        # `conanfile.py`-hashed key already existed, freezing the cache
+        # at whatever the first run wrote. The primary key now includes
+        # `github.run_id` so it's unique per run, cache-hit is never
+        # `'true'`, and the save actually runs — but the gate stays as
+        # documentation of the invariant we want (save only when we
+        # have something new to save).
         if: always() && inputs.upload != true && steps.restore-ccache.outputs.cache-hit != 'true'
         continue-on-error: true
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: /github/home/.cache/ccache
-          key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-${{ hashFiles('conanfile.py') }}
+          key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-${{ github.run_id }}
 
       - name: 📊 Build summary
         if: always()

--- a/.github/workflows/build-without-container.yml
+++ b/.github/workflows/build-without-container.yml
@@ -126,7 +126,16 @@ jobs:
           path: ~/Library/Caches/ccache
           # Two disjoint cache families ('sanitizers' / 'clean') so the
           # restore-keys' prefix match can't leak across families.
-          key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-${{ hashFiles('conanfile.py') }}
+          #
+          # The primary key ends in `${{ github.run_id }}` on purpose:
+          # `actions/cache@v5`'s post-job save only runs when the primary
+          # key was NOT restored, so pinning the key to a stable value
+          # (previously `hashFiles('conanfile.py')`) meant the post-save
+          # never fired — the cache was frozen at whatever the first
+          # run populated. A unique-per-run primary key guarantees the
+          # save fires; restore falls through to `restore-keys` and
+          # picks the most-recently-saved family member.
+          key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-${{ github.run_id }}
           restore-keys: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-
 
       - name: 🔨 Build


### PR DESCRIPTION
Fixes #406.

## What was happening

Linux Build & Test on every recent master run:

\`\`\`
Local storage:
  Cache size (GiB):  0.3 /  5.0 ( 6.60%)
  Hits:                0 / 1090 ( 0.00%)
  Misses:           1090 / 1090 (100.0%)
\`\`\`

A 205 MB ccache blob got restored on every run, contributed **zero** hits, and never got refreshed. The Build phase kept taking ~78–84 min because every one of the ~1090 objects was compiled from scratch.

## Root cause

Primary cache key ended in \`hashFiles('conanfile.py')\`, so in practice it was stable across runs. Both \`actions/cache/save@v5\` (Linux side) and the composite \`actions/cache@v5\` (macOS side) skip the post-job save when the restore was an exact-key hit — the Linux workflow explicitly gates on \`steps.restore-ccache.outputs.cache-hit != 'true'\`, and \`actions/cache@v5\` does the equivalent internally.

Net effect: the save step never fired. The on-disk cache stayed pinned to whatever the very first run had populated (a state that no longer matches anything the current source compiles to), and every subsequent run produced 100 % misses.

## Fix

Make the primary key unique per run by suffixing \`${{ github.run_id }}\`. Now:

- \`cache-hit\` on restore is never \`'true'\` → save actually runs.
- Restore falls through to \`restore-keys\` (unchanged family prefix) and picks the most-recently-saved sibling.
- Every run writes back a fresh cache under its own unique key.

GHA's LRU eviction at the 10 GB per-repo cap keeps growth bounded (each save is ~200 MB per family).

Applied symmetrically to both \`build-with-container.yml\` (Linux) and \`build-without-container.yml\` (macOS).

## Follows up #405

That PR removed one class of per-commit cache invalidation (the \`kth::version\` \`inline constexpr\` in a header transitively pulled by \`<kth/domain.hpp>\`). Its payoff was invisible in the CI numbers because the ccache save was already broken. Now that this lands, the next master run should:

1. Save a fresh cache built against current master.
2. The next PR/push against the same family (clean/sanitizers) restores that cache and gets its first real hits.
3. Build phase drops from ~78-84 min to the incremental-compile envelope.

## Test plan

- [x] YAML lints.
- [ ] CI green on this PR.
- [ ] After merge, the following master run's Linux Build & Test job shows the ccache Save step actually completing (not \"skipped\").
- [ ] The run after that shows Hits > 0.