### PR TITLE
refactor(c-api): align kth_wallet_ec_to_address version with C++

### DIFF
--- a/src/c-api/include/kth/capi/wallet/wallet.h
+++ b/src/c-api/include/kth/capi/wallet/wallet.h
@@ -39,7 +39,7 @@ KTH_EXPORT
 kth_ec_public_t kth_wallet_ec_to_public(kth_ec_secret_t secret, kth_bool_t uncompressed);
 
 KTH_EXPORT
-kth_payment_address_t kth_wallet_ec_to_address(kth_ec_public_t point, uint32_t version);
+kth_payment_address_t kth_wallet_ec_to_address(kth_ec_public_t point, uint8_t version);
 
 
 // KTH_EXPORT

--- a/src/c-api/src/wallet/wallet.cpp
+++ b/src/c-api/src/wallet/wallet.cpp
@@ -102,9 +102,9 @@ kth_ec_public_t kth_wallet_ec_to_public(kth_ec_secret_t secret, kth_bool_t uncom
     return kth::leak<kth::domain::wallet::ec_public>(point, !uncompressed_cpp);
 }
 
-kth_payment_address_t kth_wallet_ec_to_address(kth_ec_public_t point, uint32_t version) {
+kth_payment_address_t kth_wallet_ec_to_address(kth_ec_public_t point, uint8_t version) {
     kth::domain::wallet::ec_public const& point_cpp = *static_cast<kth::domain::wallet::ec_public const*>(point);
-    auto result = kth::domain::wallet::payment_address::from_ec_public(point_cpp, static_cast<uint8_t>(version));
+    auto result = kth::domain::wallet::payment_address::from_ec_public(point_cpp, version);
     if ( ! result) {
         return nullptr;
     }


### PR DESCRIPTION
## Summary

The C-API entry point took \`uint32_t version\`, while the C++ wrapper it forwards to (\`payment_address::from_ec_public(ec_public, uint8_t)\`) expects a single-byte address prefix. The width mismatch forced a \`static_cast<uint8_t>\` inside the shim body.

Change the C-API signature to \`uint8_t version\` so the two sides line up. The cast in the body disappears.

- \`kth_wallet_ec_to_address(kth_ec_public_t point, uint32_t version)\` → \`kth_wallet_ec_to_address(kth_ec_public_t point, uint8_t version)\`
- Cast removed from the wrapper body.

## Why

Project policy: the C-API mirrors the C++ shape. When the two disagree, the fix is at the signature, not a cast inside the shim. ABI break across kth releases is acceptable — this is a single hand-written entry point in \`src/c-api/src/wallet/wallet.cpp\` that pre-dated the generator.

## Test plan

- [x] Local build clean.
- [x] \`kth_capi_test\` 769/769 pass.
- [ ] Consumers (py-native, node bindings) picking up the new header rebuild against the new signature.