### PR TITLE
refactor(infrastructure): modernize decode_hash to std::expected

### DIFF
--- a/src/database/test/internal_database.cpp
+++ b/src/database/test/internal_database.cpp
@@ -221,8 +221,7 @@ void print_db_entries_count(KTH_DB_env* env_, KTH_DB_dbi& dbi ) {
 void check_reorg_output(KTH_DB_env* env_, KTH_DB_dbi& dbi_reorg_pool_, std::string txid_enc, uint32_t pos, std::string output_enc) {
     KTH_DB_txn* db_txn;
 
-    hash_digest txid;
-    REQUIRE(decode_hash(txid, txid_enc));
+    auto const txid = decode_hash(txid_enc).value();
     output_point point{txid, pos};
     auto keyarr = point.to_data(false);
     auto key = kth_db_make_value(keyarr.size(), keyarr.data());
@@ -244,8 +243,7 @@ void check_reorg_output(KTH_DB_env* env_, KTH_DB_dbi& dbi_reorg_pool_, std::stri
 void check_reorg_output_just_existence(KTH_DB_env* env_, KTH_DB_dbi& dbi_reorg_pool_, std::string txid_enc, uint32_t pos) {
     KTH_DB_txn* db_txn;
 
-    hash_digest txid;
-    REQUIRE(decode_hash(txid, txid_enc));
+    auto const txid = decode_hash(txid_enc).value();
     output_point point{txid, pos};
     auto keyarr = point.to_data(false);
     auto key = kth_db_make_value(keyarr.size(), keyarr.data());
@@ -259,8 +257,7 @@ void check_reorg_output_just_existence(KTH_DB_env* env_, KTH_DB_dbi& dbi_reorg_p
 void check_reorg_output_doesnt_exists(KTH_DB_env* env_, KTH_DB_dbi& dbi_reorg_pool_, std::string txid_enc, uint32_t pos) {
     KTH_DB_txn* db_txn;
 
-    hash_digest txid;
-    REQUIRE(decode_hash(txid, txid_enc));
+    auto const txid = decode_hash(txid_enc).value();
     output_point point{txid, pos};
     auto keyarr = point.to_data(false);
     auto key = kth_db_make_value(keyarr.size(), keyarr.data());
@@ -435,8 +432,7 @@ void check_reorg_index(KTH_DB_env* env_, KTH_DB_dbi& dbi_reorg_index_, std::stri
     REQUIRE(point_indexed_res);
     auto point_indexed = *point_indexed_res;
 
-    hash_digest txid;
-    REQUIRE(decode_hash(txid, txid_enc));
+    auto const txid = decode_hash(txid_enc).value();
     output_point point{txid, pos};
 
     REQUIRE(point == point_indexed);
@@ -660,9 +656,8 @@ TEST_CASE("internal database insert genesis", "[None]") {
 
     REQUIRE(db.get_block(0).header().hash() == genesis.hash());
 
-    hash_digest txid;
     std::string txid_enc = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b";
-    REQUIRE(decode_hash(txid, txid_enc));
+    auto const txid = decode_hash(txid_enc).value();
 
     auto entry = db.get_utxo(output_point{txid, 0});
     REQUIRE(entry.is_valid());
@@ -761,9 +756,8 @@ TEST_CASE("internal database insert block genesis and get transaction", "[None]"
 
 
 
-    hash_digest txid;
     auto txid_enc = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b";
-    REQUIRE(decode_hash(txid, txid_enc));
+    auto const txid = decode_hash(txid_enc).value();
 
     auto const tx2 = db.get_transaction(txid,max_size_t);
     REQUIRE(tx2.is_valid() == true);
@@ -846,9 +840,8 @@ TEST_CASE("internal database spend", "[None]") {
     REQUIRE(db.open());
     REQUIRE(db.push_block(orig, 0, 1) == result_code::success);
 
-    hash_digest txid;
     std::string txid_enc = "f5d8ee39a430901c91a5917b9f2dc19d6d1a0e9cea205b009ca73dd04470b9a6";
-    REQUIRE(decode_hash(txid, txid_enc));
+    auto txid = decode_hash(txid_enc).value();
     auto entry = db.get_utxo(output_point{txid, 0});
     REQUIRE(entry.is_valid());
 
@@ -872,7 +865,7 @@ TEST_CASE("internal database spend", "[None]") {
     REQUIRE( !  output.is_valid());
 
     txid_enc = "c06fbab289f723c6261d3030ddb6be121f7d2508d77862bb1e484f5cd7f92b25";
-    REQUIRE(decode_hash(txid, txid_enc));
+    txid = decode_hash(txid_enc).value();
     entry = db.get_utxo(output_point{txid, 0});
     REQUIRE(entry.is_valid());
     REQUIRE(entry.height() == 1);
@@ -885,7 +878,7 @@ TEST_CASE("internal database spend", "[None]") {
     REQUIRE(encode_base16(output.to_data(true)) == output_enc);
 
     txid_enc = "5a4ebf66822b0b2d56bd9dc64ece0bc38ee7844a23ff1d7320a88c5fdb2ad3e2";
-    REQUIRE(decode_hash(txid, txid_enc));
+    txid = decode_hash(txid_enc).value();
     entry = db.get_utxo(output_point{txid, 0});
     REQUIRE(entry.is_valid());
     REQUIRE(entry.height() == 1);
@@ -1455,12 +1448,9 @@ TEST_CASE("internal database reorg 0", "[None]") {
 
     using my_clock = dummy_clock<1284613427>;
 
-    hash_digest txid;
-    hash_digest txid2;
-    hash_digest txid3;
-    REQUIRE(decode_hash(txid, "f5d8ee39a430901c91a5917b9f2dc19d6d1a0e9cea205b009ca73dd04470b9a6"));
-    REQUIRE(decode_hash(txid2, "c06fbab289f723c6261d3030ddb6be121f7d2508d77862bb1e484f5cd7f92b25"));
-    REQUIRE(decode_hash(txid3, "5a4ebf66822b0b2d56bd9dc64ece0bc38ee7844a23ff1d7320a88c5fdb2ad3e2"));
+    auto const txid = decode_hash("f5d8ee39a430901c91a5917b9f2dc19d6d1a0e9cea205b009ca73dd04470b9a6").value();
+    auto const txid2 = decode_hash("c06fbab289f723c6261d3030ddb6be121f7d2508d77862bb1e484f5cd7f92b25").value();
+    auto const txid3 = decode_hash("5a4ebf66822b0b2d56bd9dc64ece0bc38ee7844a23ff1d7320a88c5fdb2ad3e2").value();
 
     KTH_DB_env* env_;
     KTH_DB_dbi dbi_utxo_;
@@ -1497,9 +1487,8 @@ TEST_CASE("internal database reorg 0", "[None]") {
 
         auto history_item = history_list[0];
 
-        hash_digest txid;
         std::string txid_enc = "f5d8ee39a430901c91a5917b9f2dc19d6d1a0e9cea205b009ca73dd04470b9a6";
-        REQUIRE(decode_hash(txid, txid_enc));
+        auto const txid = decode_hash(txid_enc).value();
 
         REQUIRE(history_item.kind == point_kind::output);
         REQUIRE(history_item.point.hash() == txid);
@@ -1587,9 +1576,8 @@ TEST_CASE("internal database reorg 0", "[None]") {
 
         auto history_item = history_list[0];
 
-        hash_digest txid;
         std::string txid_enc = "f5d8ee39a430901c91a5917b9f2dc19d6d1a0e9cea205b009ca73dd04470b9a6";
-        REQUIRE(decode_hash(txid, txid_enc));
+        auto txid = decode_hash(txid_enc).value();
 
         REQUIRE(history_item.kind == point_kind::output);
         REQUIRE(history_item.point.hash() == txid);
@@ -1599,9 +1587,8 @@ TEST_CASE("internal database reorg 0", "[None]") {
 
         history_item = history_list[1];
 
-        hash_digest txid2;
         std::string txid_enc2 = "5a4ebf66822b0b2d56bd9dc64ece0bc38ee7844a23ff1d7320a88c5fdb2ad3e2";
-        REQUIRE(decode_hash(txid2, txid_enc2));
+        auto const txid2 = decode_hash(txid_enc2).value();
 
         auto const& tx_entry = db.get_transaction(txid,max_uint32);
         REQUIRE(tx_entry.is_valid());
@@ -1623,7 +1610,7 @@ TEST_CASE("internal database reorg 0", "[None]") {
 
         history_item = history_list[0];
 
-        REQUIRE(decode_hash(txid, txid_enc));
+        txid = decode_hash(txid_enc).value();
 
         REQUIRE(history_item.kind == point_kind::output);
         REQUIRE(history_item.point.hash() == txid2);
@@ -1823,9 +1810,8 @@ TEST_CASE("internal database reorg 0", "[None]") {
 
         auto history_item = history_list[0];
 
-        hash_digest txid;
         std::string txid_enc = "f5d8ee39a430901c91a5917b9f2dc19d6d1a0e9cea205b009ca73dd04470b9a6";
-        REQUIRE(decode_hash(txid, txid_enc));
+        auto txid = decode_hash(txid_enc).value();
 
         REQUIRE(history_item.kind == point_kind::output);
         REQUIRE(history_item.point.hash() == txid);
@@ -1835,9 +1821,8 @@ TEST_CASE("internal database reorg 0", "[None]") {
 
         history_item = history_list[1];
 
-        hash_digest txid2;
         std::string txid_enc2 = "5a4ebf66822b0b2d56bd9dc64ece0bc38ee7844a23ff1d7320a88c5fdb2ad3e2";
-        REQUIRE(decode_hash(txid2, txid_enc2));
+        auto const txid2 = decode_hash(txid_enc2).value();
 
         auto const& tx_entry = db.get_transaction(txid, max_uint32);
         REQUIRE(tx_entry.is_valid());
@@ -1861,7 +1846,7 @@ TEST_CASE("internal database reorg 0", "[None]") {
 
         history_item = history_list[0];
 
-        REQUIRE(decode_hash(txid, txid_enc));
+        txid = decode_hash(txid_enc).value();
 
         REQUIRE(history_item.kind == point_kind::output);
         REQUIRE(history_item.point.hash() == txid2);
@@ -1935,12 +1920,9 @@ TEST_CASE("internal database reorg 1", "[None]") {
 
     using my_clock = dummy_clock<1284613427 + 600>;
 
-    hash_digest txid;
-    hash_digest txid2;
-    hash_digest txid3;
-    REQUIRE(decode_hash(txid, "f5d8ee39a430901c91a5917b9f2dc19d6d1a0e9cea205b009ca73dd04470b9a6"));
-    REQUIRE(decode_hash(txid2, "c06fbab289f723c6261d3030ddb6be121f7d2508d77862bb1e484f5cd7f92b25"));
-    REQUIRE(decode_hash(txid3, "5a4ebf66822b0b2d56bd9dc64ece0bc38ee7844a23ff1d7320a88c5fdb2ad3e2"));
+    auto const txid = decode_hash("f5d8ee39a430901c91a5917b9f2dc19d6d1a0e9cea205b009ca73dd04470b9a6").value();
+    auto const txid2 = decode_hash("c06fbab289f723c6261d3030ddb6be121f7d2508d77862bb1e484f5cd7f92b25").value();
+    auto const txid3 = decode_hash("5a4ebf66822b0b2d56bd9dc64ece0bc38ee7844a23ff1d7320a88c5fdb2ad3e2").value();
 
 
     KTH_DB_env* env_;
@@ -2154,8 +2136,7 @@ TEST_CASE("internal database prune", "[None]") {
     spender80000b.header().set_timestamp(spender80000b.header().timestamp() + 600 * 1);
     spender80000b.transactions()[0].set_version(2); //To change the coinbase tx hash
     {
-        hash_digest txid;
-        REQUIRE(decode_hash(txid, "0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098"));
+        auto const txid = decode_hash("0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098").value();
         spender80000b.transactions()[1].inputs()[0].previous_output().set_hash(txid);
     }
     // std::println("src/database/test/internal_database.cpp", encode_hash(spender80000b.transactions()[1].inputs()[0].previous_output().hash()));
@@ -2165,8 +2146,7 @@ TEST_CASE("internal database prune", "[None]") {
     spender80000c.header().set_timestamp(spender80000b.header().timestamp() + 600 * 2);
     spender80000c.transactions()[0].set_version(3);
     {
-        hash_digest txid;
-        REQUIRE(decode_hash(txid, "9b0fc92260312ce44e74ef369f5c66bbb85848f2eddd5a7a1cde251e54ccfdd5"));
+        auto const txid = decode_hash("9b0fc92260312ce44e74ef369f5c66bbb85848f2eddd5a7a1cde251e54ccfdd5").value();
         spender80000c.transactions()[1].inputs()[0].previous_output().set_hash(txid);
     }
     // std::println("src/database/test/internal_database.cpp", encode_hash(spender80000c.transactions()[1].inputs()[0].previous_output().hash()));
@@ -2176,8 +2156,7 @@ TEST_CASE("internal database prune", "[None]") {
     spender80000d.header().set_timestamp(spender80000b.header().timestamp() + 600 * 3);
     spender80000d.transactions()[0].set_version(4);
     {
-        hash_digest txid;
-        REQUIRE(decode_hash(txid, "999e1c837c76a1b7fbb7e57baf87b309960f5ffefbf2a9b95dd890602272f644"));
+        auto const txid = decode_hash("999e1c837c76a1b7fbb7e57baf87b309960f5ffefbf2a9b95dd890602272f644").value();
         spender80000d.transactions()[1].inputs()[0].previous_output().set_hash(txid);
     }
     // std::println("src/database/test/internal_database.cpp", encode_hash(spender80000d.transactions()[1].inputs()[0].previous_output().hash()));
@@ -2187,8 +2166,7 @@ TEST_CASE("internal database prune", "[None]") {
     spender80000e.header().set_timestamp(spender80000b.header().timestamp() + 600 * 4);
     spender80000e.transactions()[0].set_version(5);
     {
-        hash_digest txid;
-        REQUIRE(decode_hash(txid, "df2b060fa2e5e9c8ed5eaf6a45c13753ec8c63282b2688322eba40cd98ea067a"));
+        auto const txid = decode_hash("df2b060fa2e5e9c8ed5eaf6a45c13753ec8c63282b2688322eba40cd98ea067a").value();
         spender80000e.transactions()[1].inputs()[0].previous_output().set_hash(txid);
     }
     // std::println("src/database/test/internal_database.cpp", encode_hash(spender80000e.transactions()[1].inputs()[0].previous_output().hash()));
@@ -2849,14 +2827,13 @@ TEST_CASE("internal database prune 2", "[None]") {
         spender80000b.transactions()[1].inputs().push_back(spender80000b.transactions()[1].inputs()[0]);
         spender80000b.transactions()[1].inputs().push_back(spender80000b.transactions()[1].inputs()[0]);
 
-        hash_digest txid;
-        REQUIRE(decode_hash(txid, "0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098"));
+        auto txid = decode_hash("0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098").value();
         spender80000b.transactions()[1].inputs()[0].previous_output().set_hash(txid);
-        REQUIRE(decode_hash(txid, "9b0fc92260312ce44e74ef369f5c66bbb85848f2eddd5a7a1cde251e54ccfdd5"));
+        txid = decode_hash("9b0fc92260312ce44e74ef369f5c66bbb85848f2eddd5a7a1cde251e54ccfdd5").value();
         spender80000b.transactions()[1].inputs()[1].previous_output().set_hash(txid);
-        REQUIRE(decode_hash(txid, "999e1c837c76a1b7fbb7e57baf87b309960f5ffefbf2a9b95dd890602272f644"));
+        txid = decode_hash("999e1c837c76a1b7fbb7e57baf87b309960f5ffefbf2a9b95dd890602272f644").value();
         spender80000b.transactions()[1].inputs()[2].previous_output().set_hash(txid);
-        REQUIRE(decode_hash(txid, "df2b060fa2e5e9c8ed5eaf6a45c13753ec8c63282b2688322eba40cd98ea067a"));
+        txid = decode_hash("df2b060fa2e5e9c8ed5eaf6a45c13753ec8c63282b2688322eba40cd98ea067a").value();
         spender80000b.transactions()[1].inputs()[3].previous_output().set_hash(txid);
 
     }
@@ -3434,14 +3411,13 @@ TEST_CASE("internal database prune 3", "[None]") {
         spender80000b.transactions()[1].inputs().push_back(spender80000b.transactions()[1].inputs()[0]);
         spender80000b.transactions()[1].inputs().push_back(spender80000b.transactions()[1].inputs()[0]);
 
-        hash_digest txid;
-        REQUIRE(decode_hash(txid, "0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098"));
+        auto txid = decode_hash("0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098").value();
         spender80000b.transactions()[1].inputs()[0].previous_output().set_hash(txid);
-        REQUIRE(decode_hash(txid, "9b0fc92260312ce44e74ef369f5c66bbb85848f2eddd5a7a1cde251e54ccfdd5"));
+        txid = decode_hash("9b0fc92260312ce44e74ef369f5c66bbb85848f2eddd5a7a1cde251e54ccfdd5").value();
         spender80000b.transactions()[1].inputs()[1].previous_output().set_hash(txid);
-        REQUIRE(decode_hash(txid, "999e1c837c76a1b7fbb7e57baf87b309960f5ffefbf2a9b95dd890602272f644"));
+        txid = decode_hash("999e1c837c76a1b7fbb7e57baf87b309960f5ffefbf2a9b95dd890602272f644").value();
         spender80000b.transactions()[1].inputs()[2].previous_output().set_hash(txid);
-        REQUIRE(decode_hash(txid, "df2b060fa2e5e9c8ed5eaf6a45c13753ec8c63282b2688322eba40cd98ea067a"));
+        txid = decode_hash("df2b060fa2e5e9c8ed5eaf6a45c13753ec8c63282b2688322eba40cd98ea067a").value();
         spender80000b.transactions()[1].inputs()[3].previous_output().set_hash(txid);
 
     }
@@ -3785,10 +3761,9 @@ TEST_CASE("internal database prune empty reorg pool 3", "[None]") {
         spender80000b.header().set_timestamp(spender80000b.header().timestamp() + 600 * 1);
         spender80000b.transactions()[0].set_version(2); //To change the coinbase tx hash
         spender80000b.transactions()[1].inputs().push_back(spender80000b.transactions()[1].inputs()[0]);
-        hash_digest txid;
-        REQUIRE(decode_hash(txid, "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
+        auto txid = decode_hash("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b").value();
         spender80000b.transactions()[1].inputs()[0].previous_output().set_hash(txid);
-        REQUIRE(decode_hash(txid, "0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098"));
+        txid = decode_hash("0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098").value();
         spender80000b.transactions()[1].inputs()[1].previous_output().set_hash(txid);
 
         REQUIRE(db.push_block(spender80000b, 2, 1) == result_code::success);

--- a/src/domain/test/wallet/transaction_functions.cpp
+++ b/src/domain/test/wallet/transaction_functions.cpp
@@ -52,10 +52,10 @@ TEST_CASE("seed to wallet compressed test", "[transaction functions]") {
 TEST_CASE("create transaction test", "[transaction functions]") {
     // List of inputs (outputs_to_spend)
     std::vector<chain::input_point> outputs_to_spend;
-    kth::hash_digest hash_to_spend;
-    kth::decode_hash(hash_to_spend, "980de6ce12c29698d54323c6b0f358e1a9ae867598b840ee0094b9df22b07393");
+    auto const hash_to_spend = kth::decode_hash("980de6ce12c29698d54323c6b0f358e1a9ae867598b840ee0094b9df22b07393");
+    REQUIRE(hash_to_spend);
     uint32_t const index_to_spend = 1;
-    outputs_to_spend.push_back({hash_to_spend, index_to_spend});
+    outputs_to_spend.push_back({*hash_to_spend, index_to_spend});
 
     // List of outputs
     std::vector<std::pair<payment_address, uint64_t>> outputs;

--- a/src/infrastructure/include/kth/infrastructure/formats/base_16.hpp
+++ b/src/infrastructure/include/kth/infrastructure/formats/base_16.hpp
@@ -51,9 +51,10 @@ KI_API std::string encode_hash(hash_digest hash);
 /**
  * Convert a string into a bitcoin_hash.
  * The bitcoin_hash format is like base16, but with the bytes reversed.
- * @return false if the input is malformed.
+ * @return the decoded hash, or an error code if the input is malformed.
  */
-KI_API bool decode_hash(hash_digest& out, std::string_view in);
+[[nodiscard]]
+KI_API std::expected<hash_digest, base16_errc> decode_hash(std::string_view in);
 
 } // namespace kth
 

--- a/src/infrastructure/src/config/checkpoint.cpp
+++ b/src/infrastructure/src/config/checkpoint.cpp
@@ -29,9 +29,9 @@ std::expected<checkpoint, kth::code> checkpoint::parse_from(std::string_view val
         return std::unexpected(kth::error::illegal_value);
     }
 
-    hash_digest hash;
     auto const hash_sv = match.get<1>().to_view();
-    if ( ! decode_hash(hash, std::string{hash_sv})) {
+    auto hash = decode_hash(hash_sv);
+    if ( ! hash) {
         return std::unexpected(kth::error::illegal_value);
     }
 
@@ -45,17 +45,17 @@ std::expected<checkpoint, kth::code> checkpoint::parse_from(std::string_view val
         }
     }
 
-    return checkpoint{hash, height};
+    return checkpoint{*hash, height};
 }
 
 // static
 std::expected<checkpoint, kth::code> checkpoint::parse_from(std::string_view hash,
                                                             size_t height) {
-    hash_digest decoded;
-    if ( ! decode_hash(decoded, std::string{hash})) {
+    auto decoded = decode_hash(hash);
+    if ( ! decoded) {
         return std::unexpected(kth::error::illegal_value);
     }
-    return checkpoint{decoded, height};
+    return checkpoint{*decoded, height};
 }
 
 std::string checkpoint::to_string() const {

--- a/src/infrastructure/src/config/hash256.cpp
+++ b/src/infrastructure/src/config/hash256.cpp
@@ -16,11 +16,11 @@ namespace kth::infrastructure::config {
 
 // static
 std::expected<hash256, kth::code> hash256::parse_from(std::string_view hexcode) {
-    hash_digest decoded;
-    if ( ! decode_hash(decoded, hexcode)) {
+    auto decoded = decode_hash(hexcode);
+    if ( ! decoded) {
         return std::unexpected(kth::error::illegal_value);
     }
-    return hash256{decoded};
+    return hash256{*decoded};
 }
 
 std::string hash256::to_string() const {

--- a/src/infrastructure/src/formats/base_16.cpp
+++ b/src/infrastructure/src/formats/base_16.cpp
@@ -37,19 +37,19 @@ std::string encode_hash(hash_digest hash) {
     return encode_base16(hash);
 }
 
-bool decode_hash(hash_digest& out, std::string_view in) {
+std::expected<hash_digest, base16_errc> decode_hash(std::string_view in) {
     if (in.size() != 2 * hash_size) {
-        return false;
+        return std::unexpected(base16_errc::odd_length);
     }
 
     hash_digest result;
     if ( ! detail::decode_base16(result.data(), result.size(), in.data())) {
-        return false;
+        return std::unexpected(base16_errc::invalid_character);
     }
 
     // Reverse:
-    std::reverse_copy(result.begin(), result.end(), out.begin());
-    return true;
+    std::reverse(result.begin(), result.end());
+    return result;
 }
 
 } // namespace kth

--- a/src/infrastructure/test/config/checkpoint.cpp
+++ b/src/infrastructure/test/config/checkpoint.cpp
@@ -30,9 +30,9 @@ TEST_CASE("checkpoint::parse_from defaults height to zero when omitted", "[check
 }
 
 TEST_CASE("checkpoint constructor accepts a hash_digest and height", "[checkpoint]") {
-    hash_digest digest;
-    kth::decode_hash(digest, checkpoint_hash_a);
-    checkpoint const genesis{digest, 42};
+    auto const digest = kth::decode_hash(checkpoint_hash_a);
+    REQUIRE(digest);
+    checkpoint const genesis{*digest, 42};
     REQUIRE(genesis.height() == 42u);
     REQUIRE(encode_hash(genesis.hash()) == checkpoint_hash_a);
 }

--- a/src/infrastructure/test/formats/base_encoding_benchmarks.cpp
+++ b/src/infrastructure/test/formats/base_encoding_benchmarks.cpp
@@ -372,8 +372,7 @@ void benchmark_bitcoin_operations() {
 
     Bench().title("Bitcoin Hash Decode").relative(true)
         .run("decode_hash (TX ID)", [&] {
-            hash_digest result;
-            ankerl::nanobench::doNotOptimizeAway(decode_hash(result, encoded_hash));
+            ankerl::nanobench::doNotOptimizeAway(decode_hash(encoded_hash));
         });
 
     // Bitcoin address encoding (Base58Check)


### PR DESCRIPTION
## Summary

- Mirrors the shape of `decode_base16`: `decode_hash` now returns
  `std::expected<hash_digest, base16_errc>` instead of a `bool` with an
  out-parameter. Marks the new signature `[[nodiscard]]`.
- A bitcoin_hash is byte-reversed base16, so the existing `base16_errc`
  enum applies directly (`odd_length`, `invalid_character`) -- no
  separate `hash_errc`.
- In-place `reverse` on the locally-built `hash_digest` before returning
  by value, replacing the old `reverse_copy` into the caller's buffer.
- Updates every caller across `infrastructure` (config helpers for
  `checkpoint` and `hash256`, tests, benchmarks), `domain` (transaction
  functions test) and `database` (internal_database test). In the
  config helpers, drops the `std::string{sv}` bridges that only existed
  to satisfy the old signature -- the new decoder takes
  `std::string_view` directly.

## Test plan

- [x] `kth_infrastructure_test` passes locally (all 104452 assertions in 440 test cases)
- [x] `kth_domain_test` passes locally (all 1011106 assertions in 3872 test cases)
- [x] `kth_capi_test` passes locally (all 2822 assertions in 769 test cases)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hash decoding now returns clearer success/failure results, including specific error reasons for malformed input.
* **Bug Fixes**
  * Improved parsing of checkpoint and hash values so invalid hex strings are rejected earlier and more reliably.
  * Preserved existing byte order handling while making decoding behavior more consistent across inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->