### PR TITLE
refactor(wallet): tighten ek_private surface

### DIFF
--- a/src/domain/include/kth/domain/wallet/ek_private.hpp
+++ b/src/domain/include/kth/domain/wallet/ek_private.hpp
@@ -17,8 +17,7 @@ namespace kth::domain::wallet {
 /**
  * Encrypted private key (BIP38).
  *
- * Default-constructible so the C-API generator can hand out an "empty"
- * handle; string parsing goes through `parse_from` which returns
+ * Fallible construction goes through `parse_from` which returns
  * `expect<ek_private>`.
  */
 struct KD_API ek_private {
@@ -26,25 +25,12 @@ struct KD_API ek_private {
     static
     expect<ek_private> parse_from(std::string_view encoded);
 
-    ek_private() = default;
-
     explicit
     ek_private(encrypted_private const& value)
-        : valid_(true), private_(value) {}
+        : private_(value) {}
 
     [[nodiscard]]
-    friend bool operator==(ek_private const&, ek_private const&) = default;
-
-    [[nodiscard]]
-    friend auto operator<=>(ek_private const& a, ek_private const& b) {
-        return a.to_string() <=> b.to_string();
-    }
-
-    [[nodiscard]]
-    bool valid() const noexcept { return valid_; }
-
-    [[nodiscard]]
-    encrypted_private const& value() const noexcept { return private_; }
+    friend auto operator<=>(ek_private const& a, ek_private const& b) = default;
 
     [[nodiscard]]
     encrypted_private const& private_key() const noexcept { return private_; }
@@ -54,8 +40,7 @@ struct KD_API ek_private {
     std::string to_string() const;
 
 private:
-    bool valid_{false};
-    encrypted_private private_{};
+    encrypted_private private_;
 };
 
 } // namespace kth::domain::wallet


### PR DESCRIPTION
## Summary

Four small, cohesive tightenings on the same type:

- **Drop `ek_private() = default`.** No in-tree caller relies on the default-constructed invalid state — every legitimate construction path already goes through `parse_from` (returning `expect<ek_private>`) or the explicit ctor from `encrypted_private`. After the drop the type is valid by construction.
- **Drop the `bool valid_` field and `.valid()` accessor.** With the default ctor gone `valid_` is always `true` and the check is dead code.
- **Drop the duplicated `value()` accessor** and keep the domain-named `private_key()`. Matches the `hd_private::secret()` / `hd_public::point()` convention already used elsewhere; the twin `value()` accessor was a legacy holdover.
- **Default `operator<=>` on the byte payload** instead of encoding to base58 and comparing strings. The entire state of `ek_private` is `private_` (a fixed-size `byte_array<43>`), so byte-lex comparison is equivalent to the base58-string order for this type (base58's alphabet preserves numeric order; encrypted payloads have no leading zero bytes). The defaulted spaceship is faster and reads as "just compare the state".
- **Drop the explicit `operator==`.** C++20 rewrites `==` from a defaulted `<=>`, so the explicit declaration is redundant.

C-API is intentionally left untouched — a bulk regen of the generated `.h`/`.cpp` surface will pick up the loss of `kth_wallet_ek_private_construct_default`, `.valid()`, and `.value()` in one pass at the end of the split. This PR does not build the C-API target on its own; meant to be reviewed on the domain diff and merged together with the rest of the #422 split.

Part of the #422 split.

## Test plan

- [ ] Bulk regen PR restores C-API build + tests
- [ ] `kth_domain_test` needs no adjustment