### PR TITLE
refactor(infrastructure): default authority::operator==

### DIFF
--- a/src/infrastructure/include/kth/infrastructure/config/authority.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/authority.hpp
@@ -75,8 +75,8 @@ struct KI_API authority {
     [[nodiscard]] std::string           to_string() const;
     [[nodiscard]] message::network_address to_network_address() const;
 
-    [[nodiscard]] bool operator==(authority const& x) const;
-    [[nodiscard]] bool operator!=(authority const& x) const;
+    [[nodiscard]]
+    friend bool operator==(authority const&, authority const&) = default;
 
 private:
     // Private "wrap only" ctor used by `parse_from`.

--- a/src/infrastructure/src/config/authority.cpp
+++ b/src/infrastructure/src/config/authority.cpp
@@ -216,12 +216,4 @@ std::string authority::to_string() const {
     return to_authority(to_hostname(), port());
 }
 
-bool authority::operator==(authority const& x) const {
-    return port() == x.port() && ip() == x.ip();
-}
-
-bool authority::operator!=(authority const& x) const {
-    return ! (*this == x);
-}
-
 } // namespace kth::infrastructure::config


### PR DESCRIPTION
## Summary
- Replace hand-written `bool authority::operator==` / `operator!=` with the C++20 defaulted `friend bool operator==(authority const&, authority const&) = default;`. `!=` is auto-rewritten from `==` in C++20, so it no longer needs its own declaration or out-of-line body.
- Remove the two now-unused out-of-line bodies from `src/infrastructure/src/config/authority.cpp`.
- No `operator<=>` added: a codebase-wide search found zero callers that put `authority` into an ordered container (`std::set` / `std::map` / `std::sort`), so exposing an ordering would be dead API surface.

## Semantics
The defaulted form compares members directly (`asio::ipv6 ip_` and `uint16_t port_`) instead of going through `port()` + `ip()` (which round-tripped the address through `to_bc_address`). Every currently exercised construction path stores addresses with a zero scope id, so the observable equality matches the old form. The full `[authority]` test group (90 assertions, 55 cases) and the full `kth_infrastructure_test` binary (104451 assertions, 440 cases) pass unchanged.

## Test plan
- [x] `kth_infrastructure_test [authority]` — all 55 cases pass
- [x] `kth_infrastructure_test` full run — 440 cases pass
- [x] Release build of `kth_infrastructure_test` target succeeds with no warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated equality handling for authority configuration objects to use a simpler, defaulted comparison.
  * Removed the separate inequality overload and streamlined the comparison implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->