### PR TITLE
refactor(wallet): tighten hd_private ownership

### DIFF
--- a/src/domain/include/kth/domain/wallet/hd_private.hpp
+++ b/src/domain/include/kth/domain/wallet/hd_private.hpp
@@ -25,10 +25,17 @@ uint64_t to_prefixes(uint32_t private_prefix, uint32_t public_prefix) {
 /**
  * BIP32 extended private key.
  *
- * Derives from `hd_public`. Default-constructible so callers that hold
- * an `hd_private` as a struct member can fill it later via assignment;
- * fallible construction goes through the `parse_from`-family static
- * factories, which return `expect<hd_private>`.
+ * Derives from `hd_public`. Fallible construction goes through the
+ * `parse_from`-family and `from_*` static factories, all returning
+ * `expect<hd_private>`. Failure of the private `_impl` factories is
+ * signalled internally by a default-constructed invalid instance
+ * whose inherited `.valid()` returns false; the default ctor is kept
+ * `private` so this sentinel only exists inside the class.
+ *
+ * Fully dropping the private default ctor is deferred to the
+ * `hd_public` refactor PR — it would require zeroing the inherited
+ * `hd_public` members directly, which crosses that class's
+ * encapsulation boundary.
  */
 struct KD_API hd_private : hd_public {
     static constexpr uint64_t mainnet = to_prefixes(76066276, hd_public::mainnet);
@@ -57,29 +64,35 @@ struct KD_API hd_private : hd_public {
     static
     expect<hd_private> parse_from_with_prefixes(std::string_view encoded, uint64_t prefixes);
 
-    hd_private() = default;
-    hd_private& operator=(hd_private x);
+    /// Derive a key from a random seed under a caller-supplied
+    /// prefix pair. Fallible on malformed / empty seed input.
+    [[nodiscard]]
+    static
+    expect<hd_private> from_seed(data_chunk const& seed, uint64_t prefixes);
 
-    explicit
-    hd_private(data_chunk const& seed, uint64_t prefixes = mainnet);
+    /// Wrap an already-decoded 82-byte hd key using the default
+    /// mainnet public prefix.
+    [[nodiscard]]
+    static
+    expect<hd_private> from_hd_key(hd_key const& key);
 
-    explicit
-    hd_private(hd_key const& private_key);
+    /// Wrap an already-decoded 82-byte hd key with a caller-supplied
+    /// public-side prefix. Named distinctly from
+    /// `from_hd_key_with_prefixes` so C++ integer promotion at the
+    /// call site can never pick the wrong overload (`uint32_t` ↔
+    /// `uint64_t` overlap silently otherwise).
+    [[nodiscard]]
+    static
+    expect<hd_private> from_hd_key_with_public_prefix(hd_key const& key, uint32_t public_prefix);
 
-    hd_private(hd_key const& private_key, uint64_t prefixes);
-    hd_private(hd_key const& private_key, uint32_t prefix);
+    /// Wrap an already-decoded 82-byte hd key with a caller-supplied
+    /// prefix pair.
+    [[nodiscard]]
+    static
+    expect<hd_private> from_hd_key_with_prefixes(hd_key const& key, uint64_t prefixes);
 
     [[nodiscard]]
-    friend bool operator==(hd_private const&, hd_private const&) = default;
-
-    [[nodiscard]]
-    friend auto operator<=>(hd_private const& a, hd_private const& b) {
-        return a.to_string() <=> b.to_string();
-    }
-
-    // Swap implementation required to properly handle base class.
-    friend
-    void swap(hd_private& left, hd_private& right);
+    friend auto operator<=>(hd_private const& a, hd_private const& b) = default;
 
     [[nodiscard]]
     ec_secret const& secret() const noexcept { return secret_; }
@@ -95,16 +108,25 @@ struct KD_API hd_private : hd_public {
     hd_public to_public() const;
 
     [[nodiscard]]
-    hd_private derive_private(uint32_t index) const;
+    expect<hd_private> derive_private(uint32_t index) const;
 
     [[nodiscard]]
-    hd_public derive_public(uint32_t index) const;
+    expect<hd_public> derive_public(uint32_t index) const;
+
+    /// Reset every field to the default zero state. Used by
+    /// wallet_manager to overwrite the intermediate derivation keys
+    /// once the leaf public key has been captured.
+    void wipe() noexcept;
 
 private:
-    static hd_private from_seed(byte_span seed, uint64_t prefixes);
-    static hd_private from_key(hd_key const& decoded);
-    static hd_private from_key(hd_key const& key, uint32_t public_prefix);
-    static hd_private from_key(hd_key const& key, uint64_t prefixes);
+    // Sentinel default ctor: internal-only. The private factories
+    // below return an invalid instance built via this on failure,
+    // which the inherited `.valid()` reports as false.
+    hd_private() = default;
+
+    static hd_private from_seed_impl(byte_span seed, uint64_t prefixes);
+    static hd_private from_hd_key_impl(hd_key const& key, uint32_t public_prefix);
+    static hd_private from_hd_key_impl(hd_key const& key, uint64_t prefixes);
 
     hd_private(ec_secret const& secret, hd_chain_code const& chain_code, hd_lineage const& lineage);
 

--- a/src/domain/include/kth/domain/wallet/hd_public.hpp
+++ b/src/domain/include/kth/domain/wallet/hd_public.hpp
@@ -63,12 +63,7 @@ struct KD_API hd_public {
     hd_public(hd_key const& public_key, uint32_t prefix);
 
     [[nodiscard]]
-    friend bool operator==(hd_public const&, hd_public const&) = default;
-
-    [[nodiscard]]
-    friend auto operator<=>(hd_public const& a, hd_public const& b) {
-        return a.to_string() <=> b.to_string();
-    }
+    friend auto operator<=>(hd_public const& a, hd_public const& b) = default;
 
     [[nodiscard]]
     bool valid() const noexcept { return valid_; }
@@ -90,7 +85,7 @@ struct KD_API hd_public {
     hd_key to_hd_key() const;
 
     [[nodiscard]]
-    hd_public derive_public(uint32_t index) const;
+    expect<hd_public> derive_public(uint32_t index) const;
 
 protected:
     static

--- a/src/domain/src/wallet/hd_private.cpp
+++ b/src/domain/src/wallet/hd_private.cpp
@@ -24,23 +24,6 @@
 
 namespace kth::domain::wallet {
 
-hd_private::hd_private(data_chunk const& seed, uint64_t prefixes)
-    : hd_private(from_seed(seed, prefixes))
-{}
-
-// This reads the private version and sets the public to mainnet.
-hd_private::hd_private(hd_key const& private_key)
-    : hd_private(from_key(private_key, hd_public::mainnet))
-{}
-
-hd_private::hd_private(hd_key const& private_key, uint32_t prefix)
-    : hd_private(from_key(private_key, prefix))
-{}
-
-hd_private::hd_private(hd_key const& private_key, uint64_t prefixes)
-    : hd_private(from_key(private_key, prefixes))
-{}
-
 hd_private::hd_private(ec_secret const& secret, hd_chain_code const& chain_code, hd_lineage const& lineage)
     : hd_public(from_secret(secret, chain_code, lineage))
     , secret_(secret)
@@ -62,12 +45,7 @@ expect<hd_private> hd_private::parse_from_with_public_prefix(std::string_view en
     if ( ! decode_base58(key, std::string{encoded})) {
         return std::unexpected(kth::error::illegal_value);
     }
-
-    hd_private out = from_key(key, public_prefix);
-    if ( ! out.valid()) {
-        return std::unexpected(kth::error::illegal_value);
-    }
-    return out;
+    return from_hd_key_with_public_prefix(key, public_prefix);
 }
 
 // static
@@ -76,15 +54,42 @@ expect<hd_private> hd_private::parse_from_with_prefixes(std::string_view encoded
     if ( ! decode_base58(key, std::string{encoded})) {
         return std::unexpected(kth::error::illegal_value);
     }
+    return from_hd_key_with_prefixes(key, prefixes);
+}
 
-    hd_private out{key, prefixes};
+// static
+expect<hd_private> hd_private::from_seed(data_chunk const& seed, uint64_t prefixes) {
+    hd_private out = from_seed_impl(seed, prefixes);
     if ( ! out.valid()) {
         return std::unexpected(kth::error::illegal_value);
     }
     return out;
 }
 
-hd_private hd_private::from_seed(byte_span seed, uint64_t prefixes) {
+// static
+expect<hd_private> hd_private::from_hd_key(hd_key const& key) {
+    return from_hd_key_with_public_prefix(key, hd_public::mainnet);
+}
+
+// static
+expect<hd_private> hd_private::from_hd_key_with_public_prefix(hd_key const& key, uint32_t public_prefix) {
+    hd_private out = from_hd_key_impl(key, public_prefix);
+    if ( ! out.valid()) {
+        return std::unexpected(kth::error::illegal_value);
+    }
+    return out;
+}
+
+// static
+expect<hd_private> hd_private::from_hd_key_with_prefixes(hd_key const& key, uint64_t prefixes) {
+    hd_private out = from_hd_key_impl(key, prefixes);
+    if ( ! out.valid()) {
+        return std::unexpected(kth::error::illegal_value);
+    }
+    return out;
+}
+
+hd_private hd_private::from_seed_impl(byte_span seed, uint64_t prefixes) {
     // This is a magic constant from BIP32.
     static data_chunk const magic(to_chunk("Bitcoin seed"));
 
@@ -105,12 +110,12 @@ hd_private hd_private::from_seed(byte_span seed, uint64_t prefixes) {
     return hd_private(intermediate.left, intermediate.right, master);
 }
 
-hd_private hd_private::from_key(hd_key const& key, uint32_t public_prefix) {
+hd_private hd_private::from_hd_key_impl(hd_key const& key, uint32_t public_prefix) {
     auto const prefix = from_big_endian_unsafe<uint32_t>(key);
-    return from_key(key, to_prefixes(prefix, public_prefix));
+    return from_hd_key_impl(key, to_prefixes(prefix, public_prefix));
 }
 
-hd_private hd_private::from_key(hd_key const& key, uint64_t prefixes) {
+hd_private hd_private::from_hd_key_impl(hd_key const& key, uint64_t prefixes) {
     byte_reader reader(key);
 
     auto const prefix = reader.read_big_endian<uint32_t>();
@@ -194,7 +199,7 @@ hd_public hd_private::to_public() const {
         hd_public::to_prefix(lineage_.prefixes));
 }
 
-hd_private hd_private::derive_private(uint32_t index) const {
+expect<hd_private> hd_private::derive_private(uint32_t index) const {
     constexpr uint8_t depth = 0;
 
     auto const data = (index >= hd_first_hardened_key) ?
@@ -206,11 +211,11 @@ hd_private hd_private::derive_private(uint32_t index) const {
     // The child key ki is (parse256(IL) + kpar) mod n:
     auto child = secret_;
     if ( ! ec_add(child, intermediate.left)) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     if (lineage_.depth == max_uint8) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     hd_lineage const lineage {
@@ -223,25 +228,16 @@ hd_private hd_private::derive_private(uint32_t index) const {
     return hd_private(child, intermediate.right, lineage);
 }
 
-hd_public hd_private::derive_public(uint32_t index) const {
-    return derive_private(index).to_public();
+expect<hd_public> hd_private::derive_public(uint32_t index) const {
+    auto child = derive_private(index);
+    if ( ! child) {
+        return std::unexpected(child.error());
+    }
+    return child->to_public();
 }
 
-// Operators.
-// ----------------------------------------------------------------------------
-
-hd_private& hd_private::operator=(hd_private x) {
-    swap(*this, x);
-    return *this;
-}
-
-// friend function, see: stackoverflow.com/a/5695855/1172329
-void swap(hd_private& left, hd_private& right) {
-    using std::swap;
-
-    // Must be unqualified (no std namespace).
-    swap(static_cast<hd_public&>(left), static_cast<hd_public&>(right));
-    swap(left.secret_, right.secret_);
+void hd_private::wipe() noexcept {
+    *this = hd_private{};
 }
 
 } // namespace kth::domain::wallet

--- a/src/domain/src/wallet/hd_public.cpp
+++ b/src/domain/src/wallet/hd_public.cpp
@@ -162,9 +162,9 @@ hd_key hd_public::to_hd_key() const {
     return out;
 }
 
-hd_public hd_public::derive_public(uint32_t index) const {
+expect<hd_public> hd_public::derive_public(uint32_t index) const {
     if (index >= hd_first_hardened_key) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     auto const data = splice(point_, to_big_endian(index));
@@ -173,11 +173,11 @@ hd_public hd_public::derive_public(uint32_t index) const {
     // The returned child key Ki is point(parse256(IL)) + Kpar.
     auto combined = point_;
     if ( ! ec_add(combined, intermediate.left)) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     if (lineage_.depth == max_uint8) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     hd_lineage const lineage {

--- a/src/domain/src/wallet/wallet_manager.cpp
+++ b/src/domain/src/wallet/wallet_manager.cpp
@@ -31,13 +31,6 @@ hash_digest derive_key(std::string const& password, std::array<uint8_t, default_
     return key;
 }
 
-template <typename T>
-void clear_hd(T& hd) {
-    using std::swap;
-    T tmp;
-    swap(hd, tmp);
-}
-
 std::expected<wallet_data, std::error_code>
 create(
     std::string const& password,
@@ -65,18 +58,28 @@ create(
 
     data_chunk seed_chunk(seed.begin(), seed.end());
 
-    hd_private m(seed_chunk, hd_private::mainnet);
+    auto master = hd_private::from_seed(seed_chunk, hd_private::mainnet);
     std::fill(seed_chunk.begin(), seed_chunk.end(), 0);
-    hd_private m44h = m.derive_private(44 + hd_first_hardened_key);
-    hd_private m44h145h = m44h.derive_private(145 + hd_first_hardened_key);
-    hd_private m44h145h0h = m44h145h.derive_private(0 + hd_first_hardened_key);
+    if ( ! master) {
+        return std::unexpected(master.error());
+    }
+    hd_private m = std::move(*master);
+    auto d1 = m.derive_private(44 + hd_first_hardened_key);
+    if ( ! d1) return std::unexpected(d1.error());
+    hd_private m44h = std::move(*d1);
+    auto d2 = m44h.derive_private(145 + hd_first_hardened_key);
+    if ( ! d2) return std::unexpected(d2.error());
+    hd_private m44h145h = std::move(*d2);
+    auto d3 = m44h145h.derive_private(0 + hd_first_hardened_key);
+    if ( ! d3) return std::unexpected(d3.error());
+    hd_private m44h145h0h = std::move(*d3);
     hd_public pub = m44h145h0h.to_public();
 
-    // erase all the intermediate hd_private and hd_public objects
-    clear_hd(m);
-    clear_hd(m44h);
-    clear_hd(m44h145h);
-    clear_hd(m44h145h0h);
+    // erase all the intermediate hd_private objects
+    m.wipe();
+    m44h.wipe();
+    m44h145h.wipe();
+    m44h145h0h.wipe();
 
     auto const salt = generate_salt();
     auto const iv = generate_salt<default_iv_size>();

--- a/src/domain/test/wallet/hd_private.cpp
+++ b/src/domain/test/wallet/hd_private.cpp
@@ -28,12 +28,14 @@ TEST_CASE("hd private derive private short seed expected", "[hd private tests]")
     auto const seed = decode_base16(short_seed);
     REQUIRE(seed);
 
-    hd_private const m(*seed, hd_private::mainnet);
-    auto const m0h = m.derive_private(hd_first_hardened_key);
-    auto const m0h1 = m0h.derive_private(1);
-    auto const m0h12h = m0h1.derive_private(2 + hd_first_hardened_key);
-    auto const m0h12h2 = m0h12h.derive_private(2);
-    auto const m0h12h2x = m0h12h2.derive_private(1000000000);
+    auto const m_r = hd_private::from_seed(*seed, hd_private::mainnet);
+    REQUIRE(m_r);
+    auto const& m = *m_r;
+    auto const m0h = m.derive_private(hd_first_hardened_key).value();
+    auto const m0h1 = m0h.derive_private(1).value();
+    auto const m0h12h = m0h1.derive_private(2 + hd_first_hardened_key).value();
+    auto const m0h12h2 = m0h12h.derive_private(2).value();
+    auto const m0h12h2x = m0h12h2.derive_private(1000000000).value();
 
     REQUIRE(m.to_string() == "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi");
     REQUIRE(m0h.to_string() == "xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7");
@@ -47,19 +49,21 @@ TEST_CASE("hd private derive public short seed expected", "[hd private tests]") 
     auto const seed = decode_base16(short_seed);
     REQUIRE(seed);
 
-    hd_private const m(*seed, hd_private::mainnet);
-    auto const m0h = m.derive_private(hd_first_hardened_key);
-    auto const m0h1 = m0h.derive_private(1);
-    auto const m0h12h = m0h1.derive_private(2 + hd_first_hardened_key);
-    auto const m0h12h2 = m0h12h.derive_private(2);
-    auto const m0h12h2x = m0h12h2.derive_private(1000000000);
+    auto const m_r = hd_private::from_seed(*seed, hd_private::mainnet);
+    REQUIRE(m_r);
+    auto const& m = *m_r;
+    auto const m0h = m.derive_private(hd_first_hardened_key).value();
+    auto const m0h1 = m0h.derive_private(1).value();
+    auto const m0h12h = m0h1.derive_private(2 + hd_first_hardened_key).value();
+    auto const m0h12h2 = m0h12h.derive_private(2).value();
+    auto const m0h12h2x = m0h12h2.derive_private(1000000000).value();
 
     hd_public m_pub = m;
-    auto const m0h_pub = m.derive_public(hd_first_hardened_key);
-    auto const m0h1_pub = m0h.derive_public(1);
-    auto const m0h12h_pub = m0h1.derive_public(2 + hd_first_hardened_key);
-    auto const m0h12h2_pub = m0h12h.derive_public(2);
-    auto const m0h12h2x_pub = m0h12h2.derive_public(1000000000);
+    auto const m0h_pub = m.derive_public(hd_first_hardened_key).value();
+    auto const m0h1_pub = m0h.derive_public(1).value();
+    auto const m0h12h_pub = m0h1.derive_public(2 + hd_first_hardened_key).value();
+    auto const m0h12h2_pub = m0h12h.derive_public(2).value();
+    auto const m0h12h2x_pub = m0h12h2.derive_public(1000000000).value();
 
     REQUIRE(m_pub.to_string() == "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8");
     REQUIRE(m0h_pub.to_string() == "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw");
@@ -73,12 +77,14 @@ TEST_CASE("hd private derive private long seed expected", "[hd private tests]") 
     auto const seed = decode_base16(long_seed);
     REQUIRE(seed);
 
-    hd_private const m(*seed, hd_private::mainnet);
-    auto const m0 = m.derive_private(0);
-    auto const m0xH = m0.derive_private(2147483647 + hd_first_hardened_key);
-    auto const m0xH1 = m0xH.derive_private(1);
-    auto const m0xH1yH = m0xH1.derive_private(2147483646 + hd_first_hardened_key);
-    auto const m0xH1yH2 = m0xH1yH.derive_private(2);
+    auto const m_r = hd_private::from_seed(*seed, hd_private::mainnet);
+    REQUIRE(m_r);
+    auto const& m = *m_r;
+    auto const m0 = m.derive_private(0).value();
+    auto const m0xH = m0.derive_private(2147483647 + hd_first_hardened_key).value();
+    auto const m0xH1 = m0xH.derive_private(1).value();
+    auto const m0xH1yH = m0xH1.derive_private(2147483646 + hd_first_hardened_key).value();
+    auto const m0xH1yH2 = m0xH1yH.derive_private(2).value();
 
     REQUIRE(m.to_string() == "xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U");
     REQUIRE(m0.to_string() == "xprv9vHkqa6EV4sPZHYqZznhT2NPtPCjKuDKGY38FBWLvgaDx45zo9WQRUT3dKYnjwih2yJD9mkrocEZXo1ex8G81dwSM1fwqWpWkeS3v86pgKt");
@@ -92,19 +98,21 @@ TEST_CASE("hd private derive public long seed expected", "[hd private tests]") {
     auto const seed = decode_base16(long_seed);
     REQUIRE(seed);
 
-    hd_private const m(*seed, hd_private::mainnet);
-    auto const m0 = m.derive_private(0);
-    auto const m0xH = m0.derive_private(2147483647 + hd_first_hardened_key);
-    auto const m0xH1 = m0xH.derive_private(1);
-    auto const m0xH1yH = m0xH1.derive_private(2147483646 + hd_first_hardened_key);
-    auto const m0xH1yH2 = m0xH1yH.derive_private(2);
+    auto const m_r = hd_private::from_seed(*seed, hd_private::mainnet);
+    REQUIRE(m_r);
+    auto const& m = *m_r;
+    auto const m0 = m.derive_private(0).value();
+    auto const m0xH = m0.derive_private(2147483647 + hd_first_hardened_key).value();
+    auto const m0xH1 = m0xH.derive_private(1).value();
+    auto const m0xH1yH = m0xH1.derive_private(2147483646 + hd_first_hardened_key).value();
+    auto const m0xH1yH2 = m0xH1yH.derive_private(2).value();
 
     hd_public m_pub = m;
-    auto const m0_pub = m.derive_public(0);
-    auto const m0xH_pub = m0.derive_public(2147483647 + hd_first_hardened_key);
-    auto const m0xH1_pub = m0xH.derive_public(1);
-    auto const m0xH1yH_pub = m0xH1.derive_public(2147483646 + hd_first_hardened_key);
-    auto const m0xH1yH2_pub = m0xH1yH.derive_public(2);
+    auto const m0_pub = m.derive_public(0).value();
+    auto const m0xH_pub = m0.derive_public(2147483647 + hd_first_hardened_key).value();
+    auto const m0xH1_pub = m0xH.derive_public(1).value();
+    auto const m0xH1yH_pub = m0xH1.derive_public(2147483646 + hd_first_hardened_key).value();
+    auto const m0xH1yH2_pub = m0xH1yH.derive_public(2).value();
 
     REQUIRE(m_pub.to_string() == "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB");
     REQUIRE(m0_pub.to_string() == "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH");

--- a/src/domain/test/wallet/hd_public.cpp
+++ b/src/domain/test/wallet/hd_public.cpp
@@ -21,9 +21,11 @@ TEST_CASE("hd public derive public invalid false", "[hd public tests]") {
     auto const seed = decode_base16(short_seed);
     REQUIRE(seed);
 
-    hd_private const m(*seed, hd_private::mainnet);
+    auto const m_r = hd_private::from_seed(*seed, hd_private::mainnet);
+    REQUIRE(m_r);
+    auto const& m = *m_r;
     hd_public const m_pub = m;
-    REQUIRE( ! m_pub.derive_public(hd_first_hardened_key).valid());
+    REQUIRE( ! m_pub.derive_public(hd_first_hardened_key));
 }
 
 TEST_CASE("hd public encoded round trip expected", "[hd public tests]") {
@@ -37,16 +39,18 @@ TEST_CASE("hd public derive public short seed expected", "[hd public tests]") {
     auto const seed = decode_base16(short_seed);
     REQUIRE(seed);
 
-    hd_private const m(*seed, hd_private::mainnet);
-    auto const m0h = m.derive_private(hd_first_hardened_key);
-    auto const m0h1 = m0h.derive_private(1);
+    auto const m_r = hd_private::from_seed(*seed, hd_private::mainnet);
+    REQUIRE(m_r);
+    auto const& m = *m_r;
+    auto const m0h = m.derive_private(hd_first_hardened_key).value();
+    auto const m0h1 = m0h.derive_private(1).value();
 
     hd_public const m_pub = m;
-    auto const m0h_pub = m.derive_public(hd_first_hardened_key);
-    auto const m0h1_pub = m0h_pub.derive_public(1);
-    auto const m0h12h_pub = m0h1.derive_public(2 + hd_first_hardened_key);
-    auto const m0h12h2_pub = m0h12h_pub.derive_public(2);
-    auto const m0h12h2x_pub = m0h12h2_pub.derive_public(1000000000);
+    auto const m0h_pub = m.derive_public(hd_first_hardened_key).value();
+    auto const m0h1_pub = m0h_pub.derive_public(1).value();
+    auto const m0h12h_pub = m0h1.derive_public(2 + hd_first_hardened_key).value();
+    auto const m0h12h2_pub = m0h12h_pub.derive_public(2).value();
+    auto const m0h12h2x_pub = m0h12h2_pub.derive_public(1000000000).value();
 
     REQUIRE(m_pub.to_string() == "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8");
     REQUIRE(m0h_pub.to_string() == "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw");
@@ -60,17 +64,19 @@ TEST_CASE("hd public derive public long seed expected", "[hd public tests]") {
     auto const seed = decode_base16(long_seed);
     REQUIRE(seed);
 
-    hd_private const m(*seed, hd_private::mainnet);
-    auto const m0 = m.derive_private(0);
-    auto const m0xH = m0.derive_private(2147483647 + hd_first_hardened_key);
-    auto const m0xH1 = m0xH.derive_private(1);
+    auto const m_r = hd_private::from_seed(*seed, hd_private::mainnet);
+    REQUIRE(m_r);
+    auto const& m = *m_r;
+    auto const m0 = m.derive_private(0).value();
+    auto const m0xH = m0.derive_private(2147483647 + hd_first_hardened_key).value();
+    auto const m0xH1 = m0xH.derive_private(1).value();
 
     hd_public const m_pub = m;
-    auto const m0_pub = m_pub.derive_public(0);
-    auto const m0xH_pub = m0.derive_public(2147483647 + hd_first_hardened_key);
-    auto const m0xH1_pub = m0xH_pub.derive_public(1);
-    auto const m0xH1yH_pub = m0xH1.derive_public(2147483646 + hd_first_hardened_key);
-    auto const m0xH1yH2_pub = m0xH1yH_pub.derive_public(2);
+    auto const m0_pub = m_pub.derive_public(0).value();
+    auto const m0xH_pub = m0.derive_public(2147483647 + hd_first_hardened_key).value();
+    auto const m0xH1_pub = m0xH_pub.derive_public(1).value();
+    auto const m0xH1yH_pub = m0xH1.derive_public(2147483646 + hd_first_hardened_key).value();
+    auto const m0xH1yH2_pub = m0xH1yH_pub.derive_public(2).value();
 
     REQUIRE(m_pub.to_string() == "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB");
     REQUIRE(m0_pub.to_string() == "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH");

--- a/src/domain/test/wallet/transaction_functions.cpp
+++ b/src/domain/test/wallet/transaction_functions.cpp
@@ -24,9 +24,10 @@ constexpr char complete_tx[] = "01000000019373b022dfb99400ee40b8987586aea9e158f3
 
 kth::ec_secret create_secret_from_seed(std::string const& seed_str) {
     auto seed = kth::decode_base16(seed_str);
-    hd_private const key(*seed);
+    auto const key = hd_private::from_seed(*seed, hd_private::mainnet);
+    REQUIRE(key);
     // Secret key
-    kth::ec_secret secret_key(key.secret());
+    kth::ec_secret secret_key(key->secret());
     return secret_key;
 }
 


### PR DESCRIPTION
## Summary

Applies the "valid by construction" pattern to `hd_private` and folds four review comments from the initial pass:

- **Drop the public `hd_private() = default`.** Internal factories (`from_seed_impl`, `from_hd_key_impl`, `derive_private`) still signal failure by returning a default-constructed sentinel whose `.valid()` is false, so a default ctor still has to exist. Move it to `private:` so the sentinel is an internal detail and external callers cannot construct an "empty" `hd_private`.
- **Add `void hd_private::wipe() noexcept`**, implemented as `*this = hd_private{}` (the private ctor is reachable from a member). Replaces the `clear_hd<T>` template in `wallet_manager`; the template was generic but only ever instantiated on `hd_private` and the new member expresses the intent more directly.
- **Drop the hand-written `operator=(hd_private x)` and the friend `swap(hd_private&, hd_private&)`.** The class has no non-trivial members, so the compiler-generated `operator=` handles the base class correctly. `wipe()` no longer needs the friend swap since it uses `*this = ...` directly.
- **Replace the four error-prone public ctors** (`data_chunk`+prefixes, `hd_key`, `hd_key`+`uint32_t`, `hd_key`+`uint64_t`) with named static factories returning `expect<hd_private>`. The uint32/uint64 overload pair is particularly hazardous — C++ integer promotion can silently pick the wrong ctor at the call site (the parallel `parse_from_with_public_prefix` / `parse_from_with_prefixes` factories already carry the same warning). New factories:
  - `hd_private::from_seed(data_chunk, uint64_t)`
  - `hd_private::from_hd_key(hd_key)` (implicit mainnet public prefix)
  - `hd_private::from_hd_key_with_public_prefix(hd_key, uint32_t)`
  - `hd_private::from_hd_key_with_prefixes(hd_key, uint64_t)`
  
  The private helpers keep the `_impl` suffix so the public names don't clash in class scope.
- **Default `operator<=>` on both `hd_public` and `hd_private`** instead of encoding to base58 via `to_string()` and comparing strings. Members are all byte arrays (`hd_chain_code<32>`, `ec_compressed<33>`, `ec_secret`) plus the already-defaulted `hd_lineage`; byte-lex comparison is a valid canonical order and is orders of magnitude faster than the encode-then-strcmp round-trip. Also drops the now-redundant explicit `operator==` (C++20 auto-generates `==` from a defaulted `<=>`).
- **Widen the three derive-family methods to `expect<>` returns.** All three could silently produce an invalid instance through the sentinel dance: `hd_private::derive_private(index)` on `ec_add` failure or depth-overflow (the two BIP32 CKD failure modes), `hd_private::derive_public(index)` inheriting that failure via `to_public()`, and `hd_public::derive_public(index)` with the additional legitimate "hardened index rejected" failure. New signatures:
  - `hd_private::derive_private(uint32_t) -> expect<hd_private>`
  - `hd_private::derive_public(uint32_t) -> expect<hd_public>`
  - `hd_public::derive_public(uint32_t) -> expect<hd_public>`

  The other four query methods on `hd_private` (`to_string`, `to_hd_key`, `to_public`) stay non-`expect<>` — they are pure serialisation over the fixed-size in-memory state and cannot fail once the type is valid by construction.

Adjusts the callers of both the removed ctors and the widened derive family across `wallet_manager` and the domain hd tests.

C-API is intentionally left untouched — a bulk regen of the generated `.h`/`.cpp` surface will pick up the loss of `kth_wallet_hd_private_construct_default`, the renamed factories, and the widened derive signatures in one pass at the end of the split. This PR does not build the C-API target on its own; meant to be reviewed on the domain diff and merged together with the rest of the #422 split.

Part of the #422 split.

## Test plan

- [x] `kth_domain_test` passes locally (1_011_113 assertions in 3872 test cases)
- [ ] Bulk regen PR restores C-API build + tests