### PR TITLE
refactor(test): use Catch2 StringMaker instead of ADL operator<<

### DIFF
--- a/src/domain/test/test_helpers.hpp
+++ b/src/domain/test/test_helpers.hpp
@@ -5,7 +5,7 @@
 #ifndef KTH_DOMAIN_TEST_HELPERS_HPP
 #define KTH_DOMAIN_TEST_HELPERS_HPP
 
-#include <ostream>
+#include <string>
 
 // Include infrastructure helpers (domain depends on infrastructure)
 #include "../../infrastructure/test/test_helpers.hpp"
@@ -15,50 +15,52 @@
 #include <kth/domain/message/version.hpp>
 #include <kth/infrastructure/message/network_address.hpp>
 
-// Pretty printing operators for domain-specific types. All print via
+// Pretty printing for domain-specific types via Catch2's StringMaker
+// customization point. All specializations print via
 // `kth::to_data_chunk(x, args...)` so they stay in sync with the
 // byte_writer-based serialization API.
-namespace kth::infrastructure::message {
+namespace Catch {
 
-inline
-std::ostream& operator<<(std::ostream& os, network_address const& x) {
-    os << encode_base16(kth::to_data_chunk(x, kth::domain::message::version::level::minimum, false));
-    return os;
-}
+template <>
+struct StringMaker<kth::infrastructure::message::network_address> {
+    static
+    std::string convert(kth::infrastructure::message::network_address const& x) {
+        return kth::encode_base16(kth::to_data_chunk(x, kth::domain::message::version::level::minimum, false));
+    }
+};
 
-} // namespace kth::infrastructure::message
+template <>
+struct StringMaker<kth::domain::chain::input> {
+    static
+    std::string convert(kth::domain::chain::input const& x) {
+        return kth::encode_base16(kth::to_data_chunk(x, true));
+    }
+};
 
-namespace kth::domain::chain {
+template <>
+struct StringMaker<kth::domain::chain::output> {
+    static
+    std::string convert(kth::domain::chain::output const& x) {
+        return kth::encode_base16(kth::to_data_chunk(x, true));
+    }
+};
 
-inline
-std::ostream& operator<<(std::ostream& os, input const& x) {
-    os << encode_base16(kth::to_data_chunk(x, true));
-    return os;
-}
+template <>
+struct StringMaker<kth::domain::chain::transaction> {
+    static
+    std::string convert(kth::domain::chain::transaction const& x) {
+        return kth::encode_base16(kth::to_data_chunk(x, true));
+    }
+};
 
-inline
-std::ostream& operator<<(std::ostream& os, output const& x) {
-    os << encode_base16(kth::to_data_chunk(x, true));
-    return os;
-}
+template <>
+struct StringMaker<kth::domain::message::prefilled_transaction> {
+    static
+    std::string convert(kth::domain::message::prefilled_transaction const& x) {
+        return kth::encode_base16(kth::to_data_chunk(x, kth::domain::message::version::level::minimum));
+    }
+};
 
-inline
-std::ostream& operator<<(std::ostream& os, transaction const& x) {
-    os << encode_base16(kth::to_data_chunk(x, true));
-    return os;
-}
-
-} // namespace kth::domain::chain
-
-namespace kth::domain::message {
-
-inline
-std::ostream& operator<<(std::ostream& os, prefilled_transaction const& x) {
-    os << encode_base16(kth::to_data_chunk(x, version::level::minimum));
-    return os;
-}
-
-} // namespace kth::domain::message
-
+} // namespace Catch
 
 #endif // KTH_DOMAIN_TEST_HELPERS_HPP

--- a/src/infrastructure/test/test_helpers.hpp
+++ b/src/infrastructure/test/test_helpers.hpp
@@ -5,10 +5,11 @@
 #ifndef KTH_INFRASTRUCTURE_TEST_HELPERS_HPP
 #define KTH_INFRASTRUCTURE_TEST_HELPERS_HPP
 
-#include <ostream>
+#include <string>
 #include <type_traits>
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_tostring.hpp>
 
 #include <kth/infrastructure/hash_define.hpp>
 #include <kth/infrastructure/formats/base_16.hpp>
@@ -19,15 +20,19 @@
 #define CHECK_MESSAGE(cond, msg) do { INFO(msg); CHECK(cond); } while((void)0, 0)
 #define REQUIRE_MESSAGE(cond, msg) do { INFO(msg); REQUIRE(cond); } while((void)0, 0)
 
-// Pretty printing for infrastructure types
-namespace kth {
+// Pretty printing for infrastructure types via Catch2's StringMaker
+// customization point (the idiomatic Catch2 form; avoids ADL-visible
+// operator<< overloads).
+namespace Catch {
 
-inline
-std::ostream& operator<<(std::ostream& os, hash_digest const& x) {
-    os << encode_hash(x);
-    return os;
-}
+template <>
+struct StringMaker<kth::hash_digest> {
+    static
+    std::string convert(kth::hash_digest const& x) {
+        return kth::encode_hash(x);
+    }
+};
 
-} // namespace kth
+} // namespace Catch
 
 #endif // KTH_INFRASTRUCTURE_TEST_HELPERS_HPP


### PR DESCRIPTION
## Summary

- Replace the ADL-visible `std::ostream& operator<<(std::ostream&, T const&)` overloads in the shared test helpers with `Catch::StringMaker<T>` specializations, the customization point Catch2 documents for pretty-printing test values. ADL-visible ostream operators for library types leak into unrelated overload sets across every TU that includes the helper; StringMaker is scoped to Catch2's own stringify machinery.
- Affected types: `kth::hash_digest` (infrastructure), `kth::infrastructure::message::network_address`, `kth::domain::chain::input`, `kth::domain::chain::output`, `kth::domain::chain::transaction`, and `kth::domain::message::prefilled_transaction` (domain).
- Bodies are unchanged (same `encode_hash` / `encode_base16` + `to_data_chunk` calls); each specialization returns `std::string` instead of writing to an `ostream`.
- `#include <ostream>` is dropped from both `test_helpers.hpp` files. An explicit `#include <catch2/catch_tostring.hpp>` (and `<string>`) is added so the `StringMaker` primary template is in scope regardless of Catch2 header layout changes.

## Notes

- Grepped the test tree for any use of these overloads via `<<` on a `stream`; none of the actual test files streamed one of these types directly, so no test call sites needed adjustment.
- The pretty-print path is exercised transparently by Catch2 whenever an assertion involving these types fails. Per the Catch2 docs, specializing `Catch::StringMaker<T>::convert` is the intended replacement for a `std::ostream&` overload, and Catch2 will invoke it when stringifying values in failure messages.

## Test plan

- [x] `cmake -S . -B build/Release -DCMAKE_BUILD_TYPE=Release -DENABLE_TEST=ON -DGLOBAL_BUILD=ON`
- [x] `cmake --build build/Release --target kth_infrastructure_test kth_domain_test -j 8`
- [x] `./build/Release/src/infrastructure/kth_infrastructure_test` -> all tests passed (104451 assertions in 440 test cases)
- [x] `./build/Release/src/domain/kth_domain_test` -> all tests passed (1011106 assertions in 3872 test cases)