### PR TITLE
refactor(wallet): drop unused default ctors on wallet types

### DIFF
--- a/src/c-api/include/kth/capi/chain/input.h
+++ b/src/c-api/include/kth/capi/chain/input.h
@@ -48,6 +48,9 @@ kth_input_mut_t kth_chain_input_copy(kth_input_const_t self);
 KTH_EXPORT
 kth_bool_t kth_chain_input_equals(kth_input_const_t self, kth_input_const_t other);
 
+KTH_EXPORT
+kth_bool_t kth_chain_input_not_equal(kth_input_const_t self, kth_input_const_t other);
+
 
 // Serialization
 
@@ -72,9 +75,9 @@ kth_script_const_t kth_chain_input_script(kth_input_const_t self);
 KTH_EXPORT
 uint32_t kth_chain_input_sequence(kth_input_const_t self);
 
-/** @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_payment_address_mut_t kth_chain_input_address(kth_input_const_t self);
+/** @param[out] out Must point to a null `kth_payment_address_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_payment_address_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_chain_input_address(kth_input_const_t self, KTH_OUT_OWNED kth_payment_address_mut_t* out);
 
 /** @return Owned `kth_payment_address_list_mut_t`. Caller must release with `kth_wallet_payment_address_list_destruct`. */
 KTH_EXPORT KTH_OWNED

--- a/src/c-api/include/kth/capi/chain/output.h
+++ b/src/c-api/include/kth/capi/chain/output.h
@@ -52,6 +52,9 @@ kth_output_mut_t kth_chain_output_copy(kth_output_const_t self);
 KTH_EXPORT
 kth_bool_t kth_chain_output_equals(kth_output_const_t self, kth_output_const_t other);
 
+KTH_EXPORT
+kth_bool_t kth_chain_output_not_equal(kth_output_const_t self, kth_output_const_t other);
+
 
 // Serialization
 
@@ -102,13 +105,13 @@ kth_bool_t kth_chain_output_is_dust(kth_output_const_t self, uint64_t minimum_ou
 
 // Operations
 
-/** @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_payment_address_mut_t kth_chain_output_address_simple(kth_output_const_t self, kth_bool_t testnet);
+/** @param[out] out Must point to a null `kth_payment_address_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_payment_address_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_chain_output_address_simple(kth_output_const_t self, kth_bool_t testnet, KTH_OUT_OWNED kth_payment_address_mut_t* out);
 
-/** @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_payment_address_mut_t kth_chain_output_address(kth_output_const_t self, uint8_t p2kh_version, uint8_t p2sh_version);
+/** @param[out] out Must point to a null `kth_payment_address_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_payment_address_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_chain_output_address(kth_output_const_t self, uint8_t p2kh_version, uint8_t p2sh_version, KTH_OUT_OWNED kth_payment_address_mut_t* out);
 
 /** @return Owned `kth_payment_address_list_mut_t`. Caller must release with `kth_wallet_payment_address_list_destruct`. */
 KTH_EXPORT KTH_OWNED

--- a/src/c-api/include/kth/capi/helpers.hpp
+++ b/src/c-api/include/kth/capi/helpers.hpp
@@ -8,6 +8,7 @@
 #include <array>
 #include <cstddef>
 #include <cstring>
+#include <expected>
 #include <memory>
 #include <optional>
 #include <concepts>
@@ -744,6 +745,23 @@ template <typename T>
 std::decay_t<T>* leak_if_valid(T&& x) {
     if ( ! check_valid(&x)) return nullptr;
     return new std::decay_t<T>(std::forward<T>(x));
+}
+
+// `expect<T>` overload: unwraps the expected before leaking so the
+// caller receives a `T*` (not a `std::expected<T, code>*` disguised
+// as `void*`, which the opaque-handle typedef would silently allow).
+// Selected over the generic template because it takes the concrete
+// `std::expected<T, E>` by value rather than a forwarding reference.
+template <typename T, typename E>
+T* leak_if_valid(std::expected<T, E>&& x) {
+    if ( ! x) return nullptr;
+    return new T(std::move(*x));
+}
+
+template <typename T, typename E>
+T* leak_if_valid(std::expected<T, E> const& x) {
+    if ( ! x) return nullptr;
+    return new T(*x);
 }
 
 

--- a/src/c-api/include/kth/capi/wallet/bitcoin_uri.h
+++ b/src/c-api/include/kth/capi/wallet/bitcoin_uri.h
@@ -21,6 +21,10 @@ extern "C" {
 KTH_EXPORT KTH_OWNED
 kth_bitcoin_uri_mut_t kth_wallet_bitcoin_uri_construct_default(void);
 
+/** @param[out] out Must point to a null `kth_bitcoin_uri_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_bitcoin_uri_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_wallet_bitcoin_uri_parse_from(char const* uri, kth_bool_t strict, KTH_OUT_OWNED kth_bitcoin_uri_mut_t* out);
+
 
 // Destructor
 
@@ -88,9 +92,9 @@ char* kth_wallet_bitcoin_uri_r(kth_bitcoin_uri_const_t self);
 KTH_EXPORT KTH_OWNED
 char* kth_wallet_bitcoin_uri_address(kth_bitcoin_uri_const_t self);
 
-/** @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_payment_address_mut_t kth_wallet_bitcoin_uri_payment(kth_bitcoin_uri_const_t self);
+/** @param[out] out Must point to a null `kth_payment_address_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_payment_address_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_wallet_bitcoin_uri_payment(kth_bitcoin_uri_const_t self, KTH_OUT_OWNED kth_payment_address_mut_t* out);
 
 /** @return Owned `kth_stealth_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_stealth_address_destruct`. */
 KTH_EXPORT KTH_OWNED
@@ -150,13 +154,6 @@ kth_bool_t kth_wallet_bitcoin_uri_set_parameter(kth_bitcoin_uri_mut_t self, char
 /** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
 KTH_EXPORT KTH_OWNED
 char* kth_wallet_bitcoin_uri_parameter(kth_bitcoin_uri_const_t self, char const* key);
-
-
-// Static utilities
-
-/** @param[out] out Must point to a null `kth_bitcoin_uri_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_bitcoin_uri_destruct`. Untouched on error. */
-KTH_EXPORT
-kth_error_code_t kth_wallet_bitcoin_uri_parse_from(char const* uri, kth_bool_t strict, KTH_OUT_OWNED kth_bitcoin_uri_mut_t* out);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/include/kth/capi/wallet/ec_private.h
+++ b/src/c-api/include/kth/capi/wallet/ec_private.h
@@ -17,10 +17,6 @@ extern "C" {
 
 // Constructors
 
-/** @return Owned `kth_ec_private_mut_t`. Caller must release with `kth_wallet_ec_private_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_ec_private_mut_t kth_wallet_ec_private_construct_default(void);
-
 /**
  * @return Owned `kth_ec_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_private_destruct`.
  * @param secret Borrowed input; must be non-null. Copied into the resulting object; ownership of `secret` stays with the caller.
@@ -34,6 +30,38 @@ kth_ec_private_mut_t kth_wallet_ec_private_construct(kth_hash_t const* secret, u
  */
 KTH_EXPORT KTH_OWNED
 kth_ec_private_mut_t kth_wallet_ec_private_construct_unsafe(uint8_t const* secret, uint16_t version, kth_bool_t compress);
+
+/** @param[out] out Must point to a null `kth_ec_private_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ec_private_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_wallet_ec_private_parse_from(char const* wif, uint8_t version, KTH_OUT_OWNED kth_ec_private_mut_t* out);
+
+/**
+ * @param wif Borrowed input; must be non-null. Read during the call; ownership of `wif` stays with the caller.
+ * @param[out] out Must point to a null `kth_ec_private_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ec_private_destruct`. Untouched on error.
+ */
+KTH_EXPORT
+kth_error_code_t kth_wallet_ec_private_from_compressed(kth_wif_compressed_t const* wif, uint8_t address_version, KTH_OUT_OWNED kth_ec_private_mut_t* out);
+
+/**
+ * @warning `wif` MUST point to a buffer of at least 38 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_wif_compressed_t`.
+ * @param[out] out Must point to a null `kth_ec_private_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ec_private_destruct`. Untouched on error.
+ */
+KTH_EXPORT
+kth_error_code_t kth_wallet_ec_private_from_compressed_unsafe(uint8_t const* wif, uint8_t address_version, KTH_OUT_OWNED kth_ec_private_mut_t* out);
+
+/**
+ * @param wif Borrowed input; must be non-null. Read during the call; ownership of `wif` stays with the caller.
+ * @param[out] out Must point to a null `kth_ec_private_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ec_private_destruct`. Untouched on error.
+ */
+KTH_EXPORT
+kth_error_code_t kth_wallet_ec_private_from_uncompressed(kth_wif_uncompressed_t const* wif, uint8_t address_version, KTH_OUT_OWNED kth_ec_private_mut_t* out);
+
+/**
+ * @warning `wif` MUST point to a buffer of at least 37 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_wif_uncompressed_t`.
+ * @param[out] out Must point to a null `kth_ec_private_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ec_private_destruct`. Untouched on error.
+ */
+KTH_EXPORT
+kth_error_code_t kth_wallet_ec_private_from_uncompressed_unsafe(uint8_t const* wif, uint8_t address_version, KTH_OUT_OWNED kth_ec_private_mut_t* out);
 
 
 // Destructor
@@ -94,13 +122,13 @@ uint8_t kth_wallet_ec_private_wif_version(kth_ec_private_const_t self);
 KTH_EXPORT
 kth_bool_t kth_wallet_ec_private_compressed(kth_ec_private_const_t self);
 
-/** @return Owned `kth_ec_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_public_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_ec_public_mut_t kth_wallet_ec_private_to_public(kth_ec_private_const_t self);
+/** @param[out] out Must point to a null `kth_ec_public_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ec_public_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_wallet_ec_private_to_public(kth_ec_private_const_t self, KTH_OUT_OWNED kth_ec_public_mut_t* out);
 
-/** @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_payment_address_mut_t kth_wallet_ec_private_to_payment_address(kth_ec_private_const_t self);
+/** @param[out] out Must point to a null `kth_payment_address_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_payment_address_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_wallet_ec_private_to_payment_address(kth_ec_private_const_t self, KTH_OUT_OWNED kth_payment_address_mut_t* out);
 
 KTH_EXPORT
 kth_hash_t kth_wallet_ec_private_value(kth_ec_private_const_t self);
@@ -120,38 +148,6 @@ uint8_t kth_wallet_ec_private_to_wif_prefix(uint16_t version);
 
 KTH_EXPORT
 uint16_t kth_wallet_ec_private_to_version(uint8_t address, uint8_t wif);
-
-/** @param[out] out Must point to a null `kth_ec_private_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ec_private_destruct`. Untouched on error. */
-KTH_EXPORT
-kth_error_code_t kth_wallet_ec_private_parse_from(char const* wif, uint8_t version, KTH_OUT_OWNED kth_ec_private_mut_t* out);
-
-/**
- * @param wif Borrowed input; must be non-null. Read during the call; ownership of `wif` stays with the caller.
- * @param[out] out Must point to a null `kth_ec_private_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ec_private_destruct`. Untouched on error.
- */
-KTH_EXPORT
-kth_error_code_t kth_wallet_ec_private_from_compressed(kth_wif_compressed_t const* wif, uint8_t address_version, KTH_OUT_OWNED kth_ec_private_mut_t* out);
-
-/**
- * @warning `wif` MUST point to a buffer of at least 38 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_wif_compressed_t`.
- * @param[out] out Must point to a null `kth_ec_private_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ec_private_destruct`. Untouched on error.
- */
-KTH_EXPORT
-kth_error_code_t kth_wallet_ec_private_from_compressed_unsafe(uint8_t const* wif, uint8_t address_version, KTH_OUT_OWNED kth_ec_private_mut_t* out);
-
-/**
- * @param wif Borrowed input; must be non-null. Read during the call; ownership of `wif` stays with the caller.
- * @param[out] out Must point to a null `kth_ec_private_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ec_private_destruct`. Untouched on error.
- */
-KTH_EXPORT
-kth_error_code_t kth_wallet_ec_private_from_uncompressed(kth_wif_uncompressed_t const* wif, uint8_t address_version, KTH_OUT_OWNED kth_ec_private_mut_t* out);
-
-/**
- * @warning `wif` MUST point to a buffer of at least 37 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_wif_uncompressed_t`.
- * @param[out] out Must point to a null `kth_ec_private_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ec_private_destruct`. Untouched on error.
- */
-KTH_EXPORT
-kth_error_code_t kth_wallet_ec_private_from_uncompressed_unsafe(uint8_t const* wif, uint8_t address_version, KTH_OUT_OWNED kth_ec_private_mut_t* out);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/include/kth/capi/wallet/ec_public.h
+++ b/src/c-api/include/kth/capi/wallet/ec_public.h
@@ -17,10 +17,6 @@ extern "C" {
 
 // Constructors
 
-/** @return Owned `kth_ec_public_mut_t`. Caller must release with `kth_wallet_ec_public_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_ec_public_mut_t kth_wallet_ec_public_construct_default(void);
-
 /** @param[out] out Must point to a null `kth_ec_public_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ec_public_destruct`. Untouched on error. */
 KTH_EXPORT
 kth_error_code_t kth_wallet_ec_public_construct_from_data(uint8_t const* decoded, kth_size_t n, KTH_OUT_OWNED kth_ec_public_mut_t* out);
@@ -38,6 +34,28 @@ kth_ec_public_mut_t kth_wallet_ec_public_construct(kth_ec_compressed_t const* co
  */
 KTH_EXPORT KTH_OWNED
 kth_ec_public_mut_t kth_wallet_ec_public_construct_unsafe(uint8_t const* compressed_point, kth_bool_t compress);
+
+/** @param[out] out Must point to a null `kth_ec_public_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ec_public_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_wallet_ec_public_parse_from(char const* base16, KTH_OUT_OWNED kth_ec_public_mut_t* out);
+
+/** @param[out] out Must point to a null `kth_ec_public_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ec_public_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_wallet_ec_public_from_private(kth_ec_private_const_t secret, KTH_OUT_OWNED kth_ec_public_mut_t* out);
+
+/**
+ * @param point Borrowed input; must be non-null. Read during the call; ownership of `point` stays with the caller.
+ * @param[out] out Must point to a null `kth_ec_public_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ec_public_destruct`. Untouched on error.
+ */
+KTH_EXPORT
+kth_error_code_t kth_wallet_ec_public_from_point(kth_ec_uncompressed_t const* point, kth_bool_t compress, KTH_OUT_OWNED kth_ec_public_mut_t* out);
+
+/**
+ * @warning `point` MUST point to a buffer of at least 65 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_ec_uncompressed_t`.
+ * @param[out] out Must point to a null `kth_ec_public_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ec_public_destruct`. Untouched on error.
+ */
+KTH_EXPORT
+kth_error_code_t kth_wallet_ec_public_from_point_unsafe(uint8_t const* point, kth_bool_t compress, KTH_OUT_OWNED kth_ec_public_mut_t* out);
 
 
 // Destructor
@@ -113,34 +131,9 @@ char* kth_wallet_ec_public_to_string(kth_ec_public_const_t self);
 
 // Operations
 
-/** @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_payment_address_mut_t kth_wallet_ec_public_to_payment_address(kth_ec_public_const_t self, uint8_t version);
-
-
-// Static utilities
-
-/** @param[out] out Must point to a null `kth_ec_public_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ec_public_destruct`. Untouched on error. */
+/** @param[out] out Must point to a null `kth_payment_address_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_payment_address_destruct`. Untouched on error. */
 KTH_EXPORT
-kth_error_code_t kth_wallet_ec_public_parse_from(char const* base16, KTH_OUT_OWNED kth_ec_public_mut_t* out);
-
-/** @param[out] out Must point to a null `kth_ec_public_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ec_public_destruct`. Untouched on error. */
-KTH_EXPORT
-kth_error_code_t kth_wallet_ec_public_from_private(kth_ec_private_const_t secret, KTH_OUT_OWNED kth_ec_public_mut_t* out);
-
-/**
- * @param point Borrowed input; must be non-null. Read during the call; ownership of `point` stays with the caller.
- * @param[out] out Must point to a null `kth_ec_public_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ec_public_destruct`. Untouched on error.
- */
-KTH_EXPORT
-kth_error_code_t kth_wallet_ec_public_from_point(kth_ec_uncompressed_t const* point, kth_bool_t compress, KTH_OUT_OWNED kth_ec_public_mut_t* out);
-
-/**
- * @warning `point` MUST point to a buffer of at least 65 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_ec_uncompressed_t`.
- * @param[out] out Must point to a null `kth_ec_public_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ec_public_destruct`. Untouched on error.
- */
-KTH_EXPORT
-kth_error_code_t kth_wallet_ec_public_from_point_unsafe(uint8_t const* point, kth_bool_t compress, KTH_OUT_OWNED kth_ec_public_mut_t* out);
+kth_error_code_t kth_wallet_ec_public_to_payment_address(kth_ec_public_const_t self, uint8_t version, KTH_OUT_OWNED kth_payment_address_mut_t* out);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/include/kth/capi/wallet/ek_private.h
+++ b/src/c-api/include/kth/capi/wallet/ek_private.h
@@ -17,10 +17,6 @@ extern "C" {
 
 // Constructors
 
-/** @return Owned `kth_ek_private_mut_t`. Caller must release with `kth_wallet_ek_private_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_ek_private_mut_t kth_wallet_ek_private_construct_default(void);
-
 /**
  * @return Owned `kth_ek_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ek_private_destruct`.
  * @param value Borrowed input; must be non-null. Copied into the resulting object; ownership of `value` stays with the caller.
@@ -34,6 +30,10 @@ kth_ek_private_mut_t kth_wallet_ek_private_construct(kth_encrypted_private_t con
  */
 KTH_EXPORT KTH_OWNED
 kth_ek_private_mut_t kth_wallet_ek_private_construct_unsafe(uint8_t const* value);
+
+/** @param[out] out Must point to a null `kth_ek_private_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ek_private_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_wallet_ek_private_parse_from(char const* encoded, KTH_OUT_OWNED kth_ek_private_mut_t* out);
 
 
 // Destructor
@@ -88,13 +88,6 @@ kth_encrypted_private_t kth_wallet_ek_private_value(kth_ek_private_const_t self)
 /** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
 KTH_EXPORT KTH_OWNED
 char* kth_wallet_ek_private_to_string(kth_ek_private_const_t self);
-
-
-// Static utilities
-
-/** @param[out] out Must point to a null `kth_ek_private_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ek_private_destruct`. Untouched on error. */
-KTH_EXPORT
-kth_error_code_t kth_wallet_ek_private_parse_from(char const* encoded, KTH_OUT_OWNED kth_ek_private_mut_t* out);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/include/kth/capi/wallet/ek_public.h
+++ b/src/c-api/include/kth/capi/wallet/ek_public.h
@@ -17,10 +17,6 @@ extern "C" {
 
 // Constructors
 
-/** @return Owned `kth_ek_public_mut_t`. Caller must release with `kth_wallet_ek_public_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_ek_public_mut_t kth_wallet_ek_public_construct_default(void);
-
 /**
  * @return Owned `kth_ek_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ek_public_destruct`.
  * @param value Borrowed input; must be non-null. Copied into the resulting object; ownership of `value` stays with the caller.
@@ -34,6 +30,10 @@ kth_ek_public_mut_t kth_wallet_ek_public_construct(kth_encrypted_public_t const*
  */
 KTH_EXPORT KTH_OWNED
 kth_ek_public_mut_t kth_wallet_ek_public_construct_unsafe(uint8_t const* value);
+
+/** @param[out] out Must point to a null `kth_ek_public_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ek_public_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_wallet_ek_public_parse_from(char const* encoded, KTH_OUT_OWNED kth_ek_public_mut_t* out);
 
 
 // Destructor
@@ -88,13 +88,6 @@ kth_encrypted_public_t kth_wallet_ek_public_value(kth_ek_public_const_t self);
 /** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
 KTH_EXPORT KTH_OWNED
 char* kth_wallet_ek_public_to_string(kth_ek_public_const_t self);
-
-
-// Static utilities
-
-/** @param[out] out Must point to a null `kth_ek_public_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ek_public_destruct`. Untouched on error. */
-KTH_EXPORT
-kth_error_code_t kth_wallet_ek_public_parse_from(char const* encoded, KTH_OUT_OWNED kth_ek_public_mut_t* out);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/include/kth/capi/wallet/ek_token.h
+++ b/src/c-api/include/kth/capi/wallet/ek_token.h
@@ -17,10 +17,6 @@ extern "C" {
 
 // Constructors
 
-/** @return Owned `kth_ek_token_mut_t`. Caller must release with `kth_wallet_ek_token_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_ek_token_mut_t kth_wallet_ek_token_construct_default(void);
-
 /**
  * @return Owned `kth_ek_token_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ek_token_destruct`.
  * @param value Borrowed input; must be non-null. Copied into the resulting object; ownership of `value` stays with the caller.
@@ -34,6 +30,10 @@ kth_ek_token_mut_t kth_wallet_ek_token_construct(kth_encrypted_token_t const* va
  */
 KTH_EXPORT KTH_OWNED
 kth_ek_token_mut_t kth_wallet_ek_token_construct_unsafe(uint8_t const* value);
+
+/** @param[out] out Must point to a null `kth_ek_token_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ek_token_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_wallet_ek_token_parse_from(char const* encoded, KTH_OUT_OWNED kth_ek_token_mut_t* out);
 
 
 // Destructor
@@ -88,13 +88,6 @@ kth_encrypted_token_t kth_wallet_ek_token_value(kth_ek_token_const_t self);
 /** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
 KTH_EXPORT KTH_OWNED
 char* kth_wallet_ek_token_to_string(kth_ek_token_const_t self);
-
-
-// Static utilities
-
-/** @param[out] out Must point to a null `kth_ek_token_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_ek_token_destruct`. Untouched on error. */
-KTH_EXPORT
-kth_error_code_t kth_wallet_ek_token_parse_from(char const* encoded, KTH_OUT_OWNED kth_ek_token_mut_t* out);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/include/kth/capi/wallet/hd_private.h
+++ b/src/c-api/include/kth/capi/wallet/hd_private.h
@@ -18,10 +18,6 @@ extern "C" {
 
 // Constructors
 
-/** @return Owned `kth_hd_private_mut_t`. Caller must release with `kth_wallet_hd_private_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_hd_private_mut_t kth_wallet_hd_private_construct_default(void);
-
 /** @return Owned `kth_hd_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_hd_private_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_hd_private_mut_t kth_wallet_hd_private_construct_from_seed_prefixes(uint8_t const* seed, kth_size_t n, uint64_t prefixes);
@@ -67,6 +63,18 @@ kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key_prefix(kth
  */
 KTH_EXPORT KTH_OWNED
 kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key_prefix_unsafe(uint8_t const* private_key, uint32_t prefix);
+
+/** @param[out] out Must point to a null `kth_hd_private_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_hd_private_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_wallet_hd_private_parse_from(char const* encoded, KTH_OUT_OWNED kth_hd_private_mut_t* out);
+
+/** @param[out] out Must point to a null `kth_hd_private_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_hd_private_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_wallet_hd_private_parse_from_with_public_prefix(char const* encoded, uint32_t public_prefix, KTH_OUT_OWNED kth_hd_private_mut_t* out);
+
+/** @param[out] out Must point to a null `kth_hd_private_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_hd_private_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_wallet_hd_private_parse_from_with_prefixes(char const* encoded, uint64_t prefixes, KTH_OUT_OWNED kth_hd_private_mut_t* out);
 
 
 // Destructor
@@ -151,18 +159,6 @@ kth_hd_public_mut_t kth_wallet_hd_private_derive_public(kth_hd_private_const_t s
 
 KTH_EXPORT
 uint32_t kth_wallet_hd_private_to_prefix(uint64_t prefixes);
-
-/** @param[out] out Must point to a null `kth_hd_private_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_hd_private_destruct`. Untouched on error. */
-KTH_EXPORT
-kth_error_code_t kth_wallet_hd_private_parse_from(char const* encoded, KTH_OUT_OWNED kth_hd_private_mut_t* out);
-
-/** @param[out] out Must point to a null `kth_hd_private_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_hd_private_destruct`. Untouched on error. */
-KTH_EXPORT
-kth_error_code_t kth_wallet_hd_private_parse_from_with_public_prefix(char const* encoded, uint32_t public_prefix, KTH_OUT_OWNED kth_hd_private_mut_t* out);
-
-/** @param[out] out Must point to a null `kth_hd_private_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_hd_private_destruct`. Untouched on error. */
-KTH_EXPORT
-kth_error_code_t kth_wallet_hd_private_parse_from_with_prefixes(char const* encoded, uint64_t prefixes, KTH_OUT_OWNED kth_hd_private_mut_t* out);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/include/kth/capi/wallet/payment_address.h
+++ b/src/c-api/include/kth/capi/wallet/payment_address.h
@@ -17,10 +17,6 @@ extern "C" {
 
 // Constructors
 
-/** @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_payment_address_mut_t kth_wallet_payment_address_construct_default(void);
-
 /**
  * @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`.
  * @param short_hash Borrowed input; must be non-null. Copied into the resulting object; ownership of `short_hash` stays with the caller.
@@ -49,12 +45,43 @@ kth_payment_address_mut_t kth_wallet_payment_address_construct_from_hash_version
 KTH_EXPORT KTH_OWNED
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_hash_version_unsafe(uint8_t const* hash, uint8_t version);
 
-
-// Static factories
-
 /** @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_payment_address_mut_t kth_wallet_payment_address_from_script(kth_script_const_t script, uint8_t version);
+
+/** @param[out] out Must point to a null `kth_payment_address_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_payment_address_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_wallet_payment_address_from_pay_public_key_hash_script(kth_script_const_t script, uint8_t version, KTH_OUT_OWNED kth_payment_address_mut_t* out);
+
+/** @param[out] out Must point to a null `kth_payment_address_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_payment_address_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_wallet_payment_address_parse_from_simple(char const* address, KTH_OUT_OWNED kth_payment_address_mut_t* out);
+
+/** @param[out] out Must point to a null `kth_payment_address_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_payment_address_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_wallet_payment_address_parse_from(char const* address, kth_network_t net, KTH_OUT_OWNED kth_payment_address_mut_t* out);
+
+/**
+ * @param decoded Borrowed input; must be non-null. Read during the call; ownership of `decoded` stays with the caller.
+ * @param[out] out Must point to a null `kth_payment_address_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_payment_address_destruct`. Untouched on error.
+ */
+KTH_EXPORT
+kth_error_code_t kth_wallet_payment_address_from_payment(kth_payment_t const* decoded, KTH_OUT_OWNED kth_payment_address_mut_t* out);
+
+/**
+ * @warning `decoded` MUST point to a buffer of at least 25 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_payment_t`.
+ * @param[out] out Must point to a null `kth_payment_address_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_payment_address_destruct`. Untouched on error.
+ */
+KTH_EXPORT
+kth_error_code_t kth_wallet_payment_address_from_payment_unsafe(uint8_t const* decoded, KTH_OUT_OWNED kth_payment_address_mut_t* out);
+
+/** @param[out] out Must point to a null `kth_payment_address_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_payment_address_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_wallet_payment_address_from_ec_private(kth_ec_private_const_t secret, KTH_OUT_OWNED kth_payment_address_mut_t* out);
+
+/** @param[out] out Must point to a null `kth_payment_address_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_payment_address_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_wallet_payment_address_from_ec_public(kth_ec_public_const_t point, uint8_t version, KTH_OUT_OWNED kth_payment_address_mut_t* out);
 
 
 // Destructor
@@ -138,10 +165,6 @@ char* kth_wallet_payment_address_encoded_cashaddr(kth_payment_address_const_t se
 
 // Static utilities
 
-/** @param[out] out Must point to a null `kth_payment_address_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_payment_address_destruct`. Untouched on error. */
-KTH_EXPORT
-kth_error_code_t kth_wallet_payment_address_from_pay_public_key_hash_script(kth_script_const_t script, uint8_t version, KTH_OUT_OWNED kth_payment_address_mut_t* out);
-
 /** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
 KTH_EXPORT KTH_OWNED
 char* kth_wallet_payment_address_cashaddr_prefix_for(kth_network_t net);
@@ -157,36 +180,6 @@ kth_payment_address_list_mut_t kth_wallet_payment_address_extract_input(kth_scri
 /** @return Owned `kth_payment_address_list_mut_t`. Caller must release with `kth_wallet_payment_address_list_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_payment_address_list_mut_t kth_wallet_payment_address_extract_output(kth_script_const_t script, uint8_t p2kh_version, uint8_t p2sh_version);
-
-/** @param[out] out Must point to a null `kth_payment_address_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_payment_address_destruct`. Untouched on error. */
-KTH_EXPORT
-kth_error_code_t kth_wallet_payment_address_parse_from_simple(char const* address, KTH_OUT_OWNED kth_payment_address_mut_t* out);
-
-/** @param[out] out Must point to a null `kth_payment_address_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_payment_address_destruct`. Untouched on error. */
-KTH_EXPORT
-kth_error_code_t kth_wallet_payment_address_parse_from(char const* address, kth_network_t net, KTH_OUT_OWNED kth_payment_address_mut_t* out);
-
-/**
- * @param decoded Borrowed input; must be non-null. Read during the call; ownership of `decoded` stays with the caller.
- * @param[out] out Must point to a null `kth_payment_address_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_payment_address_destruct`. Untouched on error.
- */
-KTH_EXPORT
-kth_error_code_t kth_wallet_payment_address_from_payment(kth_payment_t const* decoded, KTH_OUT_OWNED kth_payment_address_mut_t* out);
-
-/**
- * @warning `decoded` MUST point to a buffer of at least 25 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_payment_t`.
- * @param[out] out Must point to a null `kth_payment_address_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_payment_address_destruct`. Untouched on error.
- */
-KTH_EXPORT
-kth_error_code_t kth_wallet_payment_address_from_payment_unsafe(uint8_t const* decoded, KTH_OUT_OWNED kth_payment_address_mut_t* out);
-
-/** @param[out] out Must point to a null `kth_payment_address_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_payment_address_destruct`. Untouched on error. */
-KTH_EXPORT
-kth_error_code_t kth_wallet_payment_address_from_ec_private(kth_ec_private_const_t secret, KTH_OUT_OWNED kth_payment_address_mut_t* out);
-
-/** @param[out] out Must point to a null `kth_payment_address_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_payment_address_destruct`. Untouched on error. */
-KTH_EXPORT
-kth_error_code_t kth_wallet_payment_address_from_ec_public(kth_ec_public_const_t point, uint8_t version, KTH_OUT_OWNED kth_payment_address_mut_t* out);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/include/kth/capi/wallet/stealth_receiver.h
+++ b/src/c-api/include/kth/capi/wallet/stealth_receiver.h
@@ -63,13 +63,19 @@ kth_stealth_address_const_t kth_wallet_stealth_receiver_stealth_address(kth_stea
 
 // Operations
 
-/** @param ephemeral_public Borrowed input; must be non-null. Read during the call; ownership of `ephemeral_public` stays with the caller. */
+/**
+ * @param ephemeral_public Borrowed input; must be non-null. Read during the call; ownership of `ephemeral_public` stays with the caller.
+ * @param[out] out Must point to a null `kth_payment_address_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_payment_address_destruct`. Untouched on error.
+ */
 KTH_EXPORT
-kth_bool_t kth_wallet_stealth_receiver_derive_address(kth_stealth_receiver_const_t self, kth_payment_address_mut_t out_address, kth_ec_compressed_t const* ephemeral_public);
+kth_error_code_t kth_wallet_stealth_receiver_derive_address(kth_stealth_receiver_const_t self, kth_ec_compressed_t const* ephemeral_public, KTH_OUT_OWNED kth_payment_address_mut_t* out);
 
-/** @warning `ephemeral_public` MUST point to a buffer of at least 33 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_ec_compressed_t`. */
+/**
+ * @warning `ephemeral_public` MUST point to a buffer of at least 33 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_ec_compressed_t`.
+ * @param[out] out Must point to a null `kth_payment_address_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_payment_address_destruct`. Untouched on error.
+ */
 KTH_EXPORT
-kth_bool_t kth_wallet_stealth_receiver_derive_address_unsafe(kth_stealth_receiver_const_t self, kth_payment_address_mut_t out_address, uint8_t const* ephemeral_public);
+kth_error_code_t kth_wallet_stealth_receiver_derive_address_unsafe(kth_stealth_receiver_const_t self, uint8_t const* ephemeral_public, KTH_OUT_OWNED kth_payment_address_mut_t* out);
 
 /** @param ephemeral_public Borrowed input; must be non-null. Read during the call; ownership of `ephemeral_public` stays with the caller. */
 KTH_EXPORT

--- a/src/c-api/src/chain/input.cpp
+++ b/src/c-api/src/chain/input.cpp
@@ -66,6 +66,12 @@ kth_bool_t kth_chain_input_equals(kth_input_const_t self, kth_input_const_t othe
     return kth::eq<cpp_t>(self, other);
 }
 
+kth_bool_t kth_chain_input_not_equal(kth_input_const_t self, kth_input_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::ne<cpp_t>(self, other);
+}
+
 
 // Serialization
 
@@ -100,9 +106,14 @@ uint32_t kth_chain_input_sequence(kth_input_const_t self) {
     return kth::cpp_ref<cpp_t>(self).sequence();
 }
 
-kth_payment_address_mut_t kth_chain_input_address(kth_input_const_t self) {
+kth_error_code_t kth_chain_input_address(kth_input_const_t self, KTH_OUT_OWNED kth_payment_address_mut_t* out) {
     KTH_PRECONDITION(self != nullptr);
-    return kth::leak_if_valid(kth::cpp_ref<cpp_t>(self).address());
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto result = kth::cpp_ref<cpp_t>(self).address();
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
 }
 
 kth_payment_address_list_mut_t kth_chain_input_addresses(kth_input_const_t self) {

--- a/src/c-api/src/chain/output.cpp
+++ b/src/c-api/src/chain/output.cpp
@@ -69,6 +69,12 @@ kth_bool_t kth_chain_output_equals(kth_output_const_t self, kth_output_const_t o
     return kth::eq<cpp_t>(self, other);
 }
 
+kth_bool_t kth_chain_output_not_equal(kth_output_const_t self, kth_output_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::ne<cpp_t>(self, other);
+}
+
 
 // Serialization
 
@@ -141,15 +147,25 @@ kth_bool_t kth_chain_output_is_dust(kth_output_const_t self, uint64_t minimum_ou
 
 // Operations
 
-kth_payment_address_mut_t kth_chain_output_address_simple(kth_output_const_t self, kth_bool_t testnet) {
+kth_error_code_t kth_chain_output_address_simple(kth_output_const_t self, kth_bool_t testnet, KTH_OUT_OWNED kth_payment_address_mut_t* out) {
     KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
     auto const testnet_cpp = kth::int_to_bool(testnet);
-    return kth::leak_if_valid(kth::cpp_ref<cpp_t>(self).address(testnet_cpp));
+    auto result = kth::cpp_ref<cpp_t>(self).address(testnet_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
 }
 
-kth_payment_address_mut_t kth_chain_output_address(kth_output_const_t self, uint8_t p2kh_version, uint8_t p2sh_version) {
+kth_error_code_t kth_chain_output_address(kth_output_const_t self, uint8_t p2kh_version, uint8_t p2sh_version, KTH_OUT_OWNED kth_payment_address_mut_t* out) {
     KTH_PRECONDITION(self != nullptr);
-    return kth::leak_if_valid(kth::cpp_ref<cpp_t>(self).address(p2kh_version, p2sh_version));
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto result = kth::cpp_ref<cpp_t>(self).address(p2kh_version, p2sh_version);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
 }
 
 kth_payment_address_list_mut_t kth_chain_output_addresses(kth_output_const_t self, uint8_t p2kh_version, uint8_t p2sh_version) {

--- a/src/c-api/src/wallet/bitcoin_uri.cpp
+++ b/src/c-api/src/wallet/bitcoin_uri.cpp
@@ -26,6 +26,18 @@ kth_bitcoin_uri_mut_t kth_wallet_bitcoin_uri_construct_default(void) {
     return kth::leak<cpp_t>();
 }
 
+kth_error_code_t kth_wallet_bitcoin_uri_parse_from(char const* uri, kth_bool_t strict, KTH_OUT_OWNED kth_bitcoin_uri_mut_t* out) {
+    KTH_PRECONDITION(uri != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const uri_cpp = std::string_view(uri);
+    auto const strict_cpp = kth::int_to_bool(strict);
+    auto result = cpp_t::parse_from(uri_cpp, strict_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
 
 // Destructor
 
@@ -126,9 +138,14 @@ char* kth_wallet_bitcoin_uri_address(kth_bitcoin_uri_const_t self) {
     return kth::create_c_str(s);
 }
 
-kth_payment_address_mut_t kth_wallet_bitcoin_uri_payment(kth_bitcoin_uri_const_t self) {
+kth_error_code_t kth_wallet_bitcoin_uri_payment(kth_bitcoin_uri_const_t self, KTH_OUT_OWNED kth_payment_address_mut_t* out) {
     KTH_PRECONDITION(self != nullptr);
-    return kth::leak_if_valid(kth::cpp_ref<cpp_t>(self).payment());
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto result = kth::cpp_ref<cpp_t>(self).payment();
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
 }
 
 kth_stealth_address_mut_t kth_wallet_bitcoin_uri_stealth(kth_bitcoin_uri_const_t self) {
@@ -244,21 +261,6 @@ char* kth_wallet_bitcoin_uri_parameter(kth_bitcoin_uri_const_t self, char const*
     auto const key_cpp = std::string(key);
     auto const s = kth::cpp_ref<cpp_t>(self).parameter(key_cpp);
     return kth::create_c_str(s);
-}
-
-
-// Static utilities
-
-kth_error_code_t kth_wallet_bitcoin_uri_parse_from(char const* uri, kth_bool_t strict, KTH_OUT_OWNED kth_bitcoin_uri_mut_t* out) {
-    KTH_PRECONDITION(uri != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
-    auto const uri_cpp = std::string_view(uri);
-    auto const strict_cpp = kth::int_to_bool(strict);
-    auto result = cpp_t::parse_from(uri_cpp, strict_cpp);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
 }
 
 } // extern "C"

--- a/src/c-api/src/wallet/ec_private.cpp
+++ b/src/c-api/src/wallet/ec_private.cpp
@@ -22,10 +22,6 @@ extern "C" {
 
 // Constructors
 
-kth_ec_private_mut_t kth_wallet_ec_private_construct_default(void) {
-    return kth::leak<cpp_t>();
-}
-
 kth_ec_private_mut_t kth_wallet_ec_private_construct(kth_hash_t const* secret, uint16_t version, kth_bool_t compress) {
     KTH_PRECONDITION(secret != nullptr);
     auto secret_cpp = kth::hash_to_cpp(secret->hash);
@@ -40,6 +36,65 @@ kth_ec_private_mut_t kth_wallet_ec_private_construct_unsafe(uint8_t const* secre
     kth::secure_scrub secret_cpp_scrub{&secret_cpp, sizeof(secret_cpp)};
     auto const compress_cpp = kth::int_to_bool(compress);
     return kth::leak_if_valid(cpp_t(secret_cpp, version, compress_cpp));
+}
+
+kth_error_code_t kth_wallet_ec_private_parse_from(char const* wif, uint8_t version, KTH_OUT_OWNED kth_ec_private_mut_t* out) {
+    KTH_PRECONDITION(wif != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const wif_cpp = std::string_view(wif);
+    auto result = cpp_t::parse_from(wif_cpp, version);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_wallet_ec_private_from_compressed(kth_wif_compressed_t const* wif, uint8_t address_version, KTH_OUT_OWNED kth_ec_private_mut_t* out) {
+    KTH_PRECONDITION(wif != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto wif_cpp = kth::wif_compressed_to_cpp(wif->data);
+    kth::secure_scrub wif_cpp_scrub{&wif_cpp, sizeof(wif_cpp)};
+    auto result = cpp_t::from_compressed(wif_cpp, address_version);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_wallet_ec_private_from_compressed_unsafe(uint8_t const* wif, uint8_t address_version, KTH_OUT_OWNED kth_ec_private_mut_t* out) {
+    KTH_PRECONDITION(wif != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto wif_cpp = kth::wif_compressed_to_cpp(wif);
+    kth::secure_scrub wif_cpp_scrub{&wif_cpp, sizeof(wif_cpp)};
+    auto result = cpp_t::from_compressed(wif_cpp, address_version);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_wallet_ec_private_from_uncompressed(kth_wif_uncompressed_t const* wif, uint8_t address_version, KTH_OUT_OWNED kth_ec_private_mut_t* out) {
+    KTH_PRECONDITION(wif != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto wif_cpp = kth::wif_uncompressed_to_cpp(wif->data);
+    kth::secure_scrub wif_cpp_scrub{&wif_cpp, sizeof(wif_cpp)};
+    auto result = cpp_t::from_uncompressed(wif_cpp, address_version);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_wallet_ec_private_from_uncompressed_unsafe(uint8_t const* wif, uint8_t address_version, KTH_OUT_OWNED kth_ec_private_mut_t* out) {
+    KTH_PRECONDITION(wif != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto wif_cpp = kth::wif_uncompressed_to_cpp(wif);
+    kth::secure_scrub wif_cpp_scrub{&wif_cpp, sizeof(wif_cpp)};
+    auto result = cpp_t::from_uncompressed(wif_cpp, address_version);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
 }
 
 
@@ -132,14 +187,24 @@ kth_bool_t kth_wallet_ec_private_compressed(kth_ec_private_const_t self) {
     return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).compressed());
 }
 
-kth_ec_public_mut_t kth_wallet_ec_private_to_public(kth_ec_private_const_t self) {
+kth_error_code_t kth_wallet_ec_private_to_public(kth_ec_private_const_t self, KTH_OUT_OWNED kth_ec_public_mut_t* out) {
     KTH_PRECONDITION(self != nullptr);
-    return kth::leak_if_valid(kth::cpp_ref<cpp_t>(self).to_public());
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto result = kth::cpp_ref<cpp_t>(self).to_public();
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
 }
 
-kth_payment_address_mut_t kth_wallet_ec_private_to_payment_address(kth_ec_private_const_t self) {
+kth_error_code_t kth_wallet_ec_private_to_payment_address(kth_ec_private_const_t self, KTH_OUT_OWNED kth_payment_address_mut_t* out) {
     KTH_PRECONDITION(self != nullptr);
-    return kth::leak_if_valid(kth::cpp_ref<cpp_t>(self).to_payment_address());
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto result = kth::cpp_ref<cpp_t>(self).to_payment_address();
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
 }
 
 kth_hash_t kth_wallet_ec_private_value(kth_ec_private_const_t self) {
@@ -166,65 +231,6 @@ uint8_t kth_wallet_ec_private_to_wif_prefix(uint16_t version) {
 
 uint16_t kth_wallet_ec_private_to_version(uint8_t address, uint8_t wif) {
     return cpp_t::to_version(address, wif);
-}
-
-kth_error_code_t kth_wallet_ec_private_parse_from(char const* wif, uint8_t version, KTH_OUT_OWNED kth_ec_private_mut_t* out) {
-    KTH_PRECONDITION(wif != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
-    auto const wif_cpp = std::string_view(wif);
-    auto result = cpp_t::parse_from(wif_cpp, version);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
-}
-
-kth_error_code_t kth_wallet_ec_private_from_compressed(kth_wif_compressed_t const* wif, uint8_t address_version, KTH_OUT_OWNED kth_ec_private_mut_t* out) {
-    KTH_PRECONDITION(wif != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
-    auto wif_cpp = kth::wif_compressed_to_cpp(wif->data);
-    kth::secure_scrub wif_cpp_scrub{&wif_cpp, sizeof(wif_cpp)};
-    auto result = cpp_t::from_compressed(wif_cpp, address_version);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
-}
-
-kth_error_code_t kth_wallet_ec_private_from_compressed_unsafe(uint8_t const* wif, uint8_t address_version, KTH_OUT_OWNED kth_ec_private_mut_t* out) {
-    KTH_PRECONDITION(wif != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
-    auto wif_cpp = kth::wif_compressed_to_cpp(wif);
-    kth::secure_scrub wif_cpp_scrub{&wif_cpp, sizeof(wif_cpp)};
-    auto result = cpp_t::from_compressed(wif_cpp, address_version);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
-}
-
-kth_error_code_t kth_wallet_ec_private_from_uncompressed(kth_wif_uncompressed_t const* wif, uint8_t address_version, KTH_OUT_OWNED kth_ec_private_mut_t* out) {
-    KTH_PRECONDITION(wif != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
-    auto wif_cpp = kth::wif_uncompressed_to_cpp(wif->data);
-    kth::secure_scrub wif_cpp_scrub{&wif_cpp, sizeof(wif_cpp)};
-    auto result = cpp_t::from_uncompressed(wif_cpp, address_version);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
-}
-
-kth_error_code_t kth_wallet_ec_private_from_uncompressed_unsafe(uint8_t const* wif, uint8_t address_version, KTH_OUT_OWNED kth_ec_private_mut_t* out) {
-    KTH_PRECONDITION(wif != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
-    auto wif_cpp = kth::wif_uncompressed_to_cpp(wif);
-    kth::secure_scrub wif_cpp_scrub{&wif_cpp, sizeof(wif_cpp)};
-    auto result = cpp_t::from_uncompressed(wif_cpp, address_version);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
 }
 
 } // extern "C"

--- a/src/c-api/src/wallet/ec_public.cpp
+++ b/src/c-api/src/wallet/ec_public.cpp
@@ -24,10 +24,6 @@ extern "C" {
 
 // Constructors
 
-kth_ec_public_mut_t kth_wallet_ec_public_construct_default(void) {
-    return kth::leak<cpp_t>();
-}
-
 kth_error_code_t kth_wallet_ec_public_construct_from_data(uint8_t const* decoded, kth_size_t n, KTH_OUT_OWNED kth_ec_public_mut_t* out) {
     KTH_PRECONDITION(decoded != nullptr || n == 0);
     KTH_PRECONDITION(out != nullptr);
@@ -51,6 +47,52 @@ kth_ec_public_mut_t kth_wallet_ec_public_construct_unsafe(uint8_t const* compres
     auto const compressed_point_cpp = kth::ec_compressed_to_cpp(compressed_point);
     auto const compress_cpp = kth::int_to_bool(compress);
     return kth::leak_if_valid(cpp_t(compressed_point_cpp, compress_cpp));
+}
+
+kth_error_code_t kth_wallet_ec_public_parse_from(char const* base16, KTH_OUT_OWNED kth_ec_public_mut_t* out) {
+    KTH_PRECONDITION(base16 != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const base16_cpp = std::string_view(base16);
+    auto result = cpp_t::parse_from(base16_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_wallet_ec_public_from_private(kth_ec_private_const_t secret, KTH_OUT_OWNED kth_ec_public_mut_t* out) {
+    KTH_PRECONDITION(secret != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const& secret_cpp = kth::cpp_ref<kth::domain::wallet::ec_private>(secret);
+    auto result = cpp_t::from_private(secret_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_wallet_ec_public_from_point(kth_ec_uncompressed_t const* point, kth_bool_t compress, KTH_OUT_OWNED kth_ec_public_mut_t* out) {
+    KTH_PRECONDITION(point != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const point_cpp = kth::ec_uncompressed_to_cpp(point->data);
+    auto const compress_cpp = kth::int_to_bool(compress);
+    auto result = cpp_t::from_point(point_cpp, compress_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_wallet_ec_public_from_point_unsafe(uint8_t const* point, kth_bool_t compress, KTH_OUT_OWNED kth_ec_public_mut_t* out) {
+    KTH_PRECONDITION(point != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const point_cpp = kth::ec_uncompressed_to_cpp(point);
+    auto const compress_cpp = kth::int_to_bool(compress);
+    auto result = cpp_t::from_point(point_cpp, compress_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
 }
 
 
@@ -172,55 +214,11 @@ char* kth_wallet_ec_public_to_string(kth_ec_public_const_t self) {
 
 // Operations
 
-kth_payment_address_mut_t kth_wallet_ec_public_to_payment_address(kth_ec_public_const_t self, uint8_t version) {
+kth_error_code_t kth_wallet_ec_public_to_payment_address(kth_ec_public_const_t self, uint8_t version, KTH_OUT_OWNED kth_payment_address_mut_t* out) {
     KTH_PRECONDITION(self != nullptr);
-    return kth::leak_if_valid(kth::cpp_ref<cpp_t>(self).to_payment_address(version));
-}
-
-
-// Static utilities
-
-kth_error_code_t kth_wallet_ec_public_parse_from(char const* base16, KTH_OUT_OWNED kth_ec_public_mut_t* out) {
-    KTH_PRECONDITION(base16 != nullptr);
     KTH_PRECONDITION(out != nullptr);
     KTH_PRECONDITION(*out == nullptr);
-    auto const base16_cpp = std::string_view(base16);
-    auto result = cpp_t::parse_from(base16_cpp);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
-}
-
-kth_error_code_t kth_wallet_ec_public_from_private(kth_ec_private_const_t secret, KTH_OUT_OWNED kth_ec_public_mut_t* out) {
-    KTH_PRECONDITION(secret != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
-    auto const& secret_cpp = kth::cpp_ref<kth::domain::wallet::ec_private>(secret);
-    auto result = cpp_t::from_private(secret_cpp);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
-}
-
-kth_error_code_t kth_wallet_ec_public_from_point(kth_ec_uncompressed_t const* point, kth_bool_t compress, KTH_OUT_OWNED kth_ec_public_mut_t* out) {
-    KTH_PRECONDITION(point != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
-    auto const point_cpp = kth::ec_uncompressed_to_cpp(point->data);
-    auto const compress_cpp = kth::int_to_bool(compress);
-    auto result = cpp_t::from_point(point_cpp, compress_cpp);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
-}
-
-kth_error_code_t kth_wallet_ec_public_from_point_unsafe(uint8_t const* point, kth_bool_t compress, KTH_OUT_OWNED kth_ec_public_mut_t* out) {
-    KTH_PRECONDITION(point != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
-    auto const point_cpp = kth::ec_uncompressed_to_cpp(point);
-    auto const compress_cpp = kth::int_to_bool(compress);
-    auto result = cpp_t::from_point(point_cpp, compress_cpp);
+    auto result = kth::cpp_ref<cpp_t>(self).to_payment_address(version);
     if ( ! result) return kth::to_c_err(result.error());
     *out = kth::leak(std::move(*result));
     return kth_ec_success;

--- a/src/c-api/src/wallet/ek_private.cpp
+++ b/src/c-api/src/wallet/ek_private.cpp
@@ -22,10 +22,6 @@ extern "C" {
 
 // Constructors
 
-kth_ek_private_mut_t kth_wallet_ek_private_construct_default(void) {
-    return kth::leak<cpp_t>();
-}
-
 kth_ek_private_mut_t kth_wallet_ek_private_construct(kth_encrypted_private_t const* value) {
     KTH_PRECONDITION(value != nullptr);
     auto const value_cpp = kth::encrypted_private_to_cpp(value->data);
@@ -36,6 +32,17 @@ kth_ek_private_mut_t kth_wallet_ek_private_construct_unsafe(uint8_t const* value
     KTH_PRECONDITION(value != nullptr);
     auto const value_cpp = kth::encrypted_private_to_cpp(value);
     return kth::leak_if_valid(cpp_t(value_cpp));
+}
+
+kth_error_code_t kth_wallet_ek_private_parse_from(char const* encoded, KTH_OUT_OWNED kth_ek_private_mut_t* out) {
+    KTH_PRECONDITION(encoded != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const encoded_cpp = std::string_view(encoded);
+    auto result = cpp_t::parse_from(encoded_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
 }
 
 
@@ -117,20 +124,6 @@ char* kth_wallet_ek_private_to_string(kth_ek_private_const_t self) {
     KTH_PRECONDITION(self != nullptr);
     auto const s = kth::cpp_ref<cpp_t>(self).to_string();
     return kth::create_c_str(s);
-}
-
-
-// Static utilities
-
-kth_error_code_t kth_wallet_ek_private_parse_from(char const* encoded, KTH_OUT_OWNED kth_ek_private_mut_t* out) {
-    KTH_PRECONDITION(encoded != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
-    auto const encoded_cpp = std::string_view(encoded);
-    auto result = cpp_t::parse_from(encoded_cpp);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
 }
 
 } // extern "C"

--- a/src/c-api/src/wallet/ek_public.cpp
+++ b/src/c-api/src/wallet/ek_public.cpp
@@ -22,10 +22,6 @@ extern "C" {
 
 // Constructors
 
-kth_ek_public_mut_t kth_wallet_ek_public_construct_default(void) {
-    return kth::leak<cpp_t>();
-}
-
 kth_ek_public_mut_t kth_wallet_ek_public_construct(kth_encrypted_public_t const* value) {
     KTH_PRECONDITION(value != nullptr);
     auto const value_cpp = kth::encrypted_public_to_cpp(value->data);
@@ -36,6 +32,17 @@ kth_ek_public_mut_t kth_wallet_ek_public_construct_unsafe(uint8_t const* value) 
     KTH_PRECONDITION(value != nullptr);
     auto const value_cpp = kth::encrypted_public_to_cpp(value);
     return kth::leak_if_valid(cpp_t(value_cpp));
+}
+
+kth_error_code_t kth_wallet_ek_public_parse_from(char const* encoded, KTH_OUT_OWNED kth_ek_public_mut_t* out) {
+    KTH_PRECONDITION(encoded != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const encoded_cpp = std::string_view(encoded);
+    auto result = cpp_t::parse_from(encoded_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
 }
 
 
@@ -117,20 +124,6 @@ char* kth_wallet_ek_public_to_string(kth_ek_public_const_t self) {
     KTH_PRECONDITION(self != nullptr);
     auto const s = kth::cpp_ref<cpp_t>(self).to_string();
     return kth::create_c_str(s);
-}
-
-
-// Static utilities
-
-kth_error_code_t kth_wallet_ek_public_parse_from(char const* encoded, KTH_OUT_OWNED kth_ek_public_mut_t* out) {
-    KTH_PRECONDITION(encoded != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
-    auto const encoded_cpp = std::string_view(encoded);
-    auto result = cpp_t::parse_from(encoded_cpp);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
 }
 
 } // extern "C"

--- a/src/c-api/src/wallet/ek_token.cpp
+++ b/src/c-api/src/wallet/ek_token.cpp
@@ -22,10 +22,6 @@ extern "C" {
 
 // Constructors
 
-kth_ek_token_mut_t kth_wallet_ek_token_construct_default(void) {
-    return kth::leak<cpp_t>();
-}
-
 kth_ek_token_mut_t kth_wallet_ek_token_construct(kth_encrypted_token_t const* value) {
     KTH_PRECONDITION(value != nullptr);
     auto const value_cpp = kth::encrypted_token_to_cpp(value->data);
@@ -36,6 +32,17 @@ kth_ek_token_mut_t kth_wallet_ek_token_construct_unsafe(uint8_t const* value) {
     KTH_PRECONDITION(value != nullptr);
     auto const value_cpp = kth::encrypted_token_to_cpp(value);
     return kth::leak_if_valid(cpp_t(value_cpp));
+}
+
+kth_error_code_t kth_wallet_ek_token_parse_from(char const* encoded, KTH_OUT_OWNED kth_ek_token_mut_t* out) {
+    KTH_PRECONDITION(encoded != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const encoded_cpp = std::string_view(encoded);
+    auto result = cpp_t::parse_from(encoded_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
 }
 
 
@@ -117,20 +124,6 @@ char* kth_wallet_ek_token_to_string(kth_ek_token_const_t self) {
     KTH_PRECONDITION(self != nullptr);
     auto const s = kth::cpp_ref<cpp_t>(self).to_string();
     return kth::create_c_str(s);
-}
-
-
-// Static utilities
-
-kth_error_code_t kth_wallet_ek_token_parse_from(char const* encoded, KTH_OUT_OWNED kth_ek_token_mut_t* out) {
-    KTH_PRECONDITION(encoded != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
-    auto const encoded_cpp = std::string_view(encoded);
-    auto result = cpp_t::parse_from(encoded_cpp);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
 }
 
 } // extern "C"

--- a/src/c-api/src/wallet/hd_private.cpp
+++ b/src/c-api/src/wallet/hd_private.cpp
@@ -22,10 +22,6 @@ extern "C" {
 
 // Constructors
 
-kth_hd_private_mut_t kth_wallet_hd_private_construct_default(void) {
-    return kth::leak<cpp_t>();
-}
-
 kth_hd_private_mut_t kth_wallet_hd_private_construct_from_seed_prefixes(uint8_t const* seed, kth_size_t n, uint64_t prefixes) {
     KTH_PRECONDITION(seed != nullptr || n == 0);
     auto const seed_cpp = n != 0 ? kth::data_chunk(seed, seed + n) : kth::data_chunk{};
@@ -72,6 +68,39 @@ kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key_prefix_uns
     auto private_key_cpp = kth::hd_key_to_cpp(private_key);
     kth::secure_scrub private_key_cpp_scrub{&private_key_cpp, sizeof(private_key_cpp)};
     return kth::leak_if_valid(cpp_t(private_key_cpp, prefix));
+}
+
+kth_error_code_t kth_wallet_hd_private_parse_from(char const* encoded, KTH_OUT_OWNED kth_hd_private_mut_t* out) {
+    KTH_PRECONDITION(encoded != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const encoded_cpp = std::string_view(encoded);
+    auto result = cpp_t::parse_from(encoded_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_wallet_hd_private_parse_from_with_public_prefix(char const* encoded, uint32_t public_prefix, KTH_OUT_OWNED kth_hd_private_mut_t* out) {
+    KTH_PRECONDITION(encoded != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const encoded_cpp = std::string_view(encoded);
+    auto result = cpp_t::parse_from_with_public_prefix(encoded_cpp, public_prefix);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_wallet_hd_private_parse_from_with_prefixes(char const* encoded, uint64_t prefixes, KTH_OUT_OWNED kth_hd_private_mut_t* out) {
+    KTH_PRECONDITION(encoded != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const encoded_cpp = std::string_view(encoded);
+    auto result = cpp_t::parse_from_with_prefixes(encoded_cpp, prefixes);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
 }
 
 
@@ -193,39 +222,6 @@ kth_hd_public_mut_t kth_wallet_hd_private_derive_public(kth_hd_private_const_t s
 
 uint32_t kth_wallet_hd_private_to_prefix(uint64_t prefixes) {
     return cpp_t::to_prefix(prefixes);
-}
-
-kth_error_code_t kth_wallet_hd_private_parse_from(char const* encoded, KTH_OUT_OWNED kth_hd_private_mut_t* out) {
-    KTH_PRECONDITION(encoded != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
-    auto const encoded_cpp = std::string_view(encoded);
-    auto result = cpp_t::parse_from(encoded_cpp);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
-}
-
-kth_error_code_t kth_wallet_hd_private_parse_from_with_public_prefix(char const* encoded, uint32_t public_prefix, KTH_OUT_OWNED kth_hd_private_mut_t* out) {
-    KTH_PRECONDITION(encoded != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
-    auto const encoded_cpp = std::string_view(encoded);
-    auto result = cpp_t::parse_from_with_public_prefix(encoded_cpp, public_prefix);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
-}
-
-kth_error_code_t kth_wallet_hd_private_parse_from_with_prefixes(char const* encoded, uint64_t prefixes, KTH_OUT_OWNED kth_hd_private_mut_t* out) {
-    KTH_PRECONDITION(encoded != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
-    auto const encoded_cpp = std::string_view(encoded);
-    auto result = cpp_t::parse_from_with_prefixes(encoded_cpp, prefixes);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
 }
 
 } // extern "C"

--- a/src/c-api/src/wallet/payment_address.cpp
+++ b/src/c-api/src/wallet/payment_address.cpp
@@ -22,10 +22,6 @@ extern "C" {
 
 // Constructors
 
-kth_payment_address_mut_t kth_wallet_payment_address_construct_default(void) {
-    return kth::leak<cpp_t>();
-}
-
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_short_hash_version(kth_shorthash_t const* short_hash, uint8_t version) {
     KTH_PRECONDITION(short_hash != nullptr);
     auto const short_hash_cpp = kth::short_hash_to_cpp(short_hash->hash);
@@ -50,13 +46,88 @@ kth_payment_address_mut_t kth_wallet_payment_address_construct_from_hash_version
     return kth::leak_if_valid(cpp_t(hash_cpp, version));
 }
 
-
-// Static factories
-
 kth_payment_address_mut_t kth_wallet_payment_address_from_script(kth_script_const_t script, uint8_t version) {
     KTH_PRECONDITION(script != nullptr);
     auto const& script_cpp = kth::cpp_ref<kth::domain::chain::script>(script);
     return kth::leak_if_valid(cpp_t::from_script(script_cpp, version));
+}
+
+kth_error_code_t kth_wallet_payment_address_from_pay_public_key_hash_script(kth_script_const_t script, uint8_t version, KTH_OUT_OWNED kth_payment_address_mut_t* out) {
+    KTH_PRECONDITION(script != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const& script_cpp = kth::cpp_ref<kth::domain::chain::script>(script);
+    auto result = cpp_t::from_pay_public_key_hash_script(script_cpp, version);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_wallet_payment_address_parse_from_simple(char const* address, KTH_OUT_OWNED kth_payment_address_mut_t* out) {
+    KTH_PRECONDITION(address != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const address_cpp = std::string_view(address);
+    auto result = cpp_t::parse_from(address_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_wallet_payment_address_parse_from(char const* address, kth_network_t net, KTH_OUT_OWNED kth_payment_address_mut_t* out) {
+    KTH_PRECONDITION(address != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const address_cpp = std::string_view(address);
+    auto const net_cpp = kth::network_to_cpp(net);
+    auto result = cpp_t::parse_from(address_cpp, net_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_wallet_payment_address_from_payment(kth_payment_t const* decoded, KTH_OUT_OWNED kth_payment_address_mut_t* out) {
+    KTH_PRECONDITION(decoded != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const decoded_cpp = kth::payment_to_cpp(decoded->hash);
+    auto result = cpp_t::from_payment(decoded_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_wallet_payment_address_from_payment_unsafe(uint8_t const* decoded, KTH_OUT_OWNED kth_payment_address_mut_t* out) {
+    KTH_PRECONDITION(decoded != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const decoded_cpp = kth::payment_to_cpp(decoded);
+    auto result = cpp_t::from_payment(decoded_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_wallet_payment_address_from_ec_private(kth_ec_private_const_t secret, KTH_OUT_OWNED kth_payment_address_mut_t* out) {
+    KTH_PRECONDITION(secret != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const& secret_cpp = kth::cpp_ref<kth::domain::wallet::ec_private>(secret);
+    auto result = cpp_t::from_ec_private(secret_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_wallet_payment_address_from_ec_public(kth_ec_public_const_t point, uint8_t version, KTH_OUT_OWNED kth_payment_address_mut_t* out) {
+    KTH_PRECONDITION(point != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const& point_cpp = kth::cpp_ref<kth::domain::wallet::ec_public>(point);
+    auto result = cpp_t::from_ec_public(point_cpp, version);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
 }
 
 
@@ -183,17 +254,6 @@ char* kth_wallet_payment_address_encoded_cashaddr(kth_payment_address_const_t se
 
 // Static utilities
 
-kth_error_code_t kth_wallet_payment_address_from_pay_public_key_hash_script(kth_script_const_t script, uint8_t version, KTH_OUT_OWNED kth_payment_address_mut_t* out) {
-    KTH_PRECONDITION(script != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
-    auto const& script_cpp = kth::cpp_ref<kth::domain::chain::script>(script);
-    auto result = cpp_t::from_pay_public_key_hash_script(script_cpp, version);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
-}
-
 char* kth_wallet_payment_address_cashaddr_prefix_for(kth_network_t net) {
     auto const net_cpp = kth::network_to_cpp(net);
     auto const s = cpp_t::cashaddr_prefix_for(net_cpp);
@@ -216,73 +276,6 @@ kth_payment_address_list_mut_t kth_wallet_payment_address_extract_output(kth_scr
     KTH_PRECONDITION(script != nullptr);
     auto const& script_cpp = kth::cpp_ref<kth::domain::chain::script>(script);
     return kth::leak_list<cpp_t>(cpp_t::extract_output(script_cpp, p2kh_version, p2sh_version));
-}
-
-kth_error_code_t kth_wallet_payment_address_parse_from_simple(char const* address, KTH_OUT_OWNED kth_payment_address_mut_t* out) {
-    KTH_PRECONDITION(address != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
-    auto const address_cpp = std::string_view(address);
-    auto result = cpp_t::parse_from(address_cpp);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
-}
-
-kth_error_code_t kth_wallet_payment_address_parse_from(char const* address, kth_network_t net, KTH_OUT_OWNED kth_payment_address_mut_t* out) {
-    KTH_PRECONDITION(address != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
-    auto const address_cpp = std::string_view(address);
-    auto const net_cpp = kth::network_to_cpp(net);
-    auto result = cpp_t::parse_from(address_cpp, net_cpp);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
-}
-
-kth_error_code_t kth_wallet_payment_address_from_payment(kth_payment_t const* decoded, KTH_OUT_OWNED kth_payment_address_mut_t* out) {
-    KTH_PRECONDITION(decoded != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
-    auto const decoded_cpp = kth::payment_to_cpp(decoded->hash);
-    auto result = cpp_t::from_payment(decoded_cpp);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
-}
-
-kth_error_code_t kth_wallet_payment_address_from_payment_unsafe(uint8_t const* decoded, KTH_OUT_OWNED kth_payment_address_mut_t* out) {
-    KTH_PRECONDITION(decoded != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
-    auto const decoded_cpp = kth::payment_to_cpp(decoded);
-    auto result = cpp_t::from_payment(decoded_cpp);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
-}
-
-kth_error_code_t kth_wallet_payment_address_from_ec_private(kth_ec_private_const_t secret, KTH_OUT_OWNED kth_payment_address_mut_t* out) {
-    KTH_PRECONDITION(secret != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
-    auto const& secret_cpp = kth::cpp_ref<kth::domain::wallet::ec_private>(secret);
-    auto result = cpp_t::from_ec_private(secret_cpp);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
-}
-
-kth_error_code_t kth_wallet_payment_address_from_ec_public(kth_ec_public_const_t point, uint8_t version, KTH_OUT_OWNED kth_payment_address_mut_t* out) {
-    KTH_PRECONDITION(point != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
-    auto const& point_cpp = kth::cpp_ref<kth::domain::wallet::ec_public>(point);
-    auto result = cpp_t::from_ec_public(point_cpp, version);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
 }
 
 } // extern "C"

--- a/src/c-api/src/wallet/stealth_receiver.cpp
+++ b/src/c-api/src/wallet/stealth_receiver.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <cstring>
+#include <utility>
 
 #include <kth/capi/wallet/stealth_receiver.h>
 
@@ -76,22 +77,28 @@ kth_stealth_address_const_t kth_wallet_stealth_receiver_stealth_address(kth_stea
 
 // Operations
 
-kth_bool_t kth_wallet_stealth_receiver_derive_address(kth_stealth_receiver_const_t self, kth_payment_address_mut_t out_address, kth_ec_compressed_t const* ephemeral_public) {
+kth_error_code_t kth_wallet_stealth_receiver_derive_address(kth_stealth_receiver_const_t self, kth_ec_compressed_t const* ephemeral_public, KTH_OUT_OWNED kth_payment_address_mut_t* out) {
     KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(out_address != nullptr);
     KTH_PRECONDITION(ephemeral_public != nullptr);
-    auto& out_address_cpp = kth::cpp_ref<kth::domain::wallet::payment_address>(out_address);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
     auto const ephemeral_public_cpp = kth::ec_compressed_to_cpp(ephemeral_public->data);
-    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).derive_address(out_address_cpp, ephemeral_public_cpp));
+    auto result = kth::cpp_ref<cpp_t>(self).derive_address(ephemeral_public_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
 }
 
-kth_bool_t kth_wallet_stealth_receiver_derive_address_unsafe(kth_stealth_receiver_const_t self, kth_payment_address_mut_t out_address, uint8_t const* ephemeral_public) {
+kth_error_code_t kth_wallet_stealth_receiver_derive_address_unsafe(kth_stealth_receiver_const_t self, uint8_t const* ephemeral_public, KTH_OUT_OWNED kth_payment_address_mut_t* out) {
     KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(out_address != nullptr);
     KTH_PRECONDITION(ephemeral_public != nullptr);
-    auto& out_address_cpp = kth::cpp_ref<kth::domain::wallet::payment_address>(out_address);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
     auto const ephemeral_public_cpp = kth::ec_compressed_to_cpp(ephemeral_public);
-    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).derive_address(out_address_cpp, ephemeral_public_cpp));
+    auto result = kth::cpp_ref<cpp_t>(self).derive_address(ephemeral_public_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
 }
 
 kth_bool_t kth_wallet_stealth_receiver_derive_private(kth_stealth_receiver_const_t self, kth_hash_t* out_private, kth_ec_compressed_t const* ephemeral_public) {

--- a/src/c-api/test/chain/script.cpp
+++ b/src/c-api/test/chain/script.cpp
@@ -277,14 +277,20 @@ TEST_CASE("C-API Script - to_pay_public_key_hash_pattern_unlocking valid pubkey 
     kth_wallet_ec_public_destruct(pub);
 }
 
-TEST_CASE("C-API Script - to_pay_public_key_hash_pattern_unlocking invalid pubkey returns NULL",
+TEST_CASE("C-API Script - to_pay_public_key_hash_pattern_unlocking with a "
+          "semantically-broken pubkey returns NULL",
           "[C-API Script]") {
-    // Default-constructed ec_public has valid_ == false, so its
-    // to_data() returns an error and the C++ factory yields an empty
-    // unlocking list that we turn into NULL.
-    kth_ec_public_mut_t pub = kth_wallet_ec_public_construct_default();
+    // `construct_unsafe` bypasses the on-curve check, so a blob of
+    // 0xFF bytes yields a handle that is "typed-valid" but stores a
+    // non-point. Building it with compress=false forces `to_data()`
+    // to route through `to_uncompressed()`, which fails on the
+    // decompression step. That failure surfaces as an empty list from
+    // the unlocking-pattern factory, which the C-API turns into NULL.
+    uint8_t garbage[33];
+    memset(garbage, 0xFF, sizeof(garbage));
+    kth_ec_public_mut_t pub =
+        kth_wallet_ec_public_construct_unsafe(garbage, /*compress=*/0);
     REQUIRE(pub != NULL);
-    REQUIRE(kth_wallet_ec_public_valid(pub) == 0);
 
     uint8_t endorsement[71];
     memset(endorsement, 0x30, sizeof(endorsement));

--- a/src/c-api/test/wallet/ek_private.cpp
+++ b/src/c-api/test/wallet/ek_private.cpp
@@ -35,17 +35,6 @@ static char const* const kEncryptedOther =
 // Lifecycle
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API wallet::ek_private - default construct is invalid",
-          "[C-API WalletEkPrivate][lifecycle]") {
-    // Matches the domain default ctor: no payload, `valid_ == false`.
-    // The handle itself is non-null (the allocation succeeded), but
-    // `valid()` returns 0 so callers know not to trust the state.
-    kth_ek_private_mut_t a = kth_wallet_ek_private_construct_default();
-    REQUIRE(a != NULL);
-    REQUIRE(kth_wallet_ek_private_valid(a) == 0);
-    kth_wallet_ek_private_destruct(a);
-}
-
 TEST_CASE("C-API wallet::ek_private - destruct(NULL) is a no-op",
           "[C-API WalletEkPrivate][lifecycle]") {
     kth_wallet_ek_private_destruct(NULL);

--- a/src/c-api/test/wallet/ek_public.cpp
+++ b/src/c-api/test/wallet/ek_public.cpp
@@ -36,14 +36,6 @@ static char const* const kEncryptedOther =
 // Lifecycle
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API wallet::ek_public - default construct is invalid",
-          "[C-API WalletEkPublic][lifecycle]") {
-    kth_ek_public_mut_t a = kth_wallet_ek_public_construct_default();
-    REQUIRE(a != NULL);
-    REQUIRE(kth_wallet_ek_public_valid(a) == 0);
-    kth_wallet_ek_public_destruct(a);
-}
-
 TEST_CASE("C-API wallet::ek_public - destruct(NULL) is a no-op",
           "[C-API WalletEkPublic][lifecycle]") {
     kth_wallet_ek_public_destruct(NULL);

--- a/src/c-api/test/wallet/ek_token.cpp
+++ b/src/c-api/test/wallet/ek_token.cpp
@@ -36,14 +36,6 @@ static char const* const kEncryptedOther =
 // Lifecycle
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API wallet::ek_token - default construct is invalid",
-          "[C-API WalletEkToken][lifecycle]") {
-    kth_ek_token_mut_t a = kth_wallet_ek_token_construct_default();
-    REQUIRE(a != NULL);
-    REQUIRE(kth_wallet_ek_token_valid(a) == 0);
-    kth_wallet_ek_token_destruct(a);
-}
-
 TEST_CASE("C-API wallet::ek_token - destruct(NULL) is a no-op",
           "[C-API WalletEkToken][lifecycle]") {
     kth_wallet_ek_token_destruct(NULL);

--- a/src/c-api/test/wallet/hd_private.cpp
+++ b/src/c-api/test/wallet/hd_private.cpp
@@ -32,12 +32,6 @@ static uint8_t const kSeed[16] = {
 // Constructors / lifecycle
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API HdPrivate - default construct is invalid", "[C-API HdPrivate]") {
-    kth_hd_private_mut_t key = kth_wallet_hd_private_construct_default();
-    REQUIRE(kth_wallet_hd_private_valid(key) == 0);
-    kth_wallet_hd_private_destruct(key);
-}
-
 TEST_CASE("C-API HdPrivate - construct from seed is valid", "[C-API HdPrivate]") {
     kth_hd_private_mut_t key = kth_wallet_hd_private_construct_from_seed_prefixes(
         kSeed, sizeof(kSeed), 0x0488ADE40488B21Eull);  // mainnet prefixes

--- a/src/c-api/test/wallet/message.cpp
+++ b/src/c-api/test/wallet/message.cpp
@@ -105,7 +105,8 @@ TEST_CASE("C-API wallet::message - sign(ec_private) + verify round-trip",
         &kSecret, /*version=*/0x8000u, /*compress=*/1);
     REQUIRE(secret != NULL);
 
-    kth_payment_address_mut_t address = kth_wallet_ec_private_to_payment_address(secret);
+    kth_payment_address_mut_t address = NULL;
+    REQUIRE(kth_wallet_ec_private_to_payment_address(secret, &address) == kth_ec_success);
     REQUIRE(address != NULL);
 
     kth_message_signature_t sig;
@@ -131,7 +132,8 @@ TEST_CASE("C-API wallet::message - verify rejects a tampered message",
           "[C-API WalletMessage][verify]") {
     kth_ec_private_mut_t secret = kth_wallet_ec_private_construct(
         &kSecret, 0x8000u, 1);
-    kth_payment_address_mut_t address = kth_wallet_ec_private_to_payment_address(secret);
+    kth_payment_address_mut_t address = NULL;
+    REQUIRE(kth_wallet_ec_private_to_payment_address(secret, &address) == kth_ec_success);
 
     kth_message_signature_t sig;
     memset(&sig, 0, sizeof(sig));

--- a/src/c-api/test/wallet/stealth_sender.cpp
+++ b/src/c-api/test/wallet/stealth_sender.cpp
@@ -259,13 +259,12 @@ TEST_CASE("C-API wallet::stealth - sender.payment_address matches receiver.deriv
     REQUIRE(kth_wallet_secret_to_public(&ephemeral_public,
                                         *(kth_ec_secret_t const*)&kEphemeralPrivate) != 0);
 
-    // Pre-construct an empty payment_address the derive_address
-    // function will mutate in place (opaque out-param by ref).
-    kth_payment_address_mut_t derived = kth_wallet_payment_address_construct_default();
-    REQUIRE(derived != NULL);
-
+    // derive_address returns an owned payment_address handle through
+    // the OUT param.
+    kth_payment_address_mut_t derived = NULL;
     REQUIRE(kth_wallet_stealth_receiver_derive_address(
-        r, derived, &ephemeral_public) != 0);
+        r, &ephemeral_public, &derived) == kth_ec_success);
+    REQUIRE(derived != NULL);
 
     char* derived_encoded = kth_wallet_payment_address_encoded_legacy(derived);
     REQUIRE(derived_encoded != NULL);

--- a/src/domain/include/kth/domain/chain/input.hpp
+++ b/src/domain/include/kth/domain/chain/input.hpp
@@ -82,7 +82,7 @@ struct KD_API input {
     /// The first payment address extracted (may be invalid).
     /// NOTE: not cached — recomputed on every call.
     [[nodiscard]]
-    wallet::payment_address address() const;
+    kth::expect<wallet::payment_address> address() const;
 
     /// The payment addresses extracted from this input as a standard script.
     /// NOTE: not cached — caller owns any caching it needs.

--- a/src/domain/include/kth/domain/chain/output.hpp
+++ b/src/domain/include/kth/domain/chain/output.hpp
@@ -101,11 +101,11 @@ struct KD_API output {
     /// The payment address extracted from this output as a standard script.
     /// NOTE: not cached — calling this in a hot loop recomputes each time.
     [[nodiscard]]
-    wallet::payment_address address(bool testnet = false) const;
+    kth::expect<wallet::payment_address> address(bool testnet = false) const;
 
     /// The first payment address extracted (may be invalid).
     [[nodiscard]]
-    wallet::payment_address address(uint8_t p2kh_version, uint8_t p2sh_version) const;
+    kth::expect<wallet::payment_address> address(uint8_t p2kh_version, uint8_t p2sh_version) const;
 
     /// The payment addresses extracted from this output as a standard script.
     /// NOTE: not cached — caller owns any caching it needs.

--- a/src/domain/include/kth/domain/wallet/bitcoin_uri.hpp
+++ b/src/domain/include/kth/domain/wallet/bitcoin_uri.hpp
@@ -64,8 +64,8 @@ struct KD_API bitcoin_uri {
     [[nodiscard]] std::string     message() const;
     [[nodiscard]] std::string     r() const;
     [[nodiscard]] std::string     address() const;
-    [[nodiscard]] payment_address payment() const;
-    [[nodiscard]] stealth_address stealth() const;
+    [[nodiscard]] kth::expect<payment_address> payment() const;
+    [[nodiscard]] kth::expect<stealth_address> stealth() const;
     [[nodiscard]] std::string     parameter(std::string const& key) const;
 
     /// Property setters.

--- a/src/domain/include/kth/domain/wallet/cashtoken_minting.hpp
+++ b/src/domain/include/kth/domain/wallet/cashtoken_minting.hpp
@@ -164,7 +164,7 @@ struct KD_API nft_spec {
 
 // Describes one NFT to mint from an existing minting NFT.
 struct KD_API nft_mint_request {
-    payment_address destination;
+    std::optional<payment_address> destination;
     data_chunk commitment;
     chain::capability_t capability = chain::capability_t::none;
     uint64_t satoshis = 1000;
@@ -182,8 +182,8 @@ struct KD_API nft_mint_request {
 // ---------------------------------------------------------------------------
 
 struct KD_API prepare_genesis_params {
-    chain::utxo utxo;                // any spendable UTXO
-    payment_address destination;     // recipient of the new output 0
+    chain::utxo utxo;                             // any spendable UTXO
+    std::optional<payment_address> destination;   // recipient of the new output 0
 
     // Default sized to comfortably cover the fee of the subsequent
     // genesis transaction (1 genesis input + 1 token output + 1 BCH
@@ -226,7 +226,7 @@ prepare_genesis_utxo(prepare_genesis_params const& params);
 
 struct KD_API token_genesis_params {
     chain::utxo genesis_utxo;             // outpoint.index() MUST be 0
-    payment_address destination;
+    std::optional<payment_address> destination;
 
     std::optional<uint64_t> ft_amount;
     std::optional<nft_spec> nft;
@@ -300,7 +300,7 @@ create_token_mint(token_mint_params const& params);
 
 struct KD_API token_transfer_params {
     std::vector<chain::utxo> token_utxos;
-    payment_address destination;
+    std::optional<payment_address> destination;
 
     std::optional<uint64_t> ft_amount;
     std::optional<nft_spec> nft;
@@ -335,7 +335,7 @@ struct KD_API token_burn_params {
     bool burn_nft = false;
     std::optional<std::string> message;     // attached as OP_RETURN
 
-    payment_address destination;
+    std::optional<payment_address> destination;
     std::vector<chain::utxo> fee_utxos;
     std::optional<payment_address> change_address;
     uint64_t satoshis = 1000;
@@ -356,7 +356,7 @@ create_token_burn(token_burn_params const& params);
 // category later.
 struct KD_API ft_params {
     chain::utxo genesis_utxo;
-    payment_address destination;
+    std::optional<payment_address> destination;
     uint64_t total_supply;
     bool with_minting_nft = false;
 
@@ -390,7 +390,7 @@ struct KD_API nft_collection_item {
 struct KD_API nft_collection_params {
     chain::utxo genesis_utxo;
     std::vector<nft_collection_item> nfts;
-    payment_address creator_address;
+    std::optional<payment_address> creator_address;
     bool keep_minting_token = false;              // false → burn at end
     std::optional<uint64_t> ft_amount;            // optional FT side-supply
     std::vector<chain::utxo> fee_utxos;

--- a/src/domain/include/kth/domain/wallet/ec_private.hpp
+++ b/src/domain/include/kth/domain/wallet/ec_private.hpp
@@ -35,10 +35,8 @@ using wif_compressed = byte_array<wif_compressed_size>;
 /**
  * EC secret with WIF version and compression metadata.
  *
- * Default-constructible (invalid state) so the C-API generator can
- * hand out an "empty" handle; fallible construction goes through
- * `parse_from` / `from_compressed` / `from_uncompressed`, each
- * returning `expect<ec_private>`.
+ * Fallible construction goes through `parse_from` / `from_compressed`
+ * / `from_uncompressed`, each returning `expect<ec_private>`.
  */
 struct KD_API ec_private {
     static uint8_t const compressed_sentinel;
@@ -84,8 +82,6 @@ struct KD_API ec_private {
     static
     expect<ec_private> from_uncompressed(wif_uncompressed const& wif, uint8_t address_version);
 
-    ec_private() = default;
-
     /// The version is 16 bits. The most significant byte is the WIF prefix
     /// and the least significant byte is the address prefix.
     explicit
@@ -126,10 +122,10 @@ struct KD_API ec_private {
     std::string to_string() const;
 
     [[nodiscard]]
-    ec_public to_public() const;
+    expect<ec_public> to_public() const;
 
     [[nodiscard]]
-    payment_address to_payment_address() const;
+    expect<payment_address> to_payment_address() const;
 
 private:
     static

--- a/src/domain/include/kth/domain/wallet/ec_public.hpp
+++ b/src/domain/include/kth/domain/wallet/ec_public.hpp
@@ -25,8 +25,8 @@ class payment_address;
 /**
  * Elliptic-curve public key, either compressed or uncompressed.
  *
- * Default-constructible (invalid state) so the C-API generator can
- * hand out an "empty" handle; the fallible construction paths return
+ * Fallible construction goes through the `parse_from` / `from_data` /
+ * `from_private` / `from_point` factories, each returning
  * `expect<ec_public>`.
  */
 struct KD_API ec_public {
@@ -56,8 +56,6 @@ struct KD_API ec_public {
     [[nodiscard]]
     static
     expect<ec_public> from_point(ec_uncompressed const& point, bool compress);
-
-    ec_public() = default;
 
     /// Wrap an already-compressed EC point.
     explicit
@@ -98,7 +96,7 @@ struct KD_API ec_public {
     std::expected<ec_uncompressed, std::error_code> to_uncompressed() const;
 
     [[nodiscard]]
-    payment_address to_payment_address(uint8_t version = mainnet_p2kh) const;
+    expect<payment_address> to_payment_address(uint8_t version = mainnet_p2kh) const;
 
 private:
     static

--- a/src/domain/include/kth/domain/wallet/ek_private.hpp
+++ b/src/domain/include/kth/domain/wallet/ek_private.hpp
@@ -17,16 +17,13 @@ namespace kth::domain::wallet {
 /**
  * Encrypted private key (BIP38).
  *
- * Default-constructible so the C-API generator can hand out an "empty"
- * handle; string parsing goes through `parse_from` which returns
+ * Fallible construction goes through `parse_from` which returns
  * `expect<ek_private>`.
  */
 struct KD_API ek_private {
     [[nodiscard]]
     static
     expect<ek_private> parse_from(std::string_view encoded);
-
-    ek_private() = default;
 
     explicit
     ek_private(encrypted_private const& value)

--- a/src/domain/include/kth/domain/wallet/ek_public.hpp
+++ b/src/domain/include/kth/domain/wallet/ek_public.hpp
@@ -17,16 +17,13 @@ namespace kth::domain::wallet {
 /**
  * Encrypted public key (BIP38).
  *
- * Default-constructible so the C-API generator can hand out an "empty"
- * handle; string parsing goes through `parse_from` which returns
+ * Fallible construction goes through `parse_from` which returns
  * `expect<ek_public>`.
  */
 struct KD_API ek_public {
     [[nodiscard]]
     static
     expect<ek_public> parse_from(std::string_view encoded);
-
-    ek_public() = default;
 
     explicit
     ek_public(encrypted_public const& value)

--- a/src/domain/include/kth/domain/wallet/ek_token.hpp
+++ b/src/domain/include/kth/domain/wallet/ek_token.hpp
@@ -17,16 +17,13 @@ namespace kth::domain::wallet {
 /**
  * BIP38 intermediate passphrase token.
  *
- * Default-constructible so the C-API generator can hand out an "empty"
- * handle; string parsing goes through `parse_from` which returns
+ * Fallible construction goes through `parse_from` which returns
  * `expect<ek_token>`.
  */
 struct KD_API ek_token {
     [[nodiscard]]
     static
     expect<ek_token> parse_from(std::string_view encoded);
-
-    ek_token() = default;
 
     explicit
     ek_token(encrypted_token const& value)

--- a/src/domain/include/kth/domain/wallet/hd_private.hpp
+++ b/src/domain/include/kth/domain/wallet/hd_private.hpp
@@ -25,10 +25,13 @@ uint64_t to_prefixes(uint32_t private_prefix, uint32_t public_prefix) {
 /**
  * BIP32 extended private key.
  *
- * Derives from `hd_public`. Default-constructible so callers that hold
- * an `hd_private` as a struct member can fill it later via assignment;
- * fallible construction goes through the `parse_from`-family static
- * factories, which return `expect<hd_private>`.
+ * Derives from `hd_public`. Fallible construction goes through the
+ * `parse_from`-family static factories, which return
+ * `expect<hd_private>`. Failure of the private `from_seed`, `from_key`,
+ * and `derive_private` internal factories is signalled by a
+ * default-constructed invalid instance whose `.valid()` returns false;
+ * the default ctor is kept `private` so this sentinel only exists
+ * inside the class.
  */
 struct KD_API hd_private : hd_public {
     static constexpr uint64_t mainnet = to_prefixes(76066276, hd_public::mainnet);
@@ -57,7 +60,6 @@ struct KD_API hd_private : hd_public {
     static
     expect<hd_private> parse_from_with_prefixes(std::string_view encoded, uint64_t prefixes);
 
-    hd_private() = default;
     hd_private& operator=(hd_private x);
 
     explicit
@@ -100,7 +102,17 @@ struct KD_API hd_private : hd_public {
     [[nodiscard]]
     hd_public derive_public(uint32_t index) const;
 
+    /// Reset every field to the default zero state. Used by
+    /// wallet_manager to overwrite the intermediate derivation keys
+    /// once the leaf public key has been captured.
+    void wipe() noexcept;
+
 private:
+    // Sentinel default ctor: internal-only. Factories that can fail
+    // (from_seed / from_key / derive_private) return an invalid
+    // instance built via this, which `.valid()` reports as false.
+    hd_private() = default;
+
     static hd_private from_seed(byte_span seed, uint64_t prefixes);
     static hd_private from_key(hd_key const& decoded);
     static hd_private from_key(hd_key const& key, uint32_t public_prefix);

--- a/src/domain/include/kth/domain/wallet/payment_address.hpp
+++ b/src/domain/include/kth/domain/wallet/payment_address.hpp
@@ -34,11 +34,11 @@ using payment = byte_array<payment_size>;
 /**
  * Non-stealth payment address (P2PKH, P2SH, or 32-byte hash variants).
  *
- * Default-constructible so callers that hold `payment_address` as a
- * struct member (e.g. `stealth_sender::address_`,
- * `cashtoken_minting::*::destination`) can fill it later via
- * assignment; fallible construction goes through the `parse_from`
- * / `from_*` named factories, each returning `expect<payment_address>`.
+ * Fallible construction goes through the `parse_from` / `from_*`
+ * named factories, each returning `expect<payment_address>`. Callers
+ * that need to hold a payment_address as a struct member before its
+ * value is known should wrap it in `std::optional` — the type has no
+ * default-constructed invalid state.
  */
 struct KD_API payment_address {
 
@@ -107,8 +107,6 @@ struct KD_API payment_address {
     [[nodiscard]]
     static
     expect<payment_address> from_pay_public_key_hash_script(chain::script const& script, uint8_t version);
-
-    payment_address() = default;
 
     /// Wrap a 20-byte hash160 payload directly. Infallible.
     payment_address(short_hash const& short_hash, uint8_t version);

--- a/src/domain/include/kth/domain/wallet/stealth_receiver.hpp
+++ b/src/domain/include/kth/domain/wallet/stealth_receiver.hpp
@@ -31,8 +31,8 @@ struct KD_API stealth_receiver {
     const wallet::stealth_address& stealth_address() const;
 
     /// Derive a payment address to compare against the blockchain.
-    bool derive_address(payment_address& out_address,
-                        ec_compressed const& ephemeral_public) const;
+    [[nodiscard]]
+    expect<payment_address> derive_address(ec_compressed const& ephemeral_public) const;
 
     /// Once address is discovered, derive the private spend key.
     bool derive_private(ec_secret& out_private,

--- a/src/domain/include/kth/domain/wallet/stealth_sender.hpp
+++ b/src/domain/include/kth/domain/wallet/stealth_sender.hpp
@@ -6,6 +6,7 @@
 #define KTH_WALLET_STEALTH_SENDER_HPP
 
 #include <cstdint>
+#include <optional>
 
 #include <kth/domain/chain/script.hpp>
 #include <kth/domain/define.hpp>
@@ -49,7 +50,7 @@ private:
 
     uint8_t const version_;
     chain::script script_;
-    wallet::payment_address address_;
+    std::optional<wallet::payment_address> address_;
 };
 
 } // namespace kth::domain::wallet

--- a/src/domain/src/chain/input.cpp
+++ b/src/domain/src/chain/input.cpp
@@ -113,9 +113,10 @@ void input::set_sequence(uint32_t value) {
     sequence_ = value;
 }
 
-payment_address input::address() const {
+kth::expect<payment_address> input::address() const {
     auto const value = addresses();
-    return value.empty() ? payment_address{} : value.front();
+    if (value.empty()) return std::unexpected(kth::error::illegal_value);
+    return value.front();
 }
 
 payment_address::list input::addresses() const {

--- a/src/domain/src/chain/output.cpp
+++ b/src/domain/src/chain/output.cpp
@@ -215,16 +215,17 @@ void output::set_token_data(chain::token_data_opt&& x) {
     token_data_ = std::move(x);
 }
 
-payment_address output::address(bool testnet /*= false*/) const {
+kth::expect<payment_address> output::address(bool testnet /*= false*/) const {
     if (testnet) {
         return address(wallet::payment_address::testnet_p2kh, wallet::payment_address::testnet_p2sh);
     }
     return address(wallet::payment_address::mainnet_p2kh, wallet::payment_address::mainnet_p2sh);
 }
 
-payment_address output::address(uint8_t p2kh_version, uint8_t p2sh_version) const {
+kth::expect<payment_address> output::address(uint8_t p2kh_version, uint8_t p2sh_version) const {
     auto const value = addresses(p2kh_version, p2sh_version);
-    return value.empty() ? payment_address{} : value.front();
+    if (value.empty()) return std::unexpected(kth::error::illegal_value);
+    return value.front();
 }
 
 payment_address::list output::addresses(uint8_t p2kh_version, uint8_t p2sh_version) const {

--- a/src/domain/src/wallet/bitcoin_uri.cpp
+++ b/src/domain/src/wallet/bitcoin_uri.cpp
@@ -75,12 +75,12 @@ std::string bitcoin_uri::r() const {
     return parameter(parameter_r);
 }
 
-payment_address bitcoin_uri::payment() const {
-    return payment_address::parse_from(address_).value_or(payment_address{});
+kth::expect<payment_address> bitcoin_uri::payment() const {
+    return payment_address::parse_from(address_);
 }
 
-stealth_address bitcoin_uri::stealth() const {
-    return stealth_address::parse_from(address_).value_or(stealth_address{});
+kth::expect<stealth_address> bitcoin_uri::stealth() const {
+    return stealth_address::parse_from(address_);
 }
 
 std::string bitcoin_uri::parameter(std::string const& key) const {

--- a/src/domain/src/wallet/cashtoken_minting.cpp
+++ b/src/domain/src/wallet/cashtoken_minting.cpp
@@ -114,7 +114,7 @@ chain::output create_combined_token_output(
 
 std::expected<prepare_genesis_result, std::error_code>
 prepare_genesis_utxo(prepare_genesis_params const& params) {
-    if ( ! params.destination.valid()) {
+    if ( ! params.destination) {
         return std::unexpected(kth::error::operation_failed);
     }
 
@@ -174,7 +174,7 @@ prepare_genesis_utxo(prepare_genesis_params const& params) {
     outputs.reserve(emit_change ? 2 : 1);
     outputs.emplace_back(
         params.satoshis,
-        chain::script{chain::script::to_pay_public_key_hash_pattern(params.destination.hash20())},
+        chain::script{chain::script::to_pay_public_key_hash_pattern(params.destination->hash20())},
         chain::token_data_opt{}
     );
 
@@ -183,7 +183,7 @@ prepare_genesis_utxo(prepare_genesis_params const& params) {
     // is safe because `prepare_genesis_utxo` only targets single-wallet
     // flows — the caller can always override via `change_address`.
     if (emit_change) {
-        auto const& change_addr = params.change_address.value_or(params.destination);
+        auto const& change_addr = params.change_address.value_or(*params.destination);
         outputs.emplace_back(
             change_amount,
             chain::script{chain::script::to_pay_public_key_hash_pattern(change_addr.hash20())},
@@ -216,9 +216,9 @@ prepare_genesis_utxo(prepare_genesis_params const& params) {
 
 std::expected<token_genesis_result, std::error_code>
 create_token_genesis(token_genesis_params const& params) {
-    // Destination address must be valid — silently building a TX with a
-    // default-constructed address would produce an unspendable output.
-    if ( ! params.destination.valid()) {
+    // Destination address must be provided — silently building a TX
+    // without a target address would produce an unspendable output.
+    if ( ! params.destination) {
         return std::unexpected(kth::error::operation_failed);
     }
 
@@ -360,12 +360,12 @@ create_token_genesis(token_genesis_params const& params) {
     outputs.reserve(emit_change ? 2 : 1);
     outputs.emplace_back(
         params.satoshis,
-        chain::script{chain::script::to_pay_public_key_hash_pattern(params.destination.hash20())},
+        chain::script{chain::script::to_pay_public_key_hash_pattern(params.destination->hash20())},
         chain::token_data_opt{std::move(token_data)}
     );
 
     if (emit_change) {
-        auto const& change_addr = params.change_address.value_or(params.destination);
+        auto const& change_addr = params.change_address.value_or(*params.destination);
         outputs.emplace_back(
             change_amount,
             chain::script{chain::script::to_pay_public_key_hash_pattern(change_addr.hash20())},
@@ -407,9 +407,9 @@ create_token_mint(token_mint_params const& params) {
         return std::unexpected(kth::error::operation_failed);
     }
 
-    // Destinations (one per requested NFT) must all be valid addresses.
+    // Destinations (one per requested NFT) must all be provided.
     for (auto const& req : params.nfts) {
-        if ( ! req.destination.valid()) {
+        if ( ! req.destination) {
             return std::unexpected(kth::error::operation_failed);
         }
     }
@@ -613,7 +613,7 @@ create_token_mint(token_mint_params const& params) {
         auto const& req = params.nfts[i];
         outputs.emplace_back(
             req.satoshis,
-            chain::script{chain::script::to_pay_public_key_hash_pattern(req.destination.hash20())},
+            chain::script{chain::script::to_pay_public_key_hash_pattern(req.destination->hash20())},
             chain::token_data_opt{chain::make_non_fungible(
                 category_id,
                 req.capability,
@@ -659,7 +659,7 @@ create_token_mint(token_mint_params const& params) {
 
 std::expected<token_tx_result, std::error_code>
 create_token_transfer(token_transfer_params const& params) {
-    if ( ! params.destination.valid()) {
+    if ( ! params.destination) {
         return std::unexpected(kth::error::operation_failed);
     }
 
@@ -788,19 +788,13 @@ create_token_transfer(token_transfer_params const& params) {
     size_t const n_carried_nft_outs = carried_nfts.size();
 
     // Resolve change addresses. `token_change_address` is required when
-    // there is any token change to emit. The resolved address must also
-    // be valid — an optional wrapping a default-constructed address
-    // would otherwise slip past `has_value()` and produce unspendable
-    // token-carrying outputs, permanently burning those tokens.
-    payment_address token_change_addr;
+    // there is any token change to emit.
+    std::optional<payment_address> token_change_addr;
     if (emit_ft_change || n_carried_nft_outs > 0) {
         if ( ! params.token_change_address.has_value()) {
             return std::unexpected(kth::error::invalid_change);
         }
         token_change_addr = *params.token_change_address;
-        if ( ! token_change_addr.valid()) {
-            return std::unexpected(kth::error::invalid_change);
-        }
     }
 
     // ---------------------------------------------------------------
@@ -873,19 +867,15 @@ create_token_transfer(token_transfer_params const& params) {
     // Prefer an explicit BCH change address; fall back to the token
     // change address if any, and ultimately to the destination as a
     // safe default so a valid transfer never fails on missing change
-    // metadata. The resolved address must be valid for the same reason
-    // explained above (avoid burning change to an unspendable output).
-    payment_address bch_change_addr;
+    // metadata.
+    std::optional<payment_address> bch_change_addr;
     if (emit_bch_change) {
         if (params.bch_change_address.has_value()) {
             bch_change_addr = *params.bch_change_address;
         } else if (params.token_change_address.has_value()) {
             bch_change_addr = *params.token_change_address;
         } else {
-            bch_change_addr = params.destination;
-        }
-        if ( ! bch_change_addr.valid()) {
-            return std::unexpected(kth::error::invalid_change);
+            bch_change_addr = *params.destination;
         }
     }
 
@@ -903,7 +893,7 @@ create_token_transfer(token_transfer_params const& params) {
     if (want_ft) {
         outputs.emplace_back(
             params.satoshis,
-            p2pkh(params.destination),
+            p2pkh(*params.destination),
             chain::token_data_opt{chain::make_fungible(category_id, *params.ft_amount)}
         );
     } else {
@@ -911,7 +901,7 @@ create_token_transfer(token_transfer_params const& params) {
         // (capability preserved from the spec provided by the caller).
         outputs.emplace_back(
             params.satoshis,
-            p2pkh(params.destination),
+            p2pkh(*params.destination),
             chain::token_data_opt{chain::make_non_fungible(
                 category_id,
                 params.nft->capability,
@@ -924,7 +914,7 @@ create_token_transfer(token_transfer_params const& params) {
     if (emit_ft_change) {
         outputs.emplace_back(
             per_token_output_sats,
-            p2pkh(token_change_addr),
+            p2pkh(*token_change_addr),
             chain::token_data_opt{chain::make_fungible(category_id, ft_change)}
         );
     }
@@ -934,7 +924,7 @@ create_token_transfer(token_transfer_params const& params) {
     for (auto const& nft : carried_nfts) {
         outputs.emplace_back(
             per_token_output_sats,
-            p2pkh(token_change_addr),
+            p2pkh(*token_change_addr),
             chain::token_data_opt{chain::make_non_fungible(
                 category_id,
                 nft.capability,
@@ -947,7 +937,7 @@ create_token_transfer(token_transfer_params const& params) {
     if (emit_bch_change) {
         outputs.emplace_back(
             bch_change,
-            p2pkh(bch_change_addr),
+            p2pkh(*bch_change_addr),
             chain::token_data_opt{}
         );
     }
@@ -982,7 +972,7 @@ create_token_transfer(token_transfer_params const& params) {
 
 std::expected<token_tx_result, std::error_code>
 create_token_burn(token_burn_params const& params) {
-    if ( ! params.destination.valid()) {
+    if ( ! params.destination) {
         return std::unexpected(kth::error::operation_failed);
     }
 
@@ -1084,7 +1074,7 @@ create_token_burn(token_burn_params const& params) {
 
     outputs.emplace_back(
         params.satoshis,
-        p2pkh(params.destination),
+        p2pkh(*params.destination),
         std::move(remaining_payload)
     );
 
@@ -1153,7 +1143,7 @@ create_token_burn(token_burn_params const& params) {
     bool const emit_change = bch_change >= bch_dust_limit;
 
     if (emit_change) {
-        auto const& change_addr = params.change_address.value_or(params.destination);
+        auto const& change_addr = params.change_address.value_or(*params.destination);
         outputs.emplace_back(
             bch_change,
             p2pkh(change_addr),
@@ -1219,27 +1209,20 @@ create_nft_collection(nft_collection_params const& params) {
         return std::unexpected(kth::error::operation_failed);
     }
 
-    // Validate every NFT commitment and destination up front — under
-    // the active script flags' cap — so a later batch failure doesn't
-    // leave the caller with a half-executed plan on-chain. Destinations
-    // are checked for the same reason: an explicit optional wrapping a
-    // default-constructed address would pass `has_value()`, survive
-    // `value_or`, and only blow up inside `create_token_mint` for that
-    // batch — after earlier batches may have been broadcast.
+    // Validate every NFT commitment up front — under the active script
+    // flags' cap — so a later batch failure doesn't leave the caller
+    // with a half-executed plan on-chain.
     size_t const commitment_cap = chain::max_token_commitment_length(params.script_flags);
     for (auto const& item : params.nfts) {
         if (item.commitment.size() > commitment_cap) {
             return std::unexpected(kth::error::token_commitment_oversized);
         }
-        if (item.destination.has_value() && ! item.destination->valid()) {
-            return std::unexpected(kth::error::operation_failed);
-        }
     }
     // The fallback for per-item destinations is `creator_address`; if
-    // any item omits its destination, `creator_address` must be valid
-    // so it produces spendable mint outputs. (Also re-validated by
+    // any item omits its destination, `creator_address` must be set so
+    // it produces spendable mint outputs. (Also re-validated by
     // `create_token_genesis` below for its own use.)
-    if ( ! params.creator_address.valid()) {
+    if ( ! params.creator_address) {
         return std::unexpected(kth::error::operation_failed);
     }
 
@@ -1275,7 +1258,7 @@ create_nft_collection(nft_collection_params const& params) {
         batch.mint_requests.reserve(end - i);
         for (size_t j = i; j < end; ++j) {
             nft_mint_request req{};
-            req.destination = params.nfts[j].destination.value_or(params.creator_address);
+            req.destination = params.nfts[j].destination.value_or(*params.creator_address);
             req.commitment = params.nfts[j].commitment;
             req.capability = chain::capability_t::none;   // minted NFTs are immutable
             req.satoshis = token_dust_limit;

--- a/src/domain/src/wallet/ec_private.cpp
+++ b/src/domain/src/wallet/ec_private.cpp
@@ -115,20 +115,19 @@ std::string ec_private::to_string() const {
 // Methods.
 // ----------------------------------------------------------------------------
 
-// A valid secret always produces a valid public point.
-ec_public ec_private::to_public() const {
-    if ( ! valid_) {
-        return ec_public{};
-    }
+// A valid secret always produces a valid public point (the failure paths
+// are only reachable for a secret that isn't a valid EC scalar, which
+// shouldn't happen for anything constructed via the parse_from factories).
+expect<ec_public> ec_private::to_public() const {
     ec_compressed point;
     if ( ! secret_to_public(point, secret_)) {
-        return ec_public{};
+        return std::unexpected(kth::error::illegal_value);
     }
     return ec_public{point, compressed()};
 }
 
-payment_address ec_private::to_payment_address() const {
-    return payment_address::from_ec_private(*this).value_or(payment_address{});
+expect<payment_address> ec_private::to_payment_address() const {
+    return payment_address::from_ec_private(*this);
 }
 
 } // namespace kth::domain::wallet

--- a/src/domain/src/wallet/ec_public.cpp
+++ b/src/domain/src/wallet/ec_public.cpp
@@ -59,7 +59,7 @@ expect<ec_public> ec_public::from_private(ec_private const& secret) {
     if ( ! secret.valid()) {
         return std::unexpected(kth::error::illegal_value);
     }
-    return ec_public{secret.to_public()};
+    return secret.to_public();
 }
 
 // static
@@ -126,8 +126,8 @@ std::expected<ec_uncompressed, std::error_code> ec_public::to_uncompressed() con
     return out;
 }
 
-payment_address ec_public::to_payment_address(uint8_t version) const {
-    return payment_address::from_ec_public(*this, version).value_or(payment_address{});
+expect<payment_address> ec_public::to_payment_address(uint8_t version) const {
+    return payment_address::from_ec_public(*this, version);
 }
 
 } // namespace kth::domain::wallet

--- a/src/domain/src/wallet/hd_private.cpp
+++ b/src/domain/src/wallet/hd_private.cpp
@@ -227,6 +227,11 @@ hd_public hd_private::derive_public(uint32_t index) const {
     return derive_private(index).to_public();
 }
 
+void hd_private::wipe() noexcept {
+    hd_private tmp;
+    swap(*this, tmp);
+}
+
 // Operators.
 // ----------------------------------------------------------------------------
 

--- a/src/domain/src/wallet/payment_address.cpp
+++ b/src/domain/src/wallet/payment_address.cpp
@@ -227,7 +227,11 @@ expect<payment_address> payment_address::from_ec_private(ec_private const& secre
     if ( ! secret.valid()) {
         return std::unexpected(kth::error::illegal_value);
     }
-    return from_ec_public(secret.to_public(), secret.payment_version());
+    auto const point = secret.to_public();
+    if ( ! point) {
+        return std::unexpected(point.error());
+    }
+    return from_ec_public(*point, secret.payment_version());
 }
 
 // static

--- a/src/domain/src/wallet/stealth_receiver.cpp
+++ b/src/domain/src/wallet/stealth_receiver.cpp
@@ -9,6 +9,7 @@
 #include <kth/domain/math/stealth.hpp>
 #include <kth/domain/wallet/payment_address.hpp>
 #include <kth/domain/wallet/stealth_address.hpp>
+#include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/math/elliptic_curve.hpp>
 #include <kth/infrastructure/utility/binary.hpp>
 
@@ -36,20 +37,13 @@ const wallet::stealth_address& stealth_receiver::stealth_address() const {
     return address_;
 }
 
-bool stealth_receiver::derive_address(payment_address& out_address,
-                                      ec_compressed const& ephemeral_public) const {
+expect<payment_address> stealth_receiver::derive_address(ec_compressed const& ephemeral_public) const {
     ec_compressed receiver_public;
     if ( ! uncover_stealth(receiver_public, ephemeral_public, scan_private_,
                          spend_public_)) {
-        return false;
+        return std::unexpected(kth::error::illegal_value);
     }
-
-    auto result = payment_address::from_ec_public(ec_public{receiver_public}, version_);
-    if ( ! result) {
-        return false;
-    }
-    out_address = *result;
-    return true;
+    return payment_address::from_ec_public(ec_public{receiver_public}, version_);
 }
 
 bool stealth_receiver::derive_private(ec_secret& out_private,

--- a/src/domain/src/wallet/stealth_sender.cpp
+++ b/src/domain/src/wallet/stealth_sender.cpp
@@ -35,7 +35,7 @@ stealth_sender::stealth_sender(ec_secret const& ephemeral_private,
 }
 
 stealth_sender::operator bool() const {
-    return address_.valid();
+    return address_.has_value();
 }
 
 // private
@@ -72,9 +72,10 @@ chain::script const& stealth_sender::stealth_script() const {
     return script_;
 }
 
-// Will be invalid if construct fails.
+// Undefined behaviour if `operator bool()` is false — caller must
+// check validity before calling this.
 const wallet::payment_address& stealth_sender::payment_address() const {
-    return address_;
+    return *address_;
 }
 
 } // namespace kth::domain::wallet

--- a/src/domain/src/wallet/wallet_manager.cpp
+++ b/src/domain/src/wallet/wallet_manager.cpp
@@ -31,12 +31,6 @@ hash_digest derive_key(std::string const& password, std::array<uint8_t, default_
     return key;
 }
 
-template <typename T>
-void clear_hd(T& hd) {
-    using std::swap;
-    T tmp;
-    swap(hd, tmp);
-}
 
 std::expected<wallet_data, std::error_code>
 create(
@@ -72,11 +66,11 @@ create(
     hd_private m44h145h0h = m44h145h.derive_private(0 + hd_first_hardened_key);
     hd_public pub = m44h145h0h.to_public();
 
-    // erase all the intermediate hd_private and hd_public objects
-    clear_hd(m);
-    clear_hd(m44h);
-    clear_hd(m44h145h);
-    clear_hd(m44h145h0h);
+    // erase all the intermediate hd_private objects
+    m.wipe();
+    m44h.wipe();
+    m44h145h.wipe();
+    m44h145h0h.wipe();
 
     auto const salt = generate_salt();
     auto const iv = generate_salt<default_iv_size>();

--- a/src/domain/test/wallet/bitcoin_uri.cpp
+++ b/src/domain/test/wallet/bitcoin_uri.cpp
@@ -186,7 +186,9 @@ TEST_CASE("bitcoin uri payment valid expected", "[bitcoin uri]") {
     auto const expected_uri = std::string("bitcoin:") + expected_payment;
     auto const uri = bitcoin_uri::parse_from(expected_uri);
     REQUIRE(uri);
-    REQUIRE(uri->payment().encoded_legacy() == expected_payment);
+    auto const paid = uri->payment();
+    REQUIRE(paid);
+    REQUIRE(paid->encoded_legacy() == expected_payment);
 }
 
 TEST_CASE("bitcoin uri stealth valid expected", "[bitcoin uri]") {
@@ -194,7 +196,9 @@ TEST_CASE("bitcoin uri stealth valid expected", "[bitcoin uri]") {
     auto const expected_uri = std::string("bitcoin:") + expected_stealth;
     auto const uri = bitcoin_uri::parse_from(expected_uri);
     REQUIRE(uri);
-    REQUIRE(uri->stealth().encoded() == expected_stealth);
+    auto const st = uri->stealth();
+    REQUIRE(st);
+    REQUIRE(st->encoded() == expected_stealth);
 }
 
 TEST_CASE("bitcoin uri address payment expected", "[bitcoin uri]") {

--- a/src/domain/test/wallet/payment_address.cpp
+++ b/src/domain/test/wallet/payment_address.cpp
@@ -57,12 +57,6 @@ constexpr char uninitialized_address[] = "1111111111111111111114oLvT2";
 
 // negative tests:
 
-TEST_CASE("payment_address construct default invalid", "[payment_address]") {
-    payment_address const address;
-    REQUIRE( ! address.valid());
-    REQUIRE(address.encoded_legacy() == uninitialized_address);
-}
-
 TEST_CASE("payment_address construct string invalid invalid", "[payment_address]") {
     REQUIRE( ! payment_address::parse_from("bogus"));
 }

--- a/src/domain/test/wallet/uri_reader.cpp
+++ b/src/domain/test/wallet/uri_reader.cpp
@@ -94,7 +94,7 @@ private:
 TEST_CASE("uri reader parse typical uri test", "[uri reader]") {
     auto const uri = parse("bitcoin:113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD?amount=0.1");
     REQUIRE(uri.valid());
-    REQUIRE(uri.payment().encoded_legacy() == "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
+    REQUIRE((uri.payment() && uri.payment()->encoded_legacy() == "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD"));
     REQUIRE(uri.amount() == 10000000u);
     REQUIRE(uri.label().empty());
     REQUIRE(uri.message().empty());
@@ -142,7 +142,7 @@ TEST_CASE("uri reader parse negative unknown required parameter test", "[uri rea
 TEST_CASE("uri reader parse address test", "[uri reader]") {
     auto const uri = parse("bitcoin:113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
     REQUIRE(uri.valid());
-    REQUIRE(uri.payment().encoded_legacy() == "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
+    REQUIRE((uri.payment() && uri.payment()->encoded_legacy() == "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD"));
     REQUIRE(uri.amount() == 0);
     REQUIRE(uri.label().empty());
     REQUIRE(uri.message().empty());
@@ -152,7 +152,7 @@ TEST_CASE("uri reader parse address test", "[uri reader]") {
 TEST_CASE("uri reader parse uri encoded address test", "[uri reader]") {
     auto const uri = parse("bitcoin:%3113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
     REQUIRE(uri.valid());
-    REQUIRE(uri.payment().encoded_legacy() == "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
+    REQUIRE((uri.payment() && uri.payment()->encoded_legacy() == "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD"));
 }
 
 TEST_CASE("uri reader parse negative address test", "[uri reader]") {
@@ -164,7 +164,7 @@ TEST_CASE("uri reader parse negative address test", "[uri reader]") {
 TEST_CASE("uri reader parse amount only test", "[uri reader]") {
     auto const uri = parse("bitcoin:?amount=4.2");
     REQUIRE(uri.valid());
-    REQUIRE( ! uri.payment().valid());
+    REQUIRE( ! uri.payment());
     REQUIRE(uri.amount() == 420000000u);
     REQUIRE(uri.label().empty());
     REQUIRE(uri.message().empty());
@@ -185,7 +185,7 @@ TEST_CASE("uri reader parse invalid amount test", "[uri reader]") {
 TEST_CASE("uri reader parse label only test", "[uri reader]") {
     auto const uri = parse("bitcoin:?label=test");
     REQUIRE(uri.valid());
-    REQUIRE( ! uri.payment().valid());
+    REQUIRE( ! uri.payment());
     REQUIRE(uri.amount() == 0);
     REQUIRE(uri.label() == "test");
     REQUIRE(uri.message().empty());
@@ -218,7 +218,7 @@ TEST_CASE("uri reader parse negative strict encoded multibyte utf8 with unencode
 
 TEST_CASE("uri reader parse message only test", "[uri reader]") {
     auto const uri = parse("bitcoin:?message=Hi%20Alice");
-    REQUIRE( ! uri.payment().valid());
+    REQUIRE( ! uri.payment());
     REQUIRE(uri.amount() == 0);
     REQUIRE(uri.label().empty());
     REQUIRE(uri.message() == "Hi Alice");
@@ -227,7 +227,7 @@ TEST_CASE("uri reader parse message only test", "[uri reader]") {
 
 TEST_CASE("uri reader parse payment protocol only test", "[uri reader]") {
     auto const uri = parse("bitcoin:?r=http://www.example.com?purchase%3Dshoes");
-    REQUIRE( ! uri.payment().valid());
+    REQUIRE( ! uri.payment());
     REQUIRE(uri.amount() == 0);
     REQUIRE(uri.label().empty());
     REQUIRE(uri.message().empty());


### PR DESCRIPTION
## Summary

Extends the `ec_private` drop-default-ctor pass across every wallet type in the tree where the default-constructed invalid state had no legitimate value in the domain:

- `ec_public`
- `ek_private`, `ek_public`, `ek_token`
- `hd_private`
- `payment_address`

**New design principle**: a constructed object is always in a valid state. A type gets a default ctor only when its default-constructed instance is itself a legitimate domain value (as `std::string()` = empty string is a valid string). `payment_address{}` is not — it is "no address at all" — so it goes, and every previously default-constructing site is converted.

`ec_public` loses its default ctor. `ec_private::to_public()` and `ec_private::to_payment_address()` now return `expect<>` (both previously relied on `value_or(default{})`). Same for `ec_public::to_payment_address()`, `input::address()`, `output::address()`, `bitcoin_uri::payment()`, `bitcoin_uri::stealth()`, and `stealth_receiver::derive_address()` (dropping its old out-param / bool-return dance for a clean `expect<payment_address>`).

Struct members that held a `payment_address` by value become `std::optional<payment_address>`:
- `stealth_sender::address_`
- `wallet::cashtoken_minting::{nft_mint_request, prepare_genesis_params, token_genesis_params, token_transfer_params, token_burn_params, ft_params, nft_collection_params}::destination` / `creator_address`

`hd_private` keeps a **private** default ctor: the internal factories `from_seed` / `from_key` / `derive_private` still signal failure by returning `hd_private{}`, and callers detect it via `.valid()` on the inherited `hd_public` field. The public surface loses the default ctor and the C-API loses `construct_default`. `wallet_manager` used to zero the intermediate derivation keys via a `clear_hd<T>` template that relied on default-construction — replaced with a public `hd_private::wipe()` member that swaps `*this` against a default-constructed sentinel from inside the class.

### C-API helper adjustment

`leak_if_valid` grows two overloads for `std::expected<T, E>` that unwrap before allocating. Without them, the generic forwarding-reference template would `new` a full `std::expected<...>` and hand its address back through the opaque `void*` handle typedef — a silent runtime UB that the C typedef would not have flagged at compile time.

C-API regenerated for the affected types.

### Test changes

- Four `_default_construct_is_invalid` C-API tests (`ek_private`, `ek_public`, `ek_token`, `hd_private`) removed — their premise no longer exists.
- The `chain::script` test that asserted an invalid pubkey yields `NULL` from `to_pay_public_key_hash_pattern_unlocking` is restored via `kth_wallet_ec_public_construct_unsafe` on a garbage 33-byte blob with `compress=false`. That path bypasses the on-curve check, and `to_data()` fails on the decompression step, which surfaces as `NULL` through the C-API's empty-list convention.
- Domain wallet tests (`bitcoin_uri`, `uri_reader`) adjusted to unwrap the new `expect<payment_address>` / `expect<stealth_address>` returns.
- The `payment_address construct default invalid` domain test removed — the premise no longer exists.
- C-API `wallet::message` and `stealth_sender` tests updated to the new error-code + out-param signatures.

### Audit — wallet types still keeping the default ctor

| Type              | Why it stays                                                       |
|-------------------|--------------------------------------------------------------------|
| `bitcoin_uri`     | Builder pattern — default construct then setters.                  |
| `hd_public`       | Held by value as struct member in `wallet_manager::wallet_data::xpub`. |
| `stealth_address` | Held by value in `stealth_receiver::address_` (cascade left for a follow-up PR alongside the `.valid()` sweep). |

## Test plan

- [x] `cmake --build build/build/Release -j` for `c-api`, `domain`, `kth_infrastructure_test`, `kth_domain_test`, `kth_capi_test`
- [x] `kth_infrastructure_test` — 104452 assertions in 440 test cases pass
- [x] `kth_domain_test` — 1011106 assertions in 3871 test cases pass
- [x] `kth_capi_test` — 2816 assertions in 765 test cases pass