### PR TITLE
refactor(domain): default equality for value-only message types

### DIFF
--- a/src/domain/include/kth/domain/message/address.hpp
+++ b/src/domain/include/kth/domain/message/address.hpp
@@ -27,8 +27,8 @@ struct KD_API address {
     address(infrastructure::message::network_address::list const& addresses);
     address(infrastructure::message::network_address::list&& addresses);
 
-    bool operator==(address const& x) const;
-    bool operator!=(address const& x) const;
+    [[nodiscard]]
+    friend bool operator==(address const&, address const&) = default;
 
     infrastructure::message::network_address::list& addresses();
 

--- a/src/domain/include/kth/domain/message/addrv2.hpp
+++ b/src/domain/include/kth/domain/message/addrv2.hpp
@@ -37,6 +37,9 @@ struct KD_API addrv2_entry {
     data_chunk addr;  // Variable length based on network type
     uint16_t port{0};
 
+    [[nodiscard]]
+    friend bool operator==(addrv2_entry const&, addrv2_entry const&) = default;
+
     /// Check if this entry is valid
     [[nodiscard]]
     bool is_valid() const;
@@ -65,8 +68,8 @@ struct KD_API addrv2 {
     addrv2(entry_list const& addresses);
     addrv2(entry_list&& addresses);
 
-    bool operator==(addrv2 const& x) const;
-    bool operator!=(addrv2 const& x) const;
+    [[nodiscard]]
+    friend bool operator==(addrv2 const&, addrv2 const&) = default;
 
     entry_list& addresses();
 

--- a/src/domain/include/kth/domain/message/alert.hpp
+++ b/src/domain/include/kth/domain/message/alert.hpp
@@ -25,8 +25,8 @@ struct KD_API alert {
     alert(data_chunk const& payload, data_chunk const& signature);
     alert(data_chunk&& payload, data_chunk&& signature);
 
-    bool operator==(alert const& x) const;
-    bool operator!=(alert const& x) const;
+    [[nodiscard]]
+    friend bool operator==(alert const&, alert const&) = default;
 
     data_chunk& payload();
 

--- a/src/domain/include/kth/domain/message/alert_payload.hpp
+++ b/src/domain/include/kth/domain/message/alert_payload.hpp
@@ -22,8 +22,8 @@ struct KD_API alert_payload {
     alert_payload(uint32_t version, uint64_t relay_until, uint64_t expiration, uint32_t id, uint32_t cancel, std::vector<uint32_t> const& set_cancel, uint32_t min_version, uint32_t max_version, std::vector<std::string> const& set_sub_version, uint32_t priority, std::string const& comment, std::string const& status_bar, std::string const& reserved);
     alert_payload(uint32_t version, uint64_t relay_until, uint64_t expiration, uint32_t id, uint32_t cancel, std::vector<uint32_t>&& set_cancel, uint32_t min_version, uint32_t max_version, std::vector<std::string>&& set_sub_version, uint32_t priority, std::string&& comment, std::string&& status_bar, std::string&& reserved);
 
-    bool operator==(alert_payload const& x) const;
-    bool operator!=(alert_payload const& x) const;
+    [[nodiscard]]
+    friend bool operator==(alert_payload const&, alert_payload const&) = default;
 
     [[nodiscard]]
     uint32_t version() const;

--- a/src/domain/include/kth/domain/message/block_transactions.hpp
+++ b/src/domain/include/kth/domain/message/block_transactions.hpp
@@ -31,8 +31,8 @@ struct KD_API block_transactions {
     // block_transactions& operator=(block_transactions&& x) = default;
     // block_transactions& operator=(block_transactions const&) = default;
 
-    bool operator==(block_transactions const& x) const;
-    bool operator!=(block_transactions const& x) const;
+    [[nodiscard]]
+    friend bool operator==(block_transactions const&, block_transactions const&) = default;
 
 
     hash_digest& block_hash();

--- a/src/domain/include/kth/domain/message/compact_block.hpp
+++ b/src/domain/include/kth/domain/message/compact_block.hpp
@@ -34,8 +34,8 @@ struct KD_API compact_block {
     compact_block(chain::header const& header, uint64_t nonce, short_id_list const& short_ids, prefilled_transaction::list const& transactions);
     compact_block(chain::header const& header, uint64_t nonce, short_id_list&& short_ids, prefilled_transaction::list&& transactions);
 
-    bool operator==(compact_block const& x) const;
-    bool operator!=(compact_block const& x) const;
+    [[nodiscard]]
+    friend bool operator==(compact_block const&, compact_block const&) = default;
 
     chain::header& header();
 

--- a/src/domain/include/kth/domain/message/double_spend_proof.hpp
+++ b/src/domain/include/kth/domain/message/double_spend_proof.hpp
@@ -56,22 +56,8 @@ struct KD_API double_spend_proof {
             push_data.clear();
         }
 
-        //TODO: use <=> operator
-        friend
-        bool operator==(spender const& x, spender const& y) {
-            return x.version == y.version &&
-                   x.out_sequence == y.out_sequence &&
-                   x.locktime == y.locktime &&
-                   x.prev_outs_hash == y.prev_outs_hash &&
-                   x.sequence_hash == y.sequence_hash &&
-                   x.outputs_hash == y.outputs_hash &&
-                   x.push_data == y.push_data;
-        }
-
-        friend
-        bool operator!=(spender const& x, spender const& y) {
-            return !(x == y);
-        }
+        [[nodiscard]]
+        friend bool operator==(spender const&, spender const&) = default;
 
         [[nodiscard]]
         size_t serialized_size() const {
@@ -102,17 +88,8 @@ struct KD_API double_spend_proof {
     double_spend_proof() = default;
     double_spend_proof(chain::output_point const& out_point, spender const& spender1, spender const& spender2);
 
-    friend
-    bool operator==(double_spend_proof const& x, double_spend_proof const& y) {
-        return x.out_point_ == y.out_point_ &&
-            x.spender1_ == y.spender1_ &&
-            x.spender2_ == y.spender2_;
-    }
-
-    friend
-    bool operator!=(double_spend_proof const& x, double_spend_proof const& y) {
-        return !(x == y);
-    }
+    [[nodiscard]]
+    friend bool operator==(double_spend_proof const&, double_spend_proof const&) = default;
 
     [[nodiscard]]
     chain::output_point const& out_point() const;

--- a/src/domain/include/kth/domain/message/filter_add.hpp
+++ b/src/domain/include/kth/domain/message/filter_add.hpp
@@ -26,8 +26,8 @@ struct KD_API filter_add {
     filter_add(data_chunk const& data);
     filter_add(data_chunk&& data);
 
-    bool operator==(filter_add const& x) const;
-    bool operator!=(filter_add const& x) const;
+    [[nodiscard]]
+    friend bool operator==(filter_add const&, filter_add const&) = default;
 
     data_chunk& data();
 

--- a/src/domain/include/kth/domain/message/filter_load.hpp
+++ b/src/domain/include/kth/domain/message/filter_load.hpp
@@ -26,8 +26,8 @@ struct KD_API filter_load {
     filter_load(data_chunk const& filter, uint32_t hash_functions, uint32_t tweak, uint8_t flags);
     filter_load(data_chunk&& filter, uint32_t hash_functions, uint32_t tweak, uint8_t flags);
 
-    bool operator==(filter_load const& x) const;
-    bool operator!=(filter_load const& x) const;
+    [[nodiscard]]
+    friend bool operator==(filter_load const&, filter_load const&) = default;
 
     data_chunk& filter();
 

--- a/src/domain/include/kth/domain/message/get_block_transactions.hpp
+++ b/src/domain/include/kth/domain/message/get_block_transactions.hpp
@@ -27,8 +27,8 @@ struct KD_API get_block_transactions {
     get_block_transactions(hash_digest const& block_hash, std::vector<uint64_t> const& indexes);
     get_block_transactions(hash_digest const& block_hash, std::vector<uint64_t>&& indexes);
 
-    bool operator==(get_block_transactions const& x) const;
-    bool operator!=(get_block_transactions const& x) const;
+    [[nodiscard]]
+    friend bool operator==(get_block_transactions const&, get_block_transactions const&) = default;
 
     hash_digest& block_hash();
 

--- a/src/domain/include/kth/domain/message/get_blocks.hpp
+++ b/src/domain/include/kth/domain/message/get_blocks.hpp
@@ -31,8 +31,8 @@ struct KD_API get_blocks {
     get_blocks(hash_list const& start, hash_digest const& stop);
     get_blocks(hash_list&& start, hash_digest const& stop);
 
-    bool operator==(get_blocks const& x) const;
-    bool operator!=(get_blocks const& x) const;
+    [[nodiscard]]
+    friend bool operator==(get_blocks const&, get_blocks const&) = default;
 
     hash_list& start_hashes();
 

--- a/src/domain/include/kth/domain/message/get_data.hpp
+++ b/src/domain/include/kth/domain/message/get_data.hpp
@@ -36,8 +36,8 @@ public:
         : inventory(std::move(inv))
     {}
 
-    bool operator==(get_data const& x) const;
-    bool operator!=(get_data const& x) const;
+    [[nodiscard]]
+    friend bool operator==(get_data const&, get_data const&) = default;
 
     static
     expect<get_data> from_data(byte_reader& reader, uint32_t version);

--- a/src/domain/include/kth/domain/message/get_headers.hpp
+++ b/src/domain/include/kth/domain/message/get_headers.hpp
@@ -25,8 +25,8 @@ public:
     get_headers(hash_list const& start, hash_digest const& stop);
     get_headers(hash_list&& start, hash_digest const& stop);
 
-    bool operator==(get_headers const& x) const;
-    bool operator!=(get_headers const& x) const;
+    [[nodiscard]]
+    friend bool operator==(get_headers const&, get_headers const&) = default;
 
     static
     expect<get_headers> from_data(byte_reader& reader, uint32_t version);

--- a/src/domain/include/kth/domain/message/headers.hpp
+++ b/src/domain/include/kth/domain/message/headers.hpp
@@ -32,8 +32,8 @@ struct KD_API headers {
     headers(header::list&& values);
     headers(std::initializer_list<header> const& values);
 
-    bool operator==(headers const& x) const;
-    bool operator!=(headers const& x) const;
+    [[nodiscard]]
+    friend bool operator==(headers const&, headers const&) = default;
 
     header::list& elements();
 

--- a/src/domain/include/kth/domain/message/heading.hpp
+++ b/src/domain/include/kth/domain/message/heading.hpp
@@ -72,8 +72,8 @@ struct KD_API heading {
     heading(uint32_t magic, std::string const& command, uint32_t payload_size, uint32_t checksum);
     heading(uint32_t magic, std::string&& command, uint32_t payload_size, uint32_t checksum);
 
-    bool operator==(heading const& x) const;
-    bool operator!=(heading const& x) const;
+    [[nodiscard]]
+    friend bool operator==(heading const&, heading const&) = default;
 
     [[nodiscard]]
     uint32_t magic() const;

--- a/src/domain/include/kth/domain/message/inventory.hpp
+++ b/src/domain/include/kth/domain/message/inventory.hpp
@@ -34,8 +34,8 @@ struct KD_API inventory {
     inventory(hash_list const& hashes, type_id type);
     inventory(std::initializer_list<inventory_vector> const& values);
 
-    bool operator==(inventory const& x) const;
-    bool operator!=(inventory const& x) const;
+    [[nodiscard]]
+    friend bool operator==(inventory const&, inventory const&) = default;
 
     inventory_vector::list& inventories();
 

--- a/src/domain/include/kth/domain/message/inventory_vector.hpp
+++ b/src/domain/include/kth/domain/message/inventory_vector.hpp
@@ -52,8 +52,8 @@ struct KD_API inventory_vector {
     inventory_vector& operator=(inventory_vector&& x) = default;
     inventory_vector& operator=(inventory_vector const& x) = default;
 
-    bool operator==(inventory_vector const& x) const;
-    bool operator!=(inventory_vector const& x) const;
+    [[nodiscard]]
+    friend bool operator==(inventory_vector const&, inventory_vector const&) = default;
 
 
     [[nodiscard]]

--- a/src/domain/include/kth/domain/message/not_found.hpp
+++ b/src/domain/include/kth/domain/message/not_found.hpp
@@ -37,8 +37,8 @@ public:
         : inventory(std::move(inv))
     {}
 
-    bool operator==(not_found const& x) const;
-    bool operator!=(not_found const& x) const;
+    [[nodiscard]]
+    friend bool operator==(not_found const&, not_found const&) = default;
 
     static
     expect<not_found> from_data(byte_reader& reader, uint32_t version);

--- a/src/domain/include/kth/domain/message/prefilled_transaction.hpp
+++ b/src/domain/include/kth/domain/message/prefilled_transaction.hpp
@@ -30,8 +30,8 @@ struct KD_API prefilled_transaction {
     prefilled_transaction& operator=(prefilled_transaction&& x) = default;
     prefilled_transaction& operator=(prefilled_transaction const& x) = default;
 
-    bool operator==(prefilled_transaction const& x) const;
-    bool operator!=(prefilled_transaction const& x) const;
+    [[nodiscard]]
+    friend bool operator==(prefilled_transaction const&, prefilled_transaction const&) = default;
 
 
     [[nodiscard]]

--- a/src/domain/include/kth/domain/message/reject.hpp
+++ b/src/domain/include/kth/domain/message/reject.hpp
@@ -60,8 +60,8 @@ struct KD_API reject {
     reject(reason_code code, std::string const& message, std::string const& reason, hash_digest const& data);
     reject(reason_code code, std::string&& message, std::string&& reason, hash_digest const& data);
 
-    bool operator==(reject const& x) const;
-    bool operator!=(reject const& x) const;
+    [[nodiscard]]
+    friend bool operator==(reject const&, reject const&) = default;
 
 
     [[nodiscard]]

--- a/src/domain/include/kth/domain/message/send_compact.hpp
+++ b/src/domain/include/kth/domain/message/send_compact.hpp
@@ -27,8 +27,8 @@ struct KD_API send_compact {
     send_compact() = default;
     send_compact(bool high_bandwidth_mode, uint64_t version);
 
-    bool operator==(send_compact const& x) const;
-    bool operator!=(send_compact const& x) const;
+    [[nodiscard]]
+    friend bool operator==(send_compact const&, send_compact const&) = default;
 
 
     [[nodiscard]]

--- a/src/domain/include/kth/domain/message/version.hpp
+++ b/src/domain/include/kth/domain/message/version.hpp
@@ -158,8 +158,8 @@ struct KD_API version {
     version(uint32_t value, uint64_t services, uint64_t timestamp, network_address const& address_receiver, network_address const& address_sender, uint64_t nonce, std::string const& user_agent, uint32_t start_height, bool relay);
     version(uint32_t value, uint64_t services, uint64_t timestamp, network_address const& address_receiver, network_address const& address_sender, uint64_t nonce, std::string&& user_agent, uint32_t start_height, bool relay);
 
-    bool operator==(version const& x) const;
-    bool operator!=(version const& x) const;
+    [[nodiscard]]
+    friend bool operator==(version const&, version const&) = default;
 
     [[nodiscard]]
     uint32_t value() const;

--- a/src/domain/include/kth/domain/message/xversion.hpp
+++ b/src/domain/include/kth/domain/message/xversion.hpp
@@ -29,8 +29,8 @@ struct KD_API xversion {
 
     xversion() = default;
 
-    bool operator==(xversion const& x) const;
-    bool operator!=(xversion const& x) const;
+    [[nodiscard]]
+    friend bool operator==(xversion const&, xversion const&) = default;
 
     static
     expect<xversion> from_data(byte_reader& reader, uint32_t version);

--- a/src/domain/src/message/address.cpp
+++ b/src/domain/src/message/address.cpp
@@ -22,15 +22,6 @@ address::address(infrastructure::message::network_address::list&& addresses)
     : addresses_(std::move(addresses))
 {}
 
-bool address::operator==(address const& x) const {
-    return (addresses_ == x.addresses_);
-}
-
-bool address::operator!=(address const& x) const {
-    return !(*this == x);
-}
-
-
 bool address::is_valid() const {
     return !addresses_.empty();
 }

--- a/src/domain/src/message/addrv2.cpp
+++ b/src/domain/src/message/addrv2.cpp
@@ -129,26 +129,6 @@ addrv2::addrv2(entry_list&& addresses)
     : addresses_(std::move(addresses))
 {}
 
-bool addrv2::operator==(addrv2 const& x) const {
-    if (addresses_.size() != x.addresses_.size()) {
-        return false;
-    }
-    for (size_t i = 0; i < addresses_.size(); ++i) {
-        if (addresses_[i].time != x.addresses_[i].time ||
-            addresses_[i].services != x.addresses_[i].services ||
-            addresses_[i].network != x.addresses_[i].network ||
-            addresses_[i].addr != x.addresses_[i].addr ||
-            addresses_[i].port != x.addresses_[i].port) {
-            return false;
-        }
-    }
-    return true;
-}
-
-bool addrv2::operator!=(addrv2 const& x) const {
-    return !(*this == x);
-}
-
 bool addrv2::is_valid() const {
     return !addresses_.empty();
 }

--- a/src/domain/src/message/alert.cpp
+++ b/src/domain/src/message/alert.cpp
@@ -23,14 +23,6 @@ alert::alert(data_chunk&& payload, data_chunk&& signature)
     : payload_(std::move(payload)), signature_(std::move(signature)) {
 }
 
-bool alert::operator==(alert const& x) const {
-    return (payload_ == x.payload_) && (signature_ == x.signature_);
-}
-
-bool alert::operator!=(alert const& x) const {
-    return !(*this == x);
-}
-
 bool alert::is_valid() const {
     return !payload_.empty() || !signature_.empty();
 }

--- a/src/domain/src/message/alert_payload.cpp
+++ b/src/domain/src/message/alert_payload.cpp
@@ -127,14 +127,6 @@ alert_payload::alert_payload(
 //     return *this;
 // }
 
-bool alert_payload::operator==(alert_payload const& x) const {
-    return (version_ == x.version_) && (relay_until_ == x.relay_until_) && (expiration_ == x.expiration_) && (id_ == x.id_) && (cancel_ == x.cancel_) && (set_cancel_ == x.set_cancel_) && (min_version_ == x.min_version_) && (max_version_ == x.max_version_) && (set_sub_version_ == x.set_sub_version_) && (priority_ == x.priority_) && (comment_ == x.comment_) && (status_bar_ == x.status_bar_) && (reserved_ == x.reserved_);
-}
-
-bool alert_payload::operator!=(alert_payload const& x) const {
-    return !(*this == x);
-}
-
 bool alert_payload::is_valid() const {
     return (version_ != 0) || (relay_until_ != 0) || (expiration_ != 0) || (id_ != 0) || (cancel_ != 0) || !set_cancel_.empty() || (min_version_ != 0) || (max_version_ != 0) || !set_sub_version_.empty() || (priority_ != 0) || !comment_.empty() || !status_bar_.empty() || !reserved_.empty();
 }

--- a/src/domain/src/message/block_transactions.cpp
+++ b/src/domain/src/message/block_transactions.cpp
@@ -29,14 +29,6 @@ block_transactions::block_transactions(hash_digest const& block_hash, chain::tra
     , transactions_(std::move(transactions))
 {}
 
-bool block_transactions::operator==(block_transactions const& x) const {
-    return (block_hash_ == x.block_hash_) && (transactions_ == x.transactions_);
-}
-
-bool block_transactions::operator!=(block_transactions const& x) const {
-    return !(*this == x);
-}
-
 bool block_transactions::is_valid() const {
     return (block_hash_ != null_hash);
 }

--- a/src/domain/src/message/compact_block.cpp
+++ b/src/domain/src/message/compact_block.cpp
@@ -57,14 +57,6 @@ compact_block::compact_block(chain::header const& header, uint64_t nonce, short_
 //     return *this;
 // }
 
-bool compact_block::operator==(compact_block const& x) const {
-    return (header_ == x.header_) && (nonce_ == x.nonce_) && (short_ids_ == x.short_ids_) && (transactions_ == x.transactions_);
-}
-
-bool compact_block::operator!=(compact_block const& x) const {
-    return !(*this == x);
-}
-
 bool compact_block::is_valid() const {
     //std::println("compact_block::is_valid");
 

--- a/src/domain/src/message/filter_add.cpp
+++ b/src/domain/src/message/filter_add.cpp
@@ -23,14 +23,6 @@ filter_add::filter_add(data_chunk&& data)
     : data_(std::move(data)) {
 }
 
-bool filter_add::operator==(filter_add const& x) const {
-    return (data_ == x.data_);
-}
-
-bool filter_add::operator!=(filter_add const& x) const {
-    return !(*this == x);
-}
-
 bool filter_add::is_valid() const {
     return !data_.empty();
 }

--- a/src/domain/src/message/filter_load.cpp
+++ b/src/domain/src/message/filter_load.cpp
@@ -22,14 +22,6 @@ filter_load::filter_load(data_chunk&& filter, uint32_t hash_functions, uint32_t 
     : filter_(std::move(filter)), hash_functions_(hash_functions), tweak_(tweak), flags_(flags) {
 }
 
-bool filter_load::operator==(filter_load const& x) const {
-    return (filter_ == x.filter_) && (hash_functions_ == x.hash_functions_) && (tweak_ == x.tweak_) && (flags_ == x.flags_);
-}
-
-bool filter_load::operator!=(filter_load const& x) const {
-    return !(*this == x);
-}
-
 bool filter_load::is_valid() const {
     return !filter_.empty() || (hash_functions_ != 0) || (tweak_ != 0) || (flags_ != 0x00);
 }

--- a/src/domain/src/message/get_block_transactions.cpp
+++ b/src/domain/src/message/get_block_transactions.cpp
@@ -30,15 +30,6 @@ get_block_transactions::get_block_transactions(hash_digest const& block_hash, st
     , indexes_(std::move(indexes))
 {}
 
-bool get_block_transactions::operator==(get_block_transactions const& x) const {
-    return (block_hash_ == x.block_hash_) && (indexes_ == x.indexes_);
-}
-
-bool get_block_transactions::operator!=(get_block_transactions const& x) const {
-    return !(*this == x);
-}
-
-
 bool get_block_transactions::is_valid() const {
     return (block_hash_ != null_hash);
 }

--- a/src/domain/src/message/get_blocks.cpp
+++ b/src/domain/src/message/get_blocks.cpp
@@ -25,21 +25,6 @@ get_blocks::get_blocks(hash_list&& start, hash_digest const& stop)
     : start_hashes_(std::move(start)), stop_hash_(stop) {
 }
 
-bool get_blocks::operator==(get_blocks const& x) const {
-    auto result = (start_hashes_.size() == x.start_hashes_.size()) &&
-                  (stop_hash_ == x.stop_hash_);
-
-    for (size_t i = 0; i < start_hashes_.size() && result; i++) {
-        result = (start_hashes_[i] == x.start_hashes_[i]);
-    }
-
-    return result;
-}
-
-bool get_blocks::operator!=(get_blocks const& x) const {
-    return !(*this == x);
-}
-
 bool get_blocks::is_valid() const {
     return !start_hashes_.empty() || (stop_hash_ != null_hash);
 }

--- a/src/domain/src/message/get_data.cpp
+++ b/src/domain/src/message/get_data.cpp
@@ -35,14 +35,6 @@ get_data::get_data(std::initializer_list<inventory_vector> const& values)
     : inventory(values) {
 }
 
-bool get_data::operator==(get_data const& x) const {
-    return (static_cast<inventory>(*this) == static_cast<inventory>(x));
-}
-
-bool get_data::operator!=(get_data const& x) const {
-    return (static_cast<inventory>(*this) != static_cast<inventory>(x));
-}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/src/message/get_headers.cpp
+++ b/src/domain/src/message/get_headers.cpp
@@ -22,14 +22,6 @@ get_headers::get_headers(hash_list&& start, hash_digest const& stop)
     : get_headers(start, stop)
 {}
 
-bool get_headers::operator==(get_headers const& x) const {
-    return (static_cast<get_blocks const&>(*this) == static_cast<get_blocks const&>(x));
-}
-
-bool get_headers::operator!=(get_headers const& x) const {
-    return !(*this == x);
-}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/src/message/headers.cpp
+++ b/src/domain/src/message/headers.cpp
@@ -34,14 +34,6 @@ headers::headers(std::initializer_list<header> const& values)
     : elements_(values) {
 }
 
-bool headers::operator==(headers const& x) const {
-    return elements_ == x.elements_;
-}
-
-bool headers::operator!=(headers const& x) const {
-    return !(*this == x);
-}
-
 bool headers::is_valid() const {
     return !elements_.empty();
 }

--- a/src/domain/src/message/heading.cpp
+++ b/src/domain/src/message/heading.cpp
@@ -55,14 +55,6 @@ heading::heading(uint32_t magic, std::string&& command, uint32_t payload_size, u
     : magic_(magic), command_(std::move(command)), payload_size_(payload_size), checksum_(checksum) {
 }
 
-bool heading::operator==(heading const& x) const {
-    return (magic_ == x.magic_) && (command_ == x.command_) && (payload_size_ == x.payload_size_) && (checksum_ == x.checksum_);
-}
-
-bool heading::operator!=(heading const& x) const {
-    return !(*this == x);
-}
-
 bool heading::is_valid() const {
     return (magic_ != 0) || (payload_size_ != 0) || (checksum_ != 0) || !command_.empty();
 }

--- a/src/domain/src/message/inventory.cpp
+++ b/src/domain/src/message/inventory.cpp
@@ -41,14 +41,6 @@ inventory::inventory(std::initializer_list<inventory_vector> const& values)
     : inventories_(values)
 {}
 
-bool inventory::operator==(inventory const& x) const {
-    return (inventories_ == x.inventories_);
-}
-
-bool inventory::operator!=(inventory const& x) const {
-    return !(*this == x);
-}
-
 bool inventory::is_valid() const {
     return !inventories_.empty();
 }

--- a/src/domain/src/message/inventory_vector.cpp
+++ b/src/domain/src/message/inventory_vector.cpp
@@ -44,14 +44,6 @@ inventory_vector::inventory_vector(type_id type, hash_digest const& hash)
     : type_(type), hash_(hash)
 {}
 
-bool inventory_vector::operator==(inventory_vector const& x) const {
-    return (hash_ == x.hash_) && (type_ == x.type_);
-}
-
-bool inventory_vector::operator!=(inventory_vector const& x) const {
-    return !(*this == x);
-}
-
 bool inventory_vector::is_valid() const {
     return (type_ != type_id::error) || (hash_ != null_hash);
 }

--- a/src/domain/src/message/not_found.cpp
+++ b/src/domain/src/message/not_found.cpp
@@ -32,14 +32,6 @@ not_found::not_found(std::initializer_list<inventory_vector> const& values)
     : inventory(values) {
 }
 
-bool not_found::operator==(not_found const& x) const {
-    return (static_cast<inventory>(*this) == static_cast<inventory>(x));
-}
-
-bool not_found::operator!=(not_found const& x) const {
-    return (static_cast<inventory>(*this) != static_cast<inventory>(x));
-}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/src/message/prefilled_transaction.cpp
+++ b/src/domain/src/message/prefilled_transaction.cpp
@@ -27,13 +27,6 @@ prefilled_transaction::prefilled_transaction(uint64_t index, chain::transaction&
     : index_(index), transaction_(std::move(tx)) {
 }
 
-bool prefilled_transaction::operator==(prefilled_transaction const& x) const {
-    return (index_ == x.index_) && (transaction_ == x.transaction_);
-}
-
-bool prefilled_transaction::operator!=(prefilled_transaction const& x) const {
-    return !(*this == x);
-}
 bool prefilled_transaction::is_valid() const {
     return (index_ < max_index) && transaction_.is_valid();
 }

--- a/src/domain/src/message/reject.cpp
+++ b/src/domain/src/message/reject.cpp
@@ -59,15 +59,6 @@ reject::reject(reason_code code, std::string&& message, std::string&& reason, ha
 //     return *this;
 // }
 
-bool reject::operator==(reject const& x) const {
-    return (code_ == x.code_) && (reason_ == x.reason_) && (message_ == x.message_) && (data_ == x.data_);
-}
-
-bool reject::operator!=(reject const& x) const {
-    return !(*this == x);
-}
-
-
 bool reject::is_valid() const {
     return !message_.empty() || (code_ != reason_code::undefined) || !reason_.empty() || (data_ != null_hash);
 }

--- a/src/domain/src/message/send_compact.cpp
+++ b/src/domain/src/message/send_compact.cpp
@@ -22,15 +22,6 @@ send_compact::send_compact(bool high_bandwidth_mode, uint64_t version)
       version_(version) {
 }
 
-bool send_compact::operator==(send_compact const& x) const {
-    return (high_bandwidth_mode_ == x.high_bandwidth_mode_) &&
-           (version_ == x.version_);
-}
-
-bool send_compact::operator!=(send_compact const& x) const {
-    return !(*this == x);
-}
-
 bool send_compact::is_valid() const {
     return (version_ != 0);
 }

--- a/src/domain/src/message/version.cpp
+++ b/src/domain/src/message/version.cpp
@@ -21,19 +21,6 @@ version::version(uint32_t value, uint64_t services, uint64_t timestamp, network_
     : value_(value), services_(services), timestamp_(timestamp), address_receiver_(address_receiver), address_sender_(address_sender), nonce_(nonce), user_agent_(std::move(user_agent)), start_height_(start_height), relay_(relay) {
 }
 
-bool version::operator==(version const& x) const {
-    return (value_ == x.value_) && (services_ == x.services_) &&
-           (timestamp_ == x.timestamp_) &&
-           (address_receiver_ == x.address_receiver_) &&
-           (address_sender_ == x.address_sender_) &&
-           (nonce_ == x.nonce_) && (user_agent_ == x.user_agent_) &&
-           (start_height_ == x.start_height_) && (relay_ == x.relay_);
-}
-
-bool version::operator!=(version const& x) const {
-    return !(*this == x);
-}
-
 bool version::is_valid() const {
     return value_ != 0
         || services_ != 0

--- a/src/domain/src/message/xversion.cpp
+++ b/src/domain/src/message/xversion.cpp
@@ -12,14 +12,6 @@ std::string const xversion::command = "xversion";
 uint32_t const message::xversion::version_minimum = version::level::minimum;
 uint32_t const message::xversion::version_maximum = version::level::maximum;
 
-bool xversion::operator==(xversion const& x) const {
-    return true;
-}
-
-bool xversion::operator!=(xversion const& x) const {
-    return !(*this == x);
-}
-
 bool xversion::is_valid() const {
     return true;
 }


### PR DESCRIPTION
## Summary

Replaces hand-written `bool operator==` / `bool operator!=` with the C++20
defaulted friend form on 25 domain::message and inner value types whose
equality is plain field-wise. `operator!=` declarations are removed —
C++20 rewrites `a != b` from `operator==` automatically.

**Style used everywhere:**
```cpp
[[nodiscard]]
friend bool operator==(T const&, T const&) = default;
```

**Types defaulted (25):** `address`, `filter_add`, `filter_load`,
`inventory_vector`, `inventory`, `get_block_transactions`, `get_blocks`,
`get_data`, `get_headers`, `not_found`, `block_transactions`,
`compact_block`, `headers`, `heading`, `version`, `xversion`, `reject`,
`alert`, `alert_payload`, `send_compact`, `prefilled_transaction`,
`addrv2_entry`, `addrv2`, `double_spend_proof`,
`double_spend_proof::spender`.

**Types deliberately left hand-written** (equality is not field-wise —
each excludes at least one member or performs normalization):

| Type | Reason |
|---|---|
| `chain::block` / `transaction` / `output` / `output_point` / `witness` | exclude `validation` / `valid_` (tracing metadata, not identity) |
| `machine::operation` | excludes `valid_` |
| `message::merkle_block` | excludes `total_transactions_` |
| `message::ping` / `pong` | exclude `valid_` / `nonceless_` |
| `message::fee_filter` | excludes `insufficient_version_` |
| `message::block` / `message::transaction` | cross-type overloads with `chain::block` / `chain::transaction`; defaulted `==` requires identical parameter types |
| `infrastructure::message::network_address` | excludes `timestamp_` |
| `infrastructure::config::authority` | compares normalized `ip()` (strips IPv6 scope-id) |
| `infrastructure::config::endpoint` | see authority — same class of address-identity concern |
| `infrastructure::utility::binary` | masks off unused bits past the bit-count |
| `infrastructure::machine::number` | mixed with `int64_t` overload / consensus-adjacent |
| `infrastructure::machine::big_number_gmp` / `big_number_boost` | polymorphic `compare()` |
| `blockchain::block_entry` | identity is `hash_` alone, not the whole record |

Net change: **45 files, +51 −274**.

## Test plan

- [x] `build/build/Release/src/infrastructure/kth_infrastructure_test`
      — 104451 assertions in 440 test cases pass
- [x] `build/build/Release/src/domain/kth_domain_test`
      — 1011106 assertions in 3872 test cases pass
- [x] `build/build/Release/src/c-api/kth_capi_test`
      — 2822 assertions in 769 test cases pass
- [x] Full Release build (`cmake --build build/build/Release -j 8`) clean,
      zero compile errors.