### PR TITLE
refactor(wallet): stealth_address named ctors and no default params

### DIFF
--- a/src/c-api/include/kth/capi/wallet/stealth_address.h
+++ b/src/c-api/include/kth/capi/wallet/stealth_address.h
@@ -21,9 +21,9 @@ extern "C" {
 KTH_EXPORT KTH_OWNED
 kth_stealth_address_mut_t kth_wallet_stealth_address_construct_default(void);
 
-/** @return Owned `kth_stealth_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_stealth_address_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_stealth_address_mut_t kth_wallet_stealth_address_construct_from_decoded(uint8_t const* decoded, kth_size_t n);
+/** @param[out] out Must point to a null `kth_stealth_address_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_stealth_address_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_wallet_stealth_address_construct_from_data(uint8_t const* decoded, kth_size_t n, KTH_OUT_OWNED kth_stealth_address_mut_t* out);
 
 /**
  * @return Owned `kth_stealth_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_stealth_address_destruct`.

--- a/src/c-api/src/wallet/stealth_address.cpp
+++ b/src/c-api/src/wallet/stealth_address.cpp
@@ -26,10 +26,15 @@ kth_stealth_address_mut_t kth_wallet_stealth_address_construct_default(void) {
     return kth::leak<cpp_t>();
 }
 
-kth_stealth_address_mut_t kth_wallet_stealth_address_construct_from_decoded(uint8_t const* decoded, kth_size_t n) {
+kth_error_code_t kth_wallet_stealth_address_construct_from_data(uint8_t const* decoded, kth_size_t n, KTH_OUT_OWNED kth_stealth_address_mut_t* out) {
     KTH_PRECONDITION(decoded != nullptr || n == 0);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
     auto const decoded_cpp = n != 0 ? kth::data_chunk(decoded, decoded + n) : kth::data_chunk{};
-    return kth::leak_if_valid(cpp_t(decoded_cpp));
+    auto result = cpp_t::from_data(decoded_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
 }
 
 kth_stealth_address_mut_t kth_wallet_stealth_address_construct_from_binary_scan_key_spend_keys_signatures_version(kth_binary_const_t filter, kth_ec_compressed_t const* scan_key, kth_ec_compressed_list_const_t spend_keys, uint8_t signatures, uint8_t version) {

--- a/src/c-api/test/wallet/stealth_address.cpp
+++ b/src/c-api/test/wallet/stealth_address.cpp
@@ -98,7 +98,7 @@ TEST_CASE("C-API StealthAddress - scan-only variant preserves version",
 // Chunk round-trip (decoded bytes)
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API StealthAddress - to_chunk / construct_from_decoded round-trips",
+TEST_CASE("C-API StealthAddress - to_chunk / construct_from_data round-trips",
           "[C-API StealthAddress][encode]") {
     kth_stealth_address_mut_t orig = NULL;
     REQUIRE(kth_wallet_stealth_address_parse_from(kScanMainnet, &orig) == kth_ec_success);
@@ -110,7 +110,8 @@ TEST_CASE("C-API StealthAddress - to_chunk / construct_from_decoded round-trips"
     REQUIRE(chunk != NULL);
     REQUIRE(size > 0);
 
-    kth_stealth_address_mut_t parsed = kth_wallet_stealth_address_construct_from_decoded(chunk, size);
+    kth_stealth_address_mut_t parsed = NULL;
+    REQUIRE(kth_wallet_stealth_address_construct_from_data(chunk, size, &parsed) == kth_ec_success);
     REQUIRE(parsed != NULL);
     REQUIRE(kth_wallet_stealth_address_valid(parsed) != 0);
     REQUIRE(kth_wallet_stealth_address_equals(orig, parsed) != 0);

--- a/src/domain/include/kth/domain/wallet/stealth_address.hpp
+++ b/src/domain/include/kth/domain/wallet/stealth_address.hpp
@@ -45,12 +45,19 @@ struct KD_API stealth_address {
     static
     expect<stealth_address> parse_from(std::string_view encoded);
 
+    /// Wrap an already-decoded stealth-address chunk.
+    /// Returns `error::illegal_value` if `decoded` does not parse.
+    [[nodiscard]]
+    static
+    expect<stealth_address> from_data(data_chunk const& decoded);
+
     stealth_address();
 
-    explicit
-    stealth_address(data_chunk const& decoded);
-
-    stealth_address(binary const& filter, ec_compressed const& scan_key, point_list const& spend_keys, uint8_t signatures = 0, uint8_t version = mainnet_p2kh);
+    stealth_address(binary const& filter,
+                    ec_compressed const& scan_key,
+                    point_list const& spend_keys,
+                    uint8_t signatures,
+                    uint8_t version);
 
     [[nodiscard]]
     friend bool operator==(stealth_address const&, stealth_address const&) = default;

--- a/src/domain/src/wallet/stealth_address.cpp
+++ b/src/domain/src/wallet/stealth_address.cpp
@@ -52,10 +52,6 @@ stealth_address::stealth_address()
     : scan_key_(null_compressed_point)
 {}
 
-stealth_address::stealth_address(data_chunk const& decoded)
-    : stealth_address(from_stealth(decoded))
-{}
-
 stealth_address::stealth_address(binary const& filter,
                                  ec_compressed const& scan_key,
                                  point_list const& spend_keys,
@@ -77,6 +73,11 @@ expect<stealth_address> stealth_address::parse_from(std::string_view encoded) {
     if ( ! decode_base58(decoded, std::string{encoded})) {
         return std::unexpected(kth::error::illegal_value);
     }
+    return from_data(decoded);
+}
+
+// static
+expect<stealth_address> stealth_address::from_data(data_chunk const& decoded) {
     stealth_address out = from_stealth(decoded);
     if ( ! out.valid()) {
         return std::unexpected(kth::error::illegal_value);

--- a/src/domain/src/wallet/stealth_receiver.cpp
+++ b/src/domain/src/wallet/stealth_receiver.cpp
@@ -23,7 +23,7 @@ stealth_receiver::stealth_receiver(ec_secret const& scan_private,
     ec_compressed scan_public;
     if (secret_to_public(scan_public, scan_private_) &&
         secret_to_public(spend_public_, spend_private_)) {
-        address_ = {filter, scan_public, {spend_public_}};
+        address_ = {filter, scan_public, {spend_public_}, uint8_t{0}, stealth_address::mainnet_p2kh};
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace the silent-fail `stealth_address(data_chunk const&)` ctor with `stealth_address::from_data(data_chunk const&)` returning `expect<stealth_address>` (`error::illegal_value` on parse failure).
- Drop the default-argument values (`signatures = 0`, `version = mainnet_p2kh`) from the multi-arg ctor per project policy on refactored APIs.
- `parse_from` now delegates to `from_data` after base58 decode; `stealth_receiver::address_` construction passes `signatures` and `version` explicitly.
- C-API: rename `kth_wallet_stealth_address_construct_from_decoded` to `kth_wallet_stealth_address_construct_from_data` with the standard `kth_error_code_t` + `KTH_OUT_OWNED` fallible signature, matching the `ec_public::from_data` pattern.

`stealth_address()` default ctor is preserved (still used by `bitcoin_uri::stealth().value_or(stealth_address{})` and exposed as `kth_wallet_stealth_address_construct_default`).

## Test plan

- [x] `kth_infrastructure_test` — all 440 test cases pass locally
- [x] `kth_domain_test` — all 3872 test cases pass locally (includes stealth_address / stealth_receiver / bitcoin_uri suites)
- [x] `kth_capi_test` — all 769 test cases pass locally (includes the updated `construct_from_data` round-trip test)
- [ ] CI green