### PR TITLE
refactor(wallet): tighten ek_token surface

### DIFF
--- a/src/domain/include/kth/domain/wallet/ek_token.hpp
+++ b/src/domain/include/kth/domain/wallet/ek_token.hpp
@@ -17,8 +17,7 @@ namespace kth::domain::wallet {
 /**
  * BIP38 intermediate passphrase token.
  *
- * Default-constructible so the C-API generator can hand out an "empty"
- * handle; string parsing goes through `parse_from` which returns
+ * Fallible construction goes through `parse_from` which returns
  * `expect<ek_token>`.
  */
 struct KD_API ek_token {
@@ -26,25 +25,12 @@ struct KD_API ek_token {
     static
     expect<ek_token> parse_from(std::string_view encoded);
 
-    ek_token() = default;
-
     explicit
     ek_token(encrypted_token const& value)
-        : valid_(true), token_(value) {}
+        : token_(value) {}
 
     [[nodiscard]]
-    friend bool operator==(ek_token const&, ek_token const&) = default;
-
-    [[nodiscard]]
-    friend auto operator<=>(ek_token const& a, ek_token const& b) {
-        return a.to_string() <=> b.to_string();
-    }
-
-    [[nodiscard]]
-    bool valid() const noexcept { return valid_; }
-
-    [[nodiscard]]
-    encrypted_token const& value() const noexcept { return token_; }
+    friend auto operator<=>(ek_token const& a, ek_token const& b) = default;
 
     [[nodiscard]]
     encrypted_token const& token() const noexcept { return token_; }
@@ -53,8 +39,7 @@ struct KD_API ek_token {
     std::string to_string() const;
 
 private:
-    bool valid_{false};
-    encrypted_token token_{};
+    encrypted_token token_;
 };
 
 } // namespace kth::domain::wallet


### PR DESCRIPTION
## Summary

Mirror of the `ek_private` (#423) and `ek_public` (#424) tightenings. Four small changes on the same type:

- **Drop `ek_token() = default`.** No in-tree caller relies on the default-constructed invalid state — construction goes through `parse_from` (returning `expect<ek_token>`) or the explicit ctor from `encrypted_token`. After the drop the type is valid by construction.
- **Drop the `bool valid_` field and `.valid()` accessor.** With the default ctor gone `valid_` is always `true` and the check is dead code.
- **Drop the duplicated `value()` accessor** and keep the domain-named `token()`. Matches the `hd_public::point()` / `hd_private::secret()` convention already used elsewhere.
- **Default `operator<=>` on the byte payload** instead of encoding to base58 and comparing strings. The entire state of `ek_token` is `token_` (a fixed-size `byte_array`), so byte-lex comparison is equivalent to the base58-string order for this type; the defaulted spaceship is faster and reads as "just compare the state". Also drops the explicit `operator==`, which C++20 auto-generates from a defaulted `<=>`.

C-API is intentionally left untouched — a bulk regen of the generated `.h`/`.cpp` surface will pick up the loss of `kth_wallet_ek_token_construct_default`, `.valid()`, and `.value()` in one pass at the end of the split. This PR does not build the C-API target on its own; meant to be reviewed on the domain diff and merged together with the rest of the #422 split.

Part of the #422 split.

## Test plan

- [ ] Bulk regen PR restores C-API build + tests
- [ ] `kth_domain_test` needs no adjustment