### PR TITLE
refactor(wallet): tighten ek_public surface

### DIFF
--- a/src/domain/include/kth/domain/wallet/ek_public.hpp
+++ b/src/domain/include/kth/domain/wallet/ek_public.hpp
@@ -17,8 +17,7 @@ namespace kth::domain::wallet {
 /**
  * Encrypted public key (BIP38).
  *
- * Default-constructible so the C-API generator can hand out an "empty"
- * handle; string parsing goes through `parse_from` which returns
+ * Fallible construction goes through `parse_from` which returns
  * `expect<ek_public>`.
  */
 struct KD_API ek_public {
@@ -26,25 +25,12 @@ struct KD_API ek_public {
     static
     expect<ek_public> parse_from(std::string_view encoded);
 
-    ek_public() = default;
-
     explicit
     ek_public(encrypted_public const& value)
-        : valid_(true), public_(value) {}
+        : public_(value) {}
 
     [[nodiscard]]
-    friend bool operator==(ek_public const&, ek_public const&) = default;
-
-    [[nodiscard]]
-    friend auto operator<=>(ek_public const& a, ek_public const& b) {
-        return a.to_string() <=> b.to_string();
-    }
-
-    [[nodiscard]]
-    bool valid() const noexcept { return valid_; }
-
-    [[nodiscard]]
-    encrypted_public const& value() const noexcept { return public_; }
+    friend auto operator<=>(ek_public const& a, ek_public const& b) = default;
 
     [[nodiscard]]
     encrypted_public const& public_key() const noexcept { return public_; }
@@ -53,8 +39,7 @@ struct KD_API ek_public {
     std::string to_string() const;
 
 private:
-    bool valid_{false};
-    encrypted_public public_{};
+    encrypted_public public_;
 };
 
 } // namespace kth::domain::wallet


### PR DESCRIPTION
## Summary

Mirror of the `ek_private` tightening (#423). Four small changes on the same type:

- **Drop `ek_public() = default`.** No in-tree caller relies on the default-constructed invalid state — construction goes through `parse_from` (returning `expect<ek_public>`) or the explicit ctor from `encrypted_public`. After the drop the type is valid by construction.
- **Drop the `bool valid_` field and `.valid()` accessor.** With the default ctor gone `valid_` is always `true` and the check is dead code.
- **Drop the duplicated `value()` accessor** and keep the domain-named `public_key()`. Matches the `hd_public::point()` / `hd_private::secret()` convention already used elsewhere.
- **Default `operator<=>` on the byte payload** instead of encoding to base58 and comparing strings. The entire state of `ek_public` is `public_` (a fixed-size `byte_array`), so byte-lex comparison is equivalent to the base58-string order for this type; the defaulted spaceship is faster and reads as "just compare the state". Also drops the explicit `operator==`, which C++20 auto-generates from a defaulted `<=>`.

C-API is intentionally left untouched — a bulk regen of the generated `.h`/`.cpp` surface will pick up the loss of `kth_wallet_ek_public_construct_default`, `.valid()`, and `.value()` in one pass at the end of the split. This PR does not build the C-API target on its own; meant to be reviewed on the domain diff and merged together with the rest of the #422 split.

Part of the #422 split.

## Test plan

- [ ] Bulk regen PR restores C-API build + tests
- [ ] `kth_domain_test` needs no adjustment