### PR TITLE
refactor(infrastructure): modernize decode_base58/85 to std::expected

### DIFF
--- a/src/domain/src/wallet/ec_private.cpp
+++ b/src/domain/src/wallet/ec_private.cpp
@@ -71,15 +71,15 @@ ec_private ec_private::from_verified_secret(ec_secret const& secret, uint16_t ve
 
 // static
 expect<ec_private> ec_private::parse_from(std::string_view wif, uint8_t version) {
-    data_chunk decoded;
-    if ( ! decode_base58(decoded, std::string{wif}) || ! is_wif(decoded)) {
+    auto decoded = decode_base58(wif);
+    if ( ! decoded || ! is_wif(*decoded)) {
         return std::unexpected(kth::error::illegal_value);
     }
 
-    if (decoded.size() == wif_compressed_size) {
-        return from_compressed(to_array<wif_compressed_size>(decoded), version);
+    if (decoded->size() == wif_compressed_size) {
+        return from_compressed(to_array<wif_compressed_size>(*decoded), version);
     }
-    return from_uncompressed(to_array<wif_uncompressed_size>(decoded), version);
+    return from_uncompressed(to_array<wif_uncompressed_size>(*decoded), version);
 }
 
 // static

--- a/src/domain/src/wallet/ek_private.cpp
+++ b/src/domain/src/wallet/ek_private.cpp
@@ -16,11 +16,11 @@ namespace kth::domain::wallet {
 
 // static
 expect<ek_private> ek_private::parse_from(std::string_view encoded) {
-    encrypted_private key;
-    if ( ! decode_base58(key, std::string{encoded}) || ! verify_checksum(key)) {
+    auto const key = decode_base58<ek_private_decoded_size>(encoded);
+    if ( ! key || ! verify_checksum(*key)) {
         return std::unexpected(kth::error::illegal_value);
     }
-    return ek_private{key};
+    return ek_private{*key};
 }
 
 std::string ek_private::to_string() const {

--- a/src/domain/src/wallet/ek_public.cpp
+++ b/src/domain/src/wallet/ek_public.cpp
@@ -16,11 +16,11 @@ namespace kth::domain::wallet {
 
 // static
 expect<ek_public> ek_public::parse_from(std::string_view encoded) {
-    encrypted_public key;
-    if ( ! decode_base58(key, std::string{encoded}) || ! verify_checksum(key)) {
+    auto const key = decode_base58<encrypted_public_decoded_size>(encoded);
+    if ( ! key || ! verify_checksum(*key)) {
         return std::unexpected(kth::error::illegal_value);
     }
-    return ek_public{key};
+    return ek_public{*key};
 }
 
 std::string ek_public::to_string() const {

--- a/src/domain/src/wallet/ek_token.cpp
+++ b/src/domain/src/wallet/ek_token.cpp
@@ -16,11 +16,11 @@ namespace kth::domain::wallet {
 
 // static
 expect<ek_token> ek_token::parse_from(std::string_view encoded) {
-    encrypted_token key;
-    if ( ! decode_base58(key, std::string{encoded}) || ! verify_checksum(key)) {
+    auto const key = decode_base58<encrypted_token_decoded_size>(encoded);
+    if ( ! key || ! verify_checksum(*key)) {
         return std::unexpected(kth::error::illegal_value);
     }
-    return ek_token{key};
+    return ek_token{*key};
 }
 
 std::string ek_token::to_string() const {

--- a/src/domain/src/wallet/hd_private.cpp
+++ b/src/domain/src/wallet/hd_private.cpp
@@ -39,20 +39,20 @@ expect<hd_private> hd_private::parse_from(std::string_view encoded) {
 
 // static
 expect<hd_private> hd_private::parse_from_with_public_prefix(std::string_view encoded, uint32_t public_prefix) {
-    hd_key key;
-    if ( ! decode_base58(key, std::string{encoded})) {
+    auto const key = decode_base58<hd_key_size>(encoded);
+    if ( ! key) {
         return std::unexpected(kth::error::illegal_value);
     }
-    return from_key_impl(key, public_prefix);
+    return from_key_impl(*key, public_prefix);
 }
 
 // static
 expect<hd_private> hd_private::parse_from_with_prefixes(std::string_view encoded, uint64_t prefixes) {
-    hd_key key;
-    if ( ! decode_base58(key, std::string{encoded})) {
+    auto const key = decode_base58<hd_key_size>(encoded);
+    if ( ! key) {
         return std::unexpected(kth::error::illegal_value);
     }
-    return from_key_impl(key, prefixes);
+    return from_key_impl(*key, prefixes);
 }
 
 // static

--- a/src/domain/src/wallet/hd_public.cpp
+++ b/src/domain/src/wallet/hd_public.cpp
@@ -29,20 +29,20 @@ namespace kth::domain::wallet {
 
 // static
 expect<hd_public> hd_public::parse_from(std::string_view encoded) {
-    hd_key key;
-    if ( ! decode_base58(key, std::string{encoded})) {
+    auto const key = decode_base58<hd_key_size>(encoded);
+    if ( ! key) {
         return std::unexpected(kth::error::illegal_value);
     }
-    return from_hd_key(key);
+    return from_hd_key(*key);
 }
 
 // static
 expect<hd_public> hd_public::parse_from_with_prefix(std::string_view encoded, uint32_t prefix) {
-    hd_key key;
-    if ( ! decode_base58(key, std::string{encoded})) {
+    auto const key = decode_base58<hd_key_size>(encoded);
+    if ( ! key) {
         return std::unexpected(kth::error::illegal_value);
     }
-    return from_hd_key_with_prefix(key, prefix);
+    return from_hd_key_with_prefix(*key, prefix);
 }
 
 // static

--- a/src/domain/src/wallet/payment_address.cpp
+++ b/src/domain/src/wallet/payment_address.cpp
@@ -182,12 +182,12 @@ expect<payment_address> payment_address::from_string_cashaddr(std::string const&
 
 // static
 expect<payment_address> payment_address::parse_from(std::string_view address) {
-    std::string const s{address};
-    payment decoded;
-    if (decode_base58(decoded, s) && is_address(decoded)) {
-        return from_payment(decoded);
+    auto const decoded = decode_base58<payment_size>(address);
+    if (decoded && is_address(*decoded)) {
+        return from_payment(*decoded);
     }
 #if defined(KTH_CURRENCY_BCH)
+    std::string const s{address};
     auto const net = detect_cashaddr_network(s);
     if (net) {
         return from_string_cashaddr(s, *net);
@@ -198,13 +198,12 @@ expect<payment_address> payment_address::parse_from(std::string_view address) {
 
 // static
 expect<payment_address> payment_address::parse_from(std::string_view address, config::network net) {
-    std::string const s{address};
-    payment decoded;
-    if (decode_base58(decoded, s) && is_address(decoded)) {
-        return from_payment(decoded);
+    auto const decoded = decode_base58<payment_size>(address);
+    if (decoded && is_address(*decoded)) {
+        return from_payment(*decoded);
     }
 #if defined(KTH_CURRENCY_BCH)
-    return from_string_cashaddr(s, net);
+    return from_string_cashaddr(std::string{address}, net);
 #else
     (void)net;
     return std::unexpected(kth::error::illegal_value);

--- a/src/domain/src/wallet/stealth_address.cpp
+++ b/src/domain/src/wallet/stealth_address.cpp
@@ -53,11 +53,11 @@ size_t const stealth_address::max_filter_bits = sizeof(uint32_t) * byte_bits;
 
 // static
 expect<stealth_address> stealth_address::parse_from(std::string_view encoded) {
-    data_chunk decoded;
-    if ( ! decode_base58(decoded, std::string{encoded})) {
+    auto const decoded = decode_base58(encoded);
+    if ( ! decoded) {
         return std::unexpected(kth::error::illegal_value);
     }
-    return from_data(decoded);
+    return from_data(*decoded);
 }
 
 // static

--- a/src/infrastructure/include/kth/infrastructure/formats/base_16.hpp
+++ b/src/infrastructure/include/kth/infrastructure/formats/base_16.hpp
@@ -5,7 +5,9 @@
 #ifndef KTH_INFRASTUCTURE_BASE_16_HPP
 #define KTH_INFRASTUCTURE_BASE_16_HPP
 
+#include <cstddef>
 #include <expected>
+#include <span>
 #include <string>
 #include <string_view>
 
@@ -15,8 +17,9 @@
 namespace kth {
 
 enum class base16_errc {
-    odd_length,
-    invalid_character
+    odd_length,           // input has an odd number of characters
+    invalid_character,    // input contains a non-hex character
+    size_mismatch,        // caller-provided buffer size doesn't match `in.size() / 2`
 };
 
 /**
@@ -32,12 +35,24 @@ bool is_base16(char c);
 KI_API std::string encode_base16(byte_span data);
 
 /**
- * Convert a hex string into bytes.
+ * Decode base16 into a caller-provided buffer.
+ * Zero allocation.
+ * @return the number of bytes written, or an error code.
+ *   `odd_length`        — input length is odd.
+ *   `size_mismatch`     — `in.size() / 2 != out.size()`.
+ *   `invalid_character` — input contains a non-hex character.
+ */
+[[nodiscard]] constexpr std::expected<size_t, base16_errc>
+decode_base16(std::string_view in, std::span<uint8_t> out);
+
+/**
+ * Convert a hex string into a freshly-allocated `data_chunk`.
  */
 [[nodiscard]] constexpr std::expected<data_chunk, base16_errc> decode_base16(std::string_view in);
 
 /**
- * Converts a hex string to a number of bytes.
+ * Convert a hex string into a fixed-size `byte_array<Size>`.
+ * Zero allocation.
  */
 template <size_t Size>
 [[nodiscard]] constexpr std::expected<byte_array<Size>, base16_errc> decode_base16(std::string_view in);

--- a/src/infrastructure/include/kth/infrastructure/formats/base_58.hpp
+++ b/src/infrastructure/include/kth/infrastructure/formats/base_58.hpp
@@ -5,6 +5,9 @@
 #ifndef KTH_INFRASTUCTURE_BASE_58_HPP
 #define KTH_INFRASTUCTURE_BASE_58_HPP
 
+#include <cstddef>
+#include <expected>
+#include <span>
 #include <string>
 #include <string_view>
 
@@ -13,24 +16,19 @@
 
 namespace kth {
 
+enum class base58_errc {
+    invalid_character,
+    size_mismatch
+};
+
+// Bitcoin base58 alphabet. `[0]` is the "zero digit" ('1') used by
+// leading-zero counting in decode; the template `decode_base58<Size>`
+// in `base_58.ipp` also uses this via `find()`.
+inline constexpr std::string_view base58_alphabet =
+    "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
 KI_API bool is_base58(char ch);
 KI_API bool is_base58(std::string_view text);
-
-/**
- * Converts a base58 string to a number of bytes.
- * @return false if the input is malformed, or the wrong length.
- */
-template <size_t Size>
-bool decode_base58(byte_array<Size>& out, std::string_view in);
-
-/**
- * Converts a base58 string literal to a data array.
- * This would be better as a C++11 user-defined literal,
- * but MSVC doesn't support those.
- * TODO: determine if the sizing function is always accurate.
- */
-template <size_t Size>
-byte_array<Size * 733 / 1000> base58_literal(char const(&string)[Size]);
 
 /**
  * Encode data as base58.
@@ -39,10 +37,54 @@ byte_array<Size * 733 / 1000> base58_literal(char const(&string)[Size]);
 KI_API std::string encode_base58(byte_span unencoded);
 
 /**
- * Attempt to decode base58 data.
- * @return false if the input contains non-base58 characters.
+ * Decode base58 into a caller-provided buffer.
+ * Zero allocation.
+ * @return the number of bytes written, or an error code.
+ *   `invalid_character` — input contains a non-base58 character.
+ *   `size_mismatch`     — decoded output would be larger than `out`.
+ * @note On error `out` may be partially mutated with intermediate
+ * base256 conversion state. Callers must NOT read `out` after a
+ * non-success return; treat the buffer as clobbered.
  */
-KI_API bool decode_base58(data_chunk& out, std::string_view in);
+[[nodiscard]]
+KI_API std::expected<size_t, base58_errc>
+decode_base58(std::string_view in, std::span<uint8_t> out);
+
+/**
+ * Decode base58 into a freshly-allocated `data_chunk`.
+ * @return the decoded bytes, or an error code.
+ */
+[[nodiscard]]
+KI_API std::expected<data_chunk, base58_errc> decode_base58(std::string_view in);
+
+/**
+ * Decode base58 into a fixed-size `byte_array<Size>`.
+ * Zero allocation.
+ * @return the decoded array, or `size_mismatch` if the input does
+ * not produce exactly `Size` bytes.
+ */
+template <size_t Size>
+[[nodiscard]]
+std::expected<byte_array<Size>, base58_errc> decode_base58(std::string_view in);
+
+// Compile-time upper bound on the number of bytes decoded from `chars`
+// base58 characters. `log(58)/log(256) ≈ 0.732487`, so we take the
+// ceiling of `chars * 733 / 1000`. Kept explicit (rather than a raw
+// `chars * 733 / 1000 + 1`) so the formula reads as what it is —
+// integer-math ceiling of `chars * 733 / 1000`.
+constexpr size_t base58_decoded_max_size(size_t chars) noexcept {
+    return (chars * 733 + 999) / 1000;
+}
+
+/**
+ * Decode a compile-time base58 string literal to a data array.
+ * Delegates to `decode_base58<base58_decoded_max_size(Size - 1)>` and
+ * asserts the result on error — intended for known-good literals in
+ * tests where the caller expects the input to decode to exactly the
+ * upper-bound number of bytes.
+ */
+template <size_t Size>
+byte_array<base58_decoded_max_size(Size - 1)> base58_literal(char const(&string)[Size]);
 
 } // namespace kth
 

--- a/src/infrastructure/include/kth/infrastructure/formats/base_85.hpp
+++ b/src/infrastructure/include/kth/infrastructure/formats/base_85.hpp
@@ -5,6 +5,9 @@
 #ifndef KTH_INFRASTUCTURE_BASE_85_HPP
 #define KTH_INFRASTUCTURE_BASE_85_HPP
 
+#include <cstddef>
+#include <expected>
+#include <span>
 #include <string>
 #include <string_view>
 
@@ -13,18 +16,50 @@
 
 namespace kth {
 
+enum class base85_errc {
+    invalid_length,
+    invalid_character
+};
+
 /**
  * Encode data as base85 (Z85).
- * @return false if the input is not of base85 size (% 4).
+ * @return the encoded string, or `invalid_length` if the input size
+ * is not a multiple of 4.
  */
-KI_API bool encode_base85(std::string& out, byte_span in);
+[[nodiscard]]
+KI_API std::expected<std::string, base85_errc> encode_base85(byte_span in);
 
 /**
- * Attempt to decode base85 (Z85) data.
- * @return false if the input contains non-base85 characters or length (% 5).
+ * Decode base85 (Z85) into a caller-provided buffer.
+ * Zero allocation.
+ * @return the number of bytes written, or an error code.
+ *   `invalid_length`    — input size is not a multiple of 5, or `out`
+ *                         is smaller than the expected `in.size() * 4 / 5`.
+ *   `invalid_character` — input contains a non-base85 character.
  */
-KI_API bool decode_base85(data_chunk& out, std::string_view in);
+[[nodiscard]]
+KI_API std::expected<size_t, base85_errc>
+decode_base85(std::string_view in, std::span<uint8_t> out);
+
+/**
+ * Decode base85 (Z85) into a freshly-allocated `data_chunk`.
+ * @return the decoded bytes, or an error code.
+ */
+[[nodiscard]]
+KI_API std::expected<data_chunk, base85_errc> decode_base85(std::string_view in);
+
+/**
+ * Decode base85 (Z85) into a fixed-size `byte_array<Size>`.
+ * Zero allocation — the byte_array lives on the caller's stack.
+ * @return the decoded array, or an error code if the input does not
+ * produce exactly `Size` bytes.
+ */
+template <size_t Size>
+[[nodiscard]]
+std::expected<byte_array<Size>, base85_errc> decode_base85(std::string_view in);
 
 } // namespace kth
+
+#include <kth/infrastructure/impl/formats/base_85.ipp>
 
 #endif

--- a/src/infrastructure/include/kth/infrastructure/impl/formats/base_16.ipp
+++ b/src/infrastructure/include/kth/infrastructure/impl/formats/base_16.ipp
@@ -61,6 +61,20 @@ constexpr bool decode_base16(uint8_t* out, size_t out_size, char const* in) {
 
 } // namespace detail
 
+constexpr std::expected<size_t, base16_errc>
+decode_base16(std::string_view in, std::span<uint8_t> out) {
+    if (in.size() % 2 != 0) {
+        return std::unexpected(base16_errc::odd_length);
+    }
+    if (in.size() / 2 != out.size()) {
+        return std::unexpected(base16_errc::size_mismatch);
+    }
+    if ( ! detail::decode_base16(out.data(), out.size(), in.data())) {
+        return std::unexpected(base16_errc::invalid_character);
+    }
+    return out.size();
+}
+
 constexpr std::expected<data_chunk, base16_errc> decode_base16(std::string_view in) {
     if (in.size() % 2 != 0) {
         return std::unexpected(base16_errc::odd_length);

--- a/src/infrastructure/include/kth/infrastructure/impl/formats/base_58.ipp
+++ b/src/infrastructure/include/kth/infrastructure/impl/formats/base_58.ipp
@@ -5,37 +5,108 @@
 #ifndef KTH_INFRASTUCTURE_BASE_58_IPP
 #define KTH_INFRASTUCTURE_BASE_58_IPP
 
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <expected>
+#include <span>
+#include <string_view>
+
 #include <kth/infrastructure/utility/assert.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 
 namespace kth {
 
-// For support of template implementation only, do not call directly.
-KI_API bool decode_base58_private(uint8_t* out, size_t out_size,
-    char const* in);
+// Inverse of `base58_alphabet`: ASCII byte → digit value (0..57), or
+// `0xff` for any non-base58 character. Consumed by both the .ipp
+// template and the .cpp span/data_chunk overloads.
+inline constexpr auto base58_decode_table = []() consteval {
+    std::array<uint8_t, 256> table{};
+    for (auto& b : table) b = 0xff;
+    for (size_t i = 0; i < base58_alphabet.size(); ++i) {
+        table[static_cast<uint8_t>(base58_alphabet[i])] = static_cast<uint8_t>(i);
+    }
+    return table;
+}();
 
 template <size_t Size>
-bool decode_base58(byte_array<Size>& out, std::string_view in)
-{
-    byte_array<Size> result;
-    if ( ! decode_base58_private(result.data(), result.size(), in.data())) {
-        return false;
-}
+std::expected<byte_array<Size>, base58_errc> decode_base58(std::string_view in) {
+    // Zero-alloc, zero-copy exact-size decode.
+    //
+    // The algorithm unpacks base58 chars into `out` in-place (using the
+    // tail as base256 scratch). No extra scratch buffer is needed
+    // because we specialise for the *exact*-size case: any input that
+    // would produce more than `Size` bytes surfaces as a residual carry
+    // (`c != 0` at the end of an iteration); any input that produces
+    // fewer than `Size` bytes leaves `scratch[0] == 0` (the payload
+    // right-aligns in the fixed-size scratch, so the "extra" leading
+    // slot never receives a real byte). Both are rejected as
+    // `size_mismatch`.
 
-    out = result;
-    return true;
-}
+    // Count leading '1's — each represents a leading zero byte in the output.
+    size_t leading_zeros = 0;
+    for (char c : in) {
+        if (c != base58_alphabet[0]) break;
+        ++leading_zeros;
+    }
+    if (leading_zeros > Size) {
+        return std::unexpected(base58_errc::size_mismatch);
+    }
 
-// TODO: determine if the sizing function is always accurate.
-template <size_t Size>
-byte_array<Size * 733 / 1000> base58_literal(char const(&string)[Size])
-{
-    // log(58) / log(256), rounded up.
-    byte_array<Size * 733 / 1000> out;
-    DEBUG_ONLY(auto const success =) decode_base58_private(out.data(),
-        out.size(), string);
-    KTH_ASSERT(success);
+    // `out` starts zero — the first `leading_zeros` bytes are already
+    // the correct leading zero prefix; the tail acts as scratch.
+    byte_array<Size> out{};
+
+    // All-zero-input fast path: only valid if the requested Size equals
+    // the leading-zero count.
+    if (in.size() == leading_zeros) {
+        if (leading_zeros == Size) return out;
+        return std::unexpected(base58_errc::size_mismatch);
+    }
+
+    std::span<uint8_t> scratch{out};
+    scratch = scratch.subspan(leading_zeros);
+
+    for (auto it = in.begin() + leading_zeros; it != in.end(); ++it) {
+        auto const digit = base58_decode_table[static_cast<uint8_t>(*it)];
+        if (digit == 0xff) {
+            return std::unexpected(base58_errc::invalid_character);
+        }
+        // In-place base256 multiply-add: scratch = scratch * 58 + digit.
+        size_t carry = digit;
+        for (auto sit = scratch.rbegin(); sit != scratch.rend(); ++sit) {
+            carry += 58 * (*sit);
+            *sit = carry % 256;
+            carry /= 256;
+        }
+        // Any residual carry means the input encodes MORE than
+        // `Size - leading_zeros` bytes of payload — reject.
+        if (carry != 0) {
+            return std::unexpected(base58_errc::size_mismatch);
+        }
+    }
+
+    // If the topmost scratch byte is still zero, the payload didn't
+    // fully populate the reserved region — the input encodes FEWER
+    // bytes than the requested `Size`. Reject.
+    if (scratch[0] == 0) {
+        return std::unexpected(base58_errc::size_mismatch);
+    }
+
     return out;
+}
+
+template <size_t Size>
+byte_array<base58_decoded_max_size(Size - 1)> base58_literal(char const(&string)[Size]) {
+    // `Size` includes the trailing NUL; `Size - 1` is the actual char
+    // count. `base58_decoded_max_size` is the ceiling of that count
+    // times `log(58)/log(256)`, so any literal that decodes to
+    // exactly that many bytes lands here successfully; any that
+    // decodes to fewer trips the assert.
+    auto const decoded = decode_base58<base58_decoded_max_size(Size - 1)>(
+        std::string_view{string, Size - 1});
+    KTH_ASSERT(decoded);
+    return *decoded;
 }
 
 } // namespace kth

--- a/src/infrastructure/include/kth/infrastructure/impl/formats/base_85.ipp
+++ b/src/infrastructure/include/kth/infrastructure/impl/formats/base_85.ipp
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_INFRASTUCTURE_BASE_85_IPP
+#define KTH_INFRASTUCTURE_BASE_85_IPP
+
+#include <algorithm>
+#include <cstddef>
+#include <expected>
+#include <string_view>
+
+#include <kth/infrastructure/utility/data.hpp>
+
+namespace kth {
+
+template <size_t Size>
+std::expected<byte_array<Size>, base85_errc> decode_base85(std::string_view in) {
+    // Every 5 characters produce 4 bytes; refuse straight away if the
+    // requested output size can't come from ANY valid input length.
+    if (in.size() * 4 / 5 != Size) {
+        return std::unexpected(base85_errc::invalid_length);
+    }
+    byte_array<Size> out;
+    auto const written = decode_base85(in, out);
+    if ( ! written) {
+        return std::unexpected(written.error());
+    }
+    // `written` must equal `Size` on success (the length guard above
+    // makes that a compile-time-derived invariant), but assert to
+    // catch any future drift in the span-form impl.
+    if (*written != Size) {
+        return std::unexpected(base85_errc::invalid_length);
+    }
+    return out;
+}
+
+} // namespace kth
+
+#endif

--- a/src/infrastructure/src/config/base58.cpp
+++ b/src/infrastructure/src/config/base58.cpp
@@ -35,11 +35,11 @@ byte_span base58::as_span() const noexcept {
 }
 
 std::expected<base58, std::error_code> base58::from_string(std::string_view text) noexcept {
-    data_chunk value;
-    if ( ! decode_base58(value, text)) {
+    auto value = decode_base58(text);
+    if ( ! value) {
         return std::unexpected(std::make_error_code(std::errc::invalid_argument));
     }
-    return base58(std::move(value));
+    return base58(std::move(*value));
 }
 
 std::string base58::to_string() const {

--- a/src/infrastructure/src/config/sodium.cpp
+++ b/src/infrastructure/src/config/sodium.cpp
@@ -17,20 +17,16 @@ namespace kth::infrastructure::config {
 
 // static
 std::expected<sodium, kth::code> sodium::parse_from(std::string_view base85) {
-    data_chunk decoded;
-    if ( ! decode_base85(decoded, std::string{base85}) || decoded.size() != hash_size) {
+    auto const decoded = decode_base85<hash_size>(base85);
+    if ( ! decoded) {
         return std::unexpected(kth::error::illegal_value);
     }
-    hash_digest value;
-    std::copy_n(decoded.begin(), hash_size, value.begin());
-    return sodium{value};
+    return sodium{*decoded};
 }
 
 std::string sodium::to_string() const {
-    std::string decoded;
     // Z85 requires four-byte alignment (hash_digest is 32 → always OK).
-    (void)encode_base85(decoded, value_);
-    return decoded;
+    return encode_base85(value_).value_or(std::string{});
 }
 
 } // namespace kth::infrastructure::config

--- a/src/infrastructure/src/formats/base_58.cpp
+++ b/src/infrastructure/src/formats/base_58.cpp
@@ -4,48 +4,50 @@
 
 #include <kth/infrastructure/formats/base_58.hpp>
 
+#include <algorithm>
+#include <cstring>
+
 #include <boost/algorithm/string.hpp>
 
 #include <kth/infrastructure/utility/assert.hpp>
 
 namespace kth {
 
-std::string const base58_chars = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-
 bool is_base58(char ch) {
-    // This works because the base58 characters happen to be in sorted order
-    return std::binary_search(base58_chars.begin(), base58_chars.end(), ch);
+    return base58_decode_table[static_cast<uint8_t>(ch)] != 0xff;
 }
 
 bool is_base58(std::string_view text) {
-    auto const test = [](char ch) {
-        return is_base58(ch);
-    };
-
-    return std::all_of(text.begin(), text.end(), test);
+    return std::all_of(text.begin(), text.end(),
+        [](char ch) { return is_base58(ch); });
 }
 
+namespace {
+
 template <typename Data>
-auto search_first_nonzero(const Data& data) -> decltype(data.cbegin()) {
+auto search_first_nonzero(Data const& data) {
     auto first_nonzero = data.cbegin();
     while (first_nonzero != data.end() && *first_nonzero == 0) {
         ++first_nonzero;
     }
-
     return first_nonzero;
 }
 
-size_t count_leading_zeros(byte_span unencoded) {
-    // Skip and count leading '1's.
+size_t count_leading_zero_bytes(byte_span unencoded) {
     size_t leading_zeros = 0;
-    for (uint8_t const byte: unencoded) {
-        if (byte != 0) {
-            break;
-        }
-
+    for (uint8_t const byte : unencoded) {
+        if (byte != 0) break;
         ++leading_zeros;
     }
+    return leading_zeros;
+}
 
+size_t count_leading_ones(std::string_view encoded) {
+    size_t leading_zeros = 0;
+    for (char const c : encoded) {
+        if (c != base58_alphabet[0]) break;
+        ++leading_zeros;
+    }
     return leading_zeros;
 }
 
@@ -56,113 +58,109 @@ void pack_value(data_chunk& indexes, size_t carry) {
         *it = carry % 58;
         carry /= 58;
     }
-
     KTH_ASSERT(carry == 0);
 }
 
+} // namespace
+
 std::string encode_base58(byte_span unencoded) {
-    size_t leading_zeros = count_leading_zeros(unencoded);
+    size_t const leading_zeros = count_leading_zero_bytes(unencoded);
 
     // size = log(256) / log(58), rounded up.
     size_t const number_nonzero = unencoded.size() - leading_zeros;
     size_t const indexes_size = number_nonzero * 138 / 100 + 1;
 
-    // Allocate enough space in big-endian base58 representation.
     data_chunk indexes(indexes_size);
-
-    // Process the bytes.
     for (auto it = unencoded.begin() + leading_zeros; it != unencoded.end(); ++it) {
         pack_value(indexes, *it);
     }
 
-    // Skip leading zeroes in base58 result.
     auto first_nonzero = search_first_nonzero(indexes);
 
-    // Translate the result into a string.
     std::string encoded;
     size_t const estimated_size = leading_zeros + (indexes.end() - first_nonzero);
     encoded.reserve(estimated_size);
-    encoded.assign(leading_zeros, '1');
-
-    // Set actual main bytes.
+    encoded.assign(leading_zeros, base58_alphabet[0]);
     for (auto it = first_nonzero; it != indexes.end(); ++it) {
-        size_t const index = *it;
-        encoded += base58_chars[index];
+        encoded += base58_alphabet[*it];
     }
-
     return encoded;
 }
 
-size_t count_leading_zeros(std::string_view encoded) {
-    // Skip and count leading '1's.
-    size_t leading_zeros = 0;
-    for (uint8_t const digit: encoded) {
-        if (digit != base58_chars[0]) {
-            break;
+// Zero-allocation decode into a caller-supplied buffer.
+//
+// The base256 conversion is done in-place on the tail of `out` (used
+// as scratch), then the payload is compacted to sit right after the
+// leading-zero prefix. Caller must provide at least
+// `leading_zeros + (in.size() - leading_zeros) * 733/1000 + 1` bytes;
+// otherwise the decode surfaces `size_mismatch`.
+std::expected<size_t, base58_errc>
+decode_base58(std::string_view in, std::span<uint8_t> out) {
+    size_t const leading_zeros = count_leading_ones(in);
+    size_t const payload_capacity = (in.size() - leading_zeros) * 733 / 1000 + 1;
+
+    if (out.size() < leading_zeros + payload_capacity) {
+        return std::unexpected(base58_errc::size_mismatch);
     }
 
-        ++leading_zeros;
-    }
+    // Use the tail of `out` (skipping the reserved leading-zero slots)
+    // as the big-endian base256 scratch. Zero it first — subsequent
+    // multiply-add writes accumulate into it.
+    auto scratch = out.subspan(leading_zeros, payload_capacity);
+    std::fill(scratch.begin(), scratch.end(), 0);
 
-    return leading_zeros;
-}
-
-void unpack_char(data_chunk& data, size_t carry) {
-    for (auto it = data.rbegin(); it != data.rend(); it++) {
-        carry += 58 * (*it);
-        *it = carry % 256;
-        carry /= 256;
-    }
-
-    KTH_ASSERT(carry == 0);
-}
-
-bool decode_base58(data_chunk& out, std::string_view in) {
-    // Trim spaces and newlines around the string.
-    auto const leading_zeros = count_leading_zeros(in);
-
-    // log(58) / log(256), rounded up.
-    size_t const data_size = in.size() * 733 / 1000 + 1;
-
-    // Allocate enough space in big-endian base256 representation.
-    data_chunk data(data_size);
-
-    // Process the characters.
     for (auto it = in.begin() + leading_zeros; it != in.end(); ++it) {
-        auto const carry = base58_chars.find(*it);
-        if (carry == std::string::npos) {
-            return false;
+        auto const digit = base58_decode_table[static_cast<uint8_t>(*it)];
+        if (digit == 0xff) {
+            return std::unexpected(base58_errc::invalid_character);
         }
-
-        unpack_char(data, carry);
+        // In-place base256 multiply-add: scratch = scratch * 58 + digit.
+        size_t carry = digit;
+        for (auto sit = scratch.rbegin(); sit != scratch.rend(); ++sit) {
+            carry += 58 * (*sit);
+            *sit = carry % 256;
+            carry /= 256;
+        }
+        // The `payload_capacity = ceil(N * log(58)/log(256))` sizing
+        // above is a strict upper bound, so `carry == 0` at loop end
+        // holds for every valid input. Return an error instead of a
+        // Release-silent `KTH_ASSERT` so any future sizing regression
+        // surfaces as a decode failure, not a truncated result.
+        if (carry != 0) {
+            return std::unexpected(base58_errc::size_mismatch);
+        }
     }
 
-    // Skip leading zeroes in data.
-    auto first_nonzero = search_first_nonzero(data);
+    // First nonzero in scratch marks the start of the actual payload.
+    size_t skip = 0;
+    while (skip < scratch.size() && scratch[skip] == 0) {
+        ++skip;
+    }
+    size_t const payload_size = scratch.size() - skip;
 
-    // Copy result into output vector.
-    data_chunk decoded;
-    size_t const estimated_size = leading_zeros + (data.end() - first_nonzero);
-    decoded.reserve(estimated_size);
-    decoded.assign(leading_zeros, 0x00);
-    decoded.insert(decoded.end(), first_nonzero, data.cend());
+    if (skip > 0) {
+        std::memmove(out.data() + leading_zeros,
+                     out.data() + leading_zeros + skip,
+                     payload_size);
+    }
+    std::fill(out.begin(), out.begin() + leading_zeros, 0);
 
-    out = decoded;
-    return true;
+    return leading_zeros + payload_size;
 }
 
-// For support of template implementation only, do not call directly.
-bool decode_base58_private(uint8_t* out, size_t out_size, char const* in) {
-    data_chunk buffer;
-    if ( ! decode_base58(buffer, in) || buffer.size() != out_size) {
-        return false;
-    }
+// Allocating overload — sizes `out` for the worst case, delegates to
+// the span form, then trims. One heap allocation, no intermediate copy.
+std::expected<data_chunk, base58_errc> decode_base58(std::string_view in) {
+    size_t const leading_zeros = count_leading_ones(in);
+    size_t const payload_capacity = (in.size() - leading_zeros) * 733 / 1000 + 1;
 
-    for (size_t i = 0; i < out_size; ++i) {
-        out[i] = buffer[i];
+    data_chunk out(leading_zeros + payload_capacity);
+    auto const written = decode_base58(in, out);
+    if ( ! written) {
+        return std::unexpected(written.error());
     }
-
-    return true;
+    out.resize(*written);
+    return out;
 }
 
 } // namespace kth

--- a/src/infrastructure/src/formats/base_85.cpp
+++ b/src/infrastructure/src/formats/base_85.cpp
@@ -74,70 +74,84 @@ static uint8_t decoder[96] =
 };
 
 // Accepts only byte arrays bounded to 4 bytes.
-bool encode_base85(std::string& out, byte_span in)
+std::expected<std::string, base85_errc> encode_base85(byte_span in)
 {
     size_t const size = in.size();
     if (size % 4 != 0) {
-        return false;
-}
+        return std::unexpected(base85_errc::invalid_length);
+    }
 
     size_t const encoded_size = size * 5 / 4;
     std::string encoded;
-    encoded.reserve(encoded_size + 1);
+    encoded.reserve(encoded_size);
     size_t byte_index = 0;
     uint32_t accumulator = 0;
 
-    for (uint8_t const unencoded_byte: in) {
+    for (uint8_t const unencoded_byte : in) {
         accumulator = accumulator * 256 + unencoded_byte;
-        if (++byte_index % 4 == 0)
-        {
+        if (++byte_index % 4 == 0) {
             for (uint32_t divise = 85 * 85 * 85 * 85; divise > 0; divise /= 85) {
                 encoded.push_back(encoder[accumulator / divise % 85]);
-}
-
+            }
             accumulator = 0;
         }
     }
 
-    out.assign(encoded.begin(), encoded.end());
-    KTH_ASSERT(out.size() == encoded_size);
-    return true;
+    KTH_ASSERT(encoded.size() == encoded_size);
+    return encoded;
 }
 
 // Accepts only strings bounded to 5 characters.
-bool decode_base85(data_chunk& out, std::string_view in)
-{
+// Span-based primary — zero allocation.
+std::expected<size_t, base85_errc>
+decode_base85(std::string_view in, std::span<uint8_t> out) {
     size_t const length = in.size();
     if (length % 5 != 0) {
-        return false;
-}
+        return std::unexpected(base85_errc::invalid_length);
+    }
 
     size_t const decoded_size = length * 4 / 5;
-    data_chunk decoded;
-    decoded.reserve(decoded_size);
+    if (out.size() < decoded_size) {
+        return std::unexpected(base85_errc::invalid_length);
+    }
+
+    size_t write_index = 0;
     size_t char_index = 0;
     uint32_t accumulator = 0;
 
-    for (uint8_t const encoded_character: in) {
+    for (uint8_t const encoded_character : in) {
         auto const position = encoded_character - 32;
-        if (position < 0 || position > 96) {
-            return false;
-}
+        // `decoder` has 96 entries (indices 0..95). `position == 96`
+        // (input byte 128) previously slipped through and read OOB.
+        if (position < 0 || position >= 96) {
+            return std::unexpected(base85_errc::invalid_character);
+        }
 
         accumulator = accumulator * 85 + decoder[position];
-        if (++char_index % 5 == 0)
-        {
+        if (++char_index % 5 == 0) {
             for (uint32_t divise = 256 * 256 * 256; divise > 0; divise /= 256) {
-                decoded.push_back(accumulator / divise % 256);
-}
-
+                out[write_index++] = accumulator / divise % 256;
+            }
             accumulator = 0;
         }
     }
 
-    out.assign(decoded.begin(), decoded.end());
-    KTH_ASSERT(out.size() == decoded_size);
-    return true;
+    KTH_ASSERT(write_index == decoded_size);
+    return decoded_size;
+}
+
+// Allocating overload — delegates to the span form.
+std::expected<data_chunk, base85_errc> decode_base85(std::string_view in) {
+    size_t const length = in.size();
+    if (length % 5 != 0) {
+        return std::unexpected(base85_errc::invalid_length);
+    }
+    data_chunk out(length * 4 / 5);
+    auto const written = decode_base85(in, out);
+    if ( ! written) {
+        return std::unexpected(written.error());
+    }
+    return out;
 }
 
 } // namespace kth

--- a/src/infrastructure/test/formats/base_58.cpp
+++ b/src/infrastructure/test/formats/base_58.cpp
@@ -13,9 +13,9 @@ void encdec_test(std::string const& hex, std::string const& encoded) {
     auto const data = decode_base16(hex);
     REQUIRE(data);
     REQUIRE(encode_base58(*data) == encoded);
-    data_chunk decoded;
-    REQUIRE(decode_base58(decoded, encoded));
-    REQUIRE(decoded == *data);
+    auto const decoded = decode_base58(encoded);
+    REQUIRE(decoded);
+    REQUIRE(*decoded == *data);
 }
 
 TEST_CASE("infrastructure base58 encode and decode various test vectors", "[infrastructure][base58]") {
@@ -45,9 +45,9 @@ TEST_CASE("infrastructure base58 encode and decode bitcoin address", "[infrastru
     };
     std::string const address = "19TbMSWwHvnxAKy12iNm3KdbGfzfaMFViT";
     REQUIRE(encode_base58(pubkey) == address);
-    data_chunk decoded;
-    REQUIRE(decode_base58(decoded, address));
-    REQUIRE(decoded == pubkey);
+    auto const decoded = decode_base58(address);
+    REQUIRE(decoded);
+    REQUIRE(*decoded == pubkey);
 }
 
 TEST_CASE("infrastructure base58 character validation", "[infrastructure][base58]") {
@@ -72,8 +72,8 @@ TEST_CASE("infrastructure base58 character validation", "[infrastructure][base58
 }
 
 TEST_CASE("infrastructure base58 decode to fixed size array", "[infrastructure][base58]") {
-    byte_array<25> converted;
-    REQUIRE(decode_base58(converted, "19TbMSWwHvnxAKy12iNm3KdbGfzfaMFViT"));
+    auto const converted = decode_base58<25>("19TbMSWwHvnxAKy12iNm3KdbGfzfaMFViT");
+    REQUIRE(converted);
     const byte_array<25> expected
     {
         {
@@ -83,7 +83,7 @@ TEST_CASE("infrastructure base58 decode to fixed size array", "[infrastructure][
             0x64
         }
     };
-    REQUIRE(converted == expected);
+    REQUIRE(*converted == expected);
 }
 
 // End Test Suite

--- a/src/infrastructure/test/formats/base_85.cpp
+++ b/src/infrastructure/test/formats/base_85.cpp
@@ -23,55 +23,55 @@ using namespace kth;
 }
 
 TEST_CASE("encode base85 empty test", "[base 85 tests]") {
-    std::string encoded;
-    REQUIRE(encode_base85(encoded, data_chunk()));
-    REQUIRE(encoded.empty());
+    auto const result = encode_base85(data_chunk());
+    REQUIRE(result);
+    REQUIRE(result->empty());
 }
 
 TEST_CASE("decode base85 empty test", "[base 85 tests]") {
-    data_chunk result;
-    REQUIRE(decode_base85(result, ""));
-    REQUIRE(result.empty());
+    auto const result = decode_base85("");
+    REQUIRE(result);
+    REQUIRE(result->empty());
 }
 
 TEST_CASE("encode base85 valid test", "[base 85 tests]") {
-    std::string encoded;
     data_chunk decoded(BASE85_DECODED);
-    REQUIRE(encode_base85(encoded, decoded));
-    REQUIRE(encoded == BASE85_ENCODED);
+    auto const result = encode_base85(decoded);
+    REQUIRE(result);
+    REQUIRE(*result == BASE85_ENCODED);
 }
 
 TEST_CASE("encode base85 invalid test", "[base 85 tests]") {
-    std::string encoded;
     data_chunk decoded(BASE85_DECODED_INVALID);
-    REQUIRE( ! encode_base85(encoded, decoded));
-    REQUIRE(encoded.empty());
+    auto const result = encode_base85(decoded);
+    REQUIRE( ! result);
+    REQUIRE(result.error() == base85_errc::invalid_length);
 }
 
 TEST_CASE("decode base85 valid test", "[base 85 tests]") {
-    data_chunk result;
-    REQUIRE(decode_base85(result, BASE85_ENCODED));
-    REQUIRE(result == data_chunk(BASE85_DECODED));
+    auto const result = decode_base85(BASE85_ENCODED);
+    REQUIRE(result);
+    REQUIRE(*result == data_chunk(BASE85_DECODED));
 }
 
 TEST_CASE("decode base85 invalid char test", "[base 85 tests]") {
-    data_chunk result;
-    REQUIRE( ! decode_base85(result, BASE85_ENCODED_INVALID_CHAR));
-    REQUIRE(result.empty());
+    auto const result = decode_base85(BASE85_ENCODED_INVALID_CHAR);
+    REQUIRE( ! result);
+    REQUIRE(result.error() == base85_errc::invalid_character);
 }
 
 TEST_CASE("decode base85 invalid length test", "[base 85 tests]") {
-    data_chunk result;
-    REQUIRE( ! decode_base85(result, BASE85_ENCODED_INVALID_LENGTH));
-    REQUIRE(result.empty());
+    auto const result = decode_base85(BASE85_ENCODED_INVALID_LENGTH);
+    REQUIRE( ! result);
+    REQUIRE(result.error() == base85_errc::invalid_length);
 }
 
 // The semicolon is not in the Z85 alphabet, and such characters are treated as
 // valid but with zero value in the reference implementation.
 TEST_CASE("decode base85 outside alphabet test", "[base 85 tests]") {
-    data_chunk result;
-    REQUIRE(decode_base85(result, ";;;;;"));
-    REQUIRE(result == data_chunk({ 0, 0, 0, 0 }));
+    auto const result = decode_base85(";;;;;");
+    REQUIRE(result);
+    REQUIRE(*result == data_chunk({ 0, 0, 0, 0 }));
 }
 
 // End Test Suite

--- a/src/infrastructure/test/formats/base_encoding_benchmarks.cpp
+++ b/src/infrastructure/test/formats/base_encoding_benchmarks.cpp
@@ -140,21 +140,18 @@ void benchmark_base58() {
     // Decoding benchmarks
     Bench().title("Base58 Decoding").relative(true)
         .run("decode 25B (address)", [&] {
-            data_chunk result;
             ankerl::nanobench::doNotOptimizeAway(
-                decode_base58(result, small_encoded)
+                decode_base58(small_encoded)
             );
         })
         .run("decode 128B", [&] {
-            data_chunk result;
             ankerl::nanobench::doNotOptimizeAway(
-                decode_base58(result, medium_encoded)
+                decode_base58(medium_encoded)
             );
         })
         .run("decode 512B", [&] {
-            data_chunk result;
             ankerl::nanobench::doNotOptimizeAway(
-                decode_base58(result, large_encoded)
+                decode_base58(large_encoded)
             );
         });
 }
@@ -261,48 +258,41 @@ void benchmark_base85() {
     // Encoding benchmarks
     Bench().title("Base85 Encoding").relative(true)
         .run("encode 32B", [&] {
-            std::string result;
             ankerl::nanobench::doNotOptimizeAway(
-                encode_base85(result, byte_span(small_data.data(), small_data.size()))
+                encode_base85(byte_span(small_data.data(), small_data.size()))
             );
         })
         .run("encode 256B", [&] {
-            std::string result;
             ankerl::nanobench::doNotOptimizeAway(
-                encode_base85(result, byte_span(medium_data.data(), medium_data.size()))
+                encode_base85(byte_span(medium_data.data(), medium_data.size()))
             );
         })
         .run("encode 1KB", [&] {
-            std::string result;
             ankerl::nanobench::doNotOptimizeAway(
-                encode_base85(result, byte_span(large_data.data(), large_data.size()))
+                encode_base85(byte_span(large_data.data(), large_data.size()))
             );
         });
 
     // Prepare encoded versions
-    std::string small_encoded, medium_encoded, large_encoded;
-    encode_base85(small_encoded, byte_span(small_data.data(), small_data.size()));
-    encode_base85(medium_encoded, byte_span(medium_data.data(), medium_data.size()));
-    encode_base85(large_encoded, byte_span(large_data.data(), large_data.size()));
+    auto small_encoded  = encode_base85(byte_span(small_data.data(),  small_data.size())).value();
+    auto medium_encoded = encode_base85(byte_span(medium_data.data(), medium_data.size())).value();
+    auto large_encoded  = encode_base85(byte_span(large_data.data(),  large_data.size())).value();
 
     // Decoding benchmarks
     Bench().title("Base85 Decoding").relative(true)
         .run("decode 32B", [&] {
-            data_chunk result;
             ankerl::nanobench::doNotOptimizeAway(
-                decode_base85(result, small_encoded)
+                decode_base85(small_encoded)
             );
         })
         .run("decode 256B", [&] {
-            data_chunk result;
             ankerl::nanobench::doNotOptimizeAway(
-                decode_base85(result, medium_encoded)
+                decode_base85(medium_encoded)
             );
         })
         .run("decode 1KB", [&] {
-            data_chunk result;
             ankerl::nanobench::doNotOptimizeAway(
-                decode_base85(result, large_encoded)
+                decode_base85(large_encoded)
             );
         });
 }
@@ -326,16 +316,14 @@ void benchmark_cross_encoding() {
             ankerl::nanobench::doNotOptimizeAway(encode_base64(data));
         })
         .run("Base85", [&] {
-            std::string result;
-            ankerl::nanobench::doNotOptimizeAway(encode_base85(result, data));
+            ankerl::nanobench::doNotOptimizeAway(encode_base85(data));
         });
 
     // Prepare encoded versions
     auto enc16 = encode_base16(data);
     auto enc58 = encode_base58(data);
     auto enc64 = encode_base64(data);
-    std::string enc85;
-    encode_base85(enc85, data);
+    auto enc85 = encode_base85(data).value();
 
     // Compare decoding speeds
     Bench().title("Decoding Comparison (256B)").relative(true)
@@ -343,16 +331,14 @@ void benchmark_cross_encoding() {
             ankerl::nanobench::doNotOptimizeAway(decode_base16(enc16));
         })
         .run("Base58", [&] {
-            data_chunk result;
-            ankerl::nanobench::doNotOptimizeAway(decode_base58(result, enc58));
+            ankerl::nanobench::doNotOptimizeAway(decode_base58(enc58));
         })
         .run("Base64", [&] {
             data_chunk result;
             ankerl::nanobench::doNotOptimizeAway(decode_base64(result, enc64));
         })
         .run("Base85", [&] {
-            data_chunk result;
-            ankerl::nanobench::doNotOptimizeAway(decode_base85(result, enc85));
+            ankerl::nanobench::doNotOptimizeAway(decode_base85(enc85));
         });
 }
 


### PR DESCRIPTION
## Summary

- Align `decode_base58` and `decode_base85` with `decode_base16`: return `std::expected<data_chunk, ErrCode>` (or `std::expected<byte_array<Size>, ErrCode>` for the fixed-size overload) instead of a `bool` with an out-parameter, and mark them `[[nodiscard]]`.
- Introduce `base58_errc` (`invalid_character`, `size_mismatch`) and `base85_errc` (`invalid_length`, `invalid_character`) so callers can distinguish failure modes.
- Update every caller across `infrastructure` (config helpers, tests, benchmarks) and `domain` (all wallet `parse_from` factories).

### Bonus cleanup

The wallet `parse_from` bodies used a `std::string{sv}` bridge purely to satisfy the old signature. That bridge is dropped now that `decode_base58` accepts `std::string_view` directly. `payment_address::parse_from` keeps a temporary `std::string` only for the cashaddr helpers, which still take `std::string const&`.

`decode_base58_private` and `base58_literal` stay in place; the literal helper is still used by the encrypted-keys tests and can migrate later.

## Test plan

- [x] Local Release build clean
- [x] `kth_infrastructure_test`: 104451 assertions in 440 test cases pass
- [x] `kth_domain_test`: 1011106 assertions in 3872 test cases pass
- [x] `kth_capi_test`: 2822 assertions in 769 test cases pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved Base16, Base58, and Base85 encoding and decoding with clearer error reporting.
  - Added zero-allocation decoding options using caller-provided buffers.
  - Added support for direct result-based encoding and decoding.
  - Base58 and Base85 operations now report specific failures, including invalid characters, incorrect lengths, and insufficient output space.
  - Updated configuration parsing and formatting to use the improved encoding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->