### PR TITLE
refactor(wallet): make hd_public + hd_private valid-by-construction

### DIFF
--- a/src/domain/include/kth/domain/wallet/hd_private.hpp
+++ b/src/domain/include/kth/domain/wallet/hd_private.hpp
@@ -22,14 +22,9 @@ uint64_t to_prefixes(uint32_t private_prefix, uint32_t public_prefix) {
     return uint64_t(private_prefix) << 32 | public_prefix;
 }
 
-/**
- * BIP32 extended private key.
- *
- * Derives from `hd_public`. Default-constructible so callers that hold
- * an `hd_private` as a struct member can fill it later via assignment;
- * fallible construction goes through the `parse_from`-family static
- * factories, which return `expect<hd_private>`.
- */
+/// BIP32 extended private key. Valid-by-construction: every reachable
+/// instance was produced by a factory that validated its inputs, so
+/// accessors and derivations are always meaningful.
 struct KD_API hd_private : hd_public {
     static constexpr uint64_t mainnet = to_prefixes(76066276, hd_public::mainnet);
     static constexpr uint64_t testnet = to_prefixes(70615956, hd_public::testnet);
@@ -57,29 +52,29 @@ struct KD_API hd_private : hd_public {
     static
     expect<hd_private> parse_from_with_prefixes(std::string_view encoded, uint64_t prefixes);
 
-    hd_private() = default;
-    hd_private& operator=(hd_private x);
+    /// Derive a master key from a seed against a caller-supplied
+    /// prefix pair (packed as `to_prefixes(private, public)`).
+    [[nodiscard]]
+    static
+    expect<hd_private> from_seed(data_chunk const& seed, uint64_t prefixes);
 
-    explicit
-    hd_private(data_chunk const& seed, uint64_t prefixes = mainnet);
+    /// Wrap an already-decoded 82-byte hd key, reading its private
+    /// prefix off the wire and pairing it with a caller-supplied
+    /// public prefix. Named distinctly from `from_hd_key_with_prefixes`
+    /// so the `uint32_t` / `uint64_t` overloads can't collide via
+    /// implicit promotion at the call site.
+    [[nodiscard]]
+    static
+    expect<hd_private> from_hd_key_with_public_prefix(hd_key const& private_key, uint32_t public_prefix);
 
-    explicit
-    hd_private(hd_key const& private_key);
-
-    hd_private(hd_key const& private_key, uint64_t prefixes);
-    hd_private(hd_key const& private_key, uint32_t prefix);
+    /// Wrap an already-decoded 82-byte hd key against a caller-
+    /// supplied prefix pair.
+    [[nodiscard]]
+    static
+    expect<hd_private> from_hd_key_with_prefixes(hd_key const& private_key, uint64_t prefixes);
 
     [[nodiscard]]
-    friend bool operator==(hd_private const&, hd_private const&) = default;
-
-    [[nodiscard]]
-    friend auto operator<=>(hd_private const& a, hd_private const& b) {
-        return a.to_string() <=> b.to_string();
-    }
-
-    // Swap implementation required to properly handle base class.
-    friend
-    void swap(hd_private& left, hd_private& right);
+    friend auto operator<=>(hd_private const&, hd_private const&) = default;
 
     [[nodiscard]]
     ec_secret const& secret() const noexcept { return secret_; }
@@ -95,18 +90,19 @@ struct KD_API hd_private : hd_public {
     hd_public to_public() const;
 
     [[nodiscard]]
-    hd_private derive_private(uint32_t index) const;
+    expect<hd_private> derive_private(uint32_t index) const;
 
     [[nodiscard]]
-    hd_public derive_public(uint32_t index) const;
+    expect<hd_public> derive_public(uint32_t index) const;
 
 private:
-    static hd_private from_seed(byte_span seed, uint64_t prefixes);
-    static hd_private from_key(hd_key const& decoded);
-    static hd_private from_key(hd_key const& key, uint32_t public_prefix);
-    static hd_private from_key(hd_key const& key, uint64_t prefixes);
+    static expect<hd_private> from_seed_impl(byte_span seed, uint64_t prefixes);
+    static expect<hd_private> from_key_impl(hd_key const& key, uint32_t public_prefix);
+    static expect<hd_private> from_key_impl(hd_key const& key, uint64_t prefixes);
 
-    hd_private(ec_secret const& secret, hd_chain_code const& chain_code, hd_lineage const& lineage);
+    static expect<hd_private> from_verified_secret(ec_secret const& secret, hd_chain_code const& chain_code, hd_lineage const& lineage);
+
+    hd_private(hd_public base, ec_secret const& secret);
 
     ec_secret secret_ {null_hash};
 };

--- a/src/domain/include/kth/domain/wallet/hd_public.hpp
+++ b/src/domain/include/kth/domain/wallet/hd_public.hpp
@@ -30,15 +30,12 @@ using hd_key = byte_array<hd_key_size>;
 
 class hd_private;
 
-/**
- * BIP32 extended public key.
- *
- * Default-constructible (invalid state) so callers that hold an
- * `hd_public` as a struct member can fill it later via assignment.
- * Fallible construction goes through `parse_from` /
- * `parse_from_with_prefix` which return `expect<hd_public>`.
- */
+/// BIP32 extended public key. Valid-by-construction: every reachable
+/// instance was produced by a factory that validated its inputs, so
+/// accessors and serializers are always meaningful.
 struct KD_API hd_public {
+    friend class hd_private;
+
     static constexpr uint32_t mainnet = 76067358;
     static constexpr uint32_t testnet = 70617039;
 
@@ -55,23 +52,20 @@ struct KD_API hd_public {
     static
     expect<hd_public> parse_from_with_prefix(std::string_view encoded, uint32_t prefix);
 
-    hd_public();
+    /// Wrap an already-decoded 82-byte hd key, reading its version
+    /// prefix straight off the wire.
+    [[nodiscard]]
+    static
+    expect<hd_public> from_hd_key(hd_key const& key);
 
-    explicit
-    hd_public(hd_key const& public_key);
-
-    hd_public(hd_key const& public_key, uint32_t prefix);
+    /// Wrap an already-decoded 82-byte hd key against a caller-
+    /// supplied version prefix. Mismatched prefix returns an error.
+    [[nodiscard]]
+    static
+    expect<hd_public> from_hd_key_with_prefix(hd_key const& key, uint32_t prefix);
 
     [[nodiscard]]
-    friend bool operator==(hd_public const&, hd_public const&) = default;
-
-    [[nodiscard]]
-    friend auto operator<=>(hd_public const& a, hd_public const& b) {
-        return a.to_string() <=> b.to_string();
-    }
-
-    [[nodiscard]]
-    bool valid() const noexcept { return valid_; }
+    friend auto operator<=>(hd_public const& a, hd_public const& b) = default;
 
     /// Base58 encoding used by `fmt::formatter<hd_public>`.
     [[nodiscard]]
@@ -90,28 +84,26 @@ struct KD_API hd_public {
     hd_key to_hd_key() const;
 
     [[nodiscard]]
-    hd_public derive_public(uint32_t index) const;
+    expect<hd_public> derive_public(uint32_t index) const;
 
 protected:
+    hd_public(ec_compressed const& point, hd_chain_code const& chain_code, hd_lineage const& lineage);
+
     static
-    hd_public from_secret(ec_secret const& secret, hd_chain_code const& chain_code, hd_lineage const& lineage);
+    expect<hd_public> from_secret(ec_secret const& secret, hd_chain_code const& chain_code, hd_lineage const& lineage);
 
     uint32_t fingerprint() const;
 
-    // These should be const, apart from the need to implement assignment.
-    bool valid_{false};
     hd_chain_code chain_;
     hd_lineage lineage_;
     ec_compressed point_;
 
 private:
     static
-    hd_public from_key(hd_key const& key);
+    expect<hd_public> from_key_impl(hd_key const& key);
 
     static
-    hd_public from_key(hd_key const& key, uint32_t prefix);
-
-    hd_public(ec_compressed const& point, hd_chain_code const& chain_code, hd_lineage const& lineage);
+    expect<hd_public> from_key_impl(hd_key const& key, uint32_t prefix);
 };
 
 } // namespace kth::domain::wallet

--- a/src/domain/src/wallet/hd_private.cpp
+++ b/src/domain/src/wallet/hd_private.cpp
@@ -24,29 +24,10 @@
 
 namespace kth::domain::wallet {
 
-hd_private::hd_private(data_chunk const& seed, uint64_t prefixes)
-    : hd_private(from_seed(seed, prefixes))
-{}
-
-// This reads the private version and sets the public to mainnet.
-hd_private::hd_private(hd_key const& private_key)
-    : hd_private(from_key(private_key, hd_public::mainnet))
-{}
-
-hd_private::hd_private(hd_key const& private_key, uint32_t prefix)
-    : hd_private(from_key(private_key, prefix))
-{}
-
-hd_private::hd_private(hd_key const& private_key, uint64_t prefixes)
-    : hd_private(from_key(private_key, prefixes))
-{}
-
-hd_private::hd_private(ec_secret const& secret, hd_chain_code const& chain_code, hd_lineage const& lineage)
-    : hd_public(from_secret(secret, chain_code, lineage))
+hd_private::hd_private(hd_public base, ec_secret const& secret)
+    : hd_public(std::move(base))
     , secret_(secret)
 {}
-
-
 
 // Factories.
 // ----------------------------------------------------------------------------
@@ -62,12 +43,7 @@ expect<hd_private> hd_private::parse_from_with_public_prefix(std::string_view en
     if ( ! decode_base58(key, std::string{encoded})) {
         return std::unexpected(kth::error::illegal_value);
     }
-
-    hd_private out = from_key(key, public_prefix);
-    if ( ! out.valid()) {
-        return std::unexpected(kth::error::illegal_value);
-    }
-    return out;
+    return from_key_impl(key, public_prefix);
 }
 
 // static
@@ -76,15 +52,35 @@ expect<hd_private> hd_private::parse_from_with_prefixes(std::string_view encoded
     if ( ! decode_base58(key, std::string{encoded})) {
         return std::unexpected(kth::error::illegal_value);
     }
-
-    hd_private out{key, prefixes};
-    if ( ! out.valid()) {
-        return std::unexpected(kth::error::illegal_value);
-    }
-    return out;
+    return from_key_impl(key, prefixes);
 }
 
-hd_private hd_private::from_seed(byte_span seed, uint64_t prefixes) {
+// static
+expect<hd_private> hd_private::from_seed(data_chunk const& seed, uint64_t prefixes) {
+    return from_seed_impl(seed, prefixes);
+}
+
+// static
+expect<hd_private> hd_private::from_hd_key_with_public_prefix(hd_key const& private_key, uint32_t public_prefix) {
+    return from_key_impl(private_key, public_prefix);
+}
+
+// static
+expect<hd_private> hd_private::from_hd_key_with_prefixes(hd_key const& private_key, uint64_t prefixes) {
+    return from_key_impl(private_key, prefixes);
+}
+
+// static
+expect<hd_private> hd_private::from_verified_secret(ec_secret const& secret, hd_chain_code const& chain_code, hd_lineage const& lineage) {
+    auto base = hd_public::from_secret(secret, chain_code, lineage);
+    if ( ! base) {
+        return std::unexpected(base.error());
+    }
+    return hd_private(std::move(*base), secret);
+}
+
+// static
+expect<hd_private> hd_private::from_seed_impl(byte_span seed, uint64_t prefixes) {
     // This is a magic constant from BIP32.
     static data_chunk const magic(to_chunk("Bitcoin seed"));
 
@@ -92,7 +88,7 @@ hd_private hd_private::from_seed(byte_span seed, uint64_t prefixes) {
 
     // The key is invalid if parse256(IL) >= n or 0:
     if ( ! verify(intermediate.left)) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     auto const master = hd_lineage {
@@ -102,49 +98,51 @@ hd_private hd_private::from_seed(byte_span seed, uint64_t prefixes) {
         0x00000000
     };
 
-    return hd_private(intermediate.left, intermediate.right, master);
+    return from_verified_secret(intermediate.left, intermediate.right, master);
 }
 
-hd_private hd_private::from_key(hd_key const& key, uint32_t public_prefix) {
+// static
+expect<hd_private> hd_private::from_key_impl(hd_key const& key, uint32_t public_prefix) {
     auto const prefix = from_big_endian_unsafe<uint32_t>(key);
-    return from_key(key, to_prefixes(prefix, public_prefix));
+    return from_key_impl(key, to_prefixes(prefix, public_prefix));
 }
 
-hd_private hd_private::from_key(hd_key const& key, uint64_t prefixes) {
+// static
+expect<hd_private> hd_private::from_key_impl(hd_key const& key, uint64_t prefixes) {
     byte_reader reader(key);
 
     auto const prefix = reader.read_big_endian<uint32_t>();
     if ( ! prefix || *prefix != to_prefix(prefixes)) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     auto const depth = reader.read_byte();
     if ( ! depth) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     auto const parent = reader.read_big_endian<uint32_t>();
     if ( ! parent) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     auto const child = reader.read_big_endian<uint32_t>();
     if ( ! child) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     auto const chain = reader.read_packed<hd_chain_code>();
     if ( ! chain) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     if ( ! reader.skip(1)) {  // padding byte
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     auto const secret = reader.read_packed<ec_secret>();
     if ( ! secret) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     hd_lineage const lineage {
@@ -154,7 +152,7 @@ hd_private hd_private::from_key(hd_key const& key, uint64_t prefixes) {
         *child
     };
 
-    return hd_private(*secret, *chain, lineage);
+    return from_verified_secret(*secret, *chain, lineage);
 }
 
 // Serializer.
@@ -189,12 +187,15 @@ hd_key hd_private::to_hd_key() const {
 }
 
 hd_public hd_private::to_public() const {
-    return hd_public(
-        ((hd_public)*this).to_hd_key(),
-        hd_public::to_prefix(lineage_.prefixes));
+    // Swap the private-side prefix out for the public-side prefix
+    // stored in the low 32 bits, then build directly from the
+    // already-derived point (no serialization round-trip).
+    hd_lineage adjusted = lineage_;
+    adjusted.prefixes = hd_public::to_prefix(lineage_.prefixes);
+    return hd_public(point_, chain_, adjusted);
 }
 
-hd_private hd_private::derive_private(uint32_t index) const {
+expect<hd_private> hd_private::derive_private(uint32_t index) const {
     constexpr uint8_t depth = 0;
 
     auto const data = (index >= hd_first_hardened_key) ?
@@ -206,11 +207,11 @@ hd_private hd_private::derive_private(uint32_t index) const {
     // The child key ki is (parse256(IL) + kpar) mod n:
     auto child = secret_;
     if ( ! ec_add(child, intermediate.left)) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     if (lineage_.depth == max_uint8) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     hd_lineage const lineage {
@@ -220,28 +221,15 @@ hd_private hd_private::derive_private(uint32_t index) const {
         index
     };
 
-    return hd_private(child, intermediate.right, lineage);
+    return from_verified_secret(child, intermediate.right, lineage);
 }
 
-hd_public hd_private::derive_public(uint32_t index) const {
-    return derive_private(index).to_public();
-}
-
-// Operators.
-// ----------------------------------------------------------------------------
-
-hd_private& hd_private::operator=(hd_private x) {
-    swap(*this, x);
-    return *this;
-}
-
-// friend function, see: stackoverflow.com/a/5695855/1172329
-void swap(hd_private& left, hd_private& right) {
-    using std::swap;
-
-    // Must be unqualified (no std namespace).
-    swap(static_cast<hd_public&>(left), static_cast<hd_public&>(right));
-    swap(left.secret_, right.secret_);
+expect<hd_public> hd_private::derive_public(uint32_t index) const {
+    auto priv = derive_private(index);
+    if ( ! priv) {
+        return std::unexpected(priv.error());
+    }
+    return priv->to_public();
 }
 
 } // namespace kth::domain::wallet

--- a/src/domain/src/wallet/hd_public.cpp
+++ b/src/domain/src/wallet/hd_public.cpp
@@ -24,28 +24,8 @@
 
 namespace kth::domain::wallet {
 
-// const uint32_t hd_public::mainnet = 76067358;
-// const uint32_t hd_public::testnet = 70617039;
-
 // hd_public
 // ----------------------------------------------------------------------------
-
-hd_public::hd_public()
-    : chain_(null_hash), lineage_({0, 0, 0, 0})
-    , point_(null_compressed_point)
-{}
-
-// This cannot validate the version.
-hd_public::hd_public(hd_key const& public_key)
-    : hd_public(from_key(public_key))
-{}
-
-// This validates the version.
-hd_public::hd_public(hd_key const& public_key, uint32_t prefix)
-    : hd_public(from_key(public_key, prefix))
-{}
-
-
 
 // static
 expect<hd_public> hd_public::parse_from(std::string_view encoded) {
@@ -53,11 +33,7 @@ expect<hd_public> hd_public::parse_from(std::string_view encoded) {
     if ( ! decode_base58(key, std::string{encoded})) {
         return std::unexpected(kth::error::illegal_value);
     }
-    auto out = from_key(key);
-    if ( ! out.valid()) {
-        return std::unexpected(kth::error::illegal_value);
-    }
-    return out;
+    return from_hd_key(key);
 }
 
 // static
@@ -66,61 +42,73 @@ expect<hd_public> hd_public::parse_from_with_prefix(std::string_view encoded, ui
     if ( ! decode_base58(key, std::string{encoded})) {
         return std::unexpected(kth::error::illegal_value);
     }
-    auto out = from_key(key, prefix);
-    if ( ! out.valid()) {
-        return std::unexpected(kth::error::illegal_value);
-    }
-    return out;
+    return from_hd_key_with_prefix(key, prefix);
+}
+
+// static
+expect<hd_public> hd_public::from_hd_key(hd_key const& key) {
+    return from_key_impl(key);
+}
+
+// static
+expect<hd_public> hd_public::from_hd_key_with_prefix(hd_key const& key, uint32_t prefix) {
+    return from_key_impl(key, prefix);
 }
 
 hd_public::hd_public(ec_compressed const& point, hd_chain_code const& chain_code, hd_lineage const& lineage)
-    : valid_(true), point_(point), chain_(chain_code), lineage_(lineage)
+    : chain_(chain_code), lineage_(lineage), point_(point)
 {}
 
 // Factories.
 // ----------------------------------------------------------------------------
 
-hd_public hd_public::from_secret(ec_secret const& secret, hd_chain_code const& chain_code, hd_lineage const& lineage) {
+// static
+expect<hd_public> hd_public::from_secret(ec_secret const& secret, hd_chain_code const& chain_code, hd_lineage const& lineage) {
     ec_compressed point;
-    return secret_to_public(point, secret) ? hd_public(point, chain_code, lineage) : hd_public{};
+    if ( ! secret_to_public(point, secret)) {
+        return std::unexpected(kth::error::illegal_value);
+    }
+    return hd_public(point, chain_code, lineage);
 }
 
-hd_public hd_public::from_key(hd_key const& key) {
+// static
+expect<hd_public> hd_public::from_key_impl(hd_key const& key) {
     auto const prefix = from_big_endian_unsafe<uint32_t>(key);
-    return from_key(key, prefix);
+    return from_key_impl(key, prefix);
 }
 
-hd_public hd_public::from_key(hd_key const& key, uint32_t prefix) {
+// static
+expect<hd_public> hd_public::from_key_impl(hd_key const& key, uint32_t prefix) {
     byte_reader reader(key);
 
     auto const actual_prefix = reader.read_big_endian<uint32_t>();
     if ( ! actual_prefix || *actual_prefix != prefix) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     auto const depth = reader.read_byte();
     if ( ! depth) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     auto const parent = reader.read_big_endian<uint32_t>();
     if ( ! parent) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     auto const child = reader.read_big_endian<uint32_t>();
     if ( ! child) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     auto const chain = reader.read_packed<hd_chain_code>();
     if ( ! chain) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     auto const point = reader.read_packed<ec_compressed>();
     if ( ! point) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     // The private prefix will be zero'd here, but there's no way to access it.
@@ -162,9 +150,9 @@ hd_key hd_public::to_hd_key() const {
     return out;
 }
 
-hd_public hd_public::derive_public(uint32_t index) const {
+expect<hd_public> hd_public::derive_public(uint32_t index) const {
     if (index >= hd_first_hardened_key) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     auto const data = splice(point_, to_big_endian(index));
@@ -173,11 +161,11 @@ hd_public hd_public::derive_public(uint32_t index) const {
     // The returned child key Ki is point(parse256(IL)) + Kpar.
     auto combined = point_;
     if ( ! ec_add(combined, intermediate.left)) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     if (lineage_.depth == max_uint8) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     hd_lineage const lineage {

--- a/src/domain/src/wallet/wallet_manager.cpp
+++ b/src/domain/src/wallet/wallet_manager.cpp
@@ -31,13 +31,6 @@ hash_digest derive_key(std::string const& password, std::array<uint8_t, default_
     return key;
 }
 
-template <typename T>
-void clear_hd(T& hd) {
-    using std::swap;
-    T tmp;
-    swap(hd, tmp);
-}
-
 std::expected<wallet_data, std::error_code>
 create(
     std::string const& password,
@@ -65,18 +58,20 @@ create(
 
     data_chunk seed_chunk(seed.begin(), seed.end());
 
-    hd_private m(seed_chunk, hd_private::mainnet);
+    auto m = hd_private::from_seed(seed_chunk, hd_private::mainnet);
     std::fill(seed_chunk.begin(), seed_chunk.end(), 0);
-    hd_private m44h = m.derive_private(44 + hd_first_hardened_key);
-    hd_private m44h145h = m44h.derive_private(145 + hd_first_hardened_key);
-    hd_private m44h145h0h = m44h145h.derive_private(0 + hd_first_hardened_key);
-    hd_public pub = m44h145h0h.to_public();
+    if ( ! m) return std::unexpected(m.error());
 
-    // erase all the intermediate hd_private and hd_public objects
-    clear_hd(m);
-    clear_hd(m44h);
-    clear_hd(m44h145h);
-    clear_hd(m44h145h0h);
+    auto m44h = m->derive_private(44 + hd_first_hardened_key);
+    if ( ! m44h) return std::unexpected(m44h.error());
+
+    auto m44h145h = m44h->derive_private(145 + hd_first_hardened_key);
+    if ( ! m44h145h) return std::unexpected(m44h145h.error());
+
+    auto m44h145h0h = m44h145h->derive_private(0 + hd_first_hardened_key);
+    if ( ! m44h145h0h) return std::unexpected(m44h145h0h.error());
+
+    hd_public pub = m44h145h0h->to_public();
 
     auto const salt = generate_salt();
     auto const iv = generate_salt<default_iv_size>();

--- a/src/domain/test/wallet/hd_private.cpp
+++ b/src/domain/test/wallet/hd_private.cpp
@@ -28,14 +28,15 @@ TEST_CASE("hd private derive private short seed expected", "[hd private tests]")
     auto const seed = decode_base16(short_seed);
     REQUIRE(seed);
 
-    hd_private const m(*seed, hd_private::mainnet);
-    auto const m0h = m.derive_private(hd_first_hardened_key);
-    auto const m0h1 = m0h.derive_private(1);
-    auto const m0h12h = m0h1.derive_private(2 + hd_first_hardened_key);
-    auto const m0h12h2 = m0h12h.derive_private(2);
-    auto const m0h12h2x = m0h12h2.derive_private(1000000000);
+    auto const m = hd_private::from_seed(*seed, hd_private::mainnet);
+    REQUIRE(m);
+    auto const m0h = m->derive_private(hd_first_hardened_key).value();
+    auto const m0h1 = m0h.derive_private(1).value();
+    auto const m0h12h = m0h1.derive_private(2 + hd_first_hardened_key).value();
+    auto const m0h12h2 = m0h12h.derive_private(2).value();
+    auto const m0h12h2x = m0h12h2.derive_private(1000000000).value();
 
-    REQUIRE(m.to_string() == "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi");
+    REQUIRE(m->to_string() == "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi");
     REQUIRE(m0h.to_string() == "xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7");
     REQUIRE(m0h1.to_string() == "xprv9wTYmMFdV23N2TdNG573QoEsfRrWKQgWeibmLntzniatZvR9BmLnvSxqu53Kw1UmYPxLgboyZQaXwTCg8MSY3H2EU4pWcQDnRnrVA1xe8fs");
     REQUIRE(m0h12h.to_string() == "xprv9z4pot5VBttmtdRTWfWQmoH1taj2axGVzFqSb8C9xaxKymcFzXBDptWmT7FwuEzG3ryjH4ktypQSAewRiNMjANTtpgP4mLTj34bhnZX7UiM");
@@ -47,19 +48,20 @@ TEST_CASE("hd private derive public short seed expected", "[hd private tests]") 
     auto const seed = decode_base16(short_seed);
     REQUIRE(seed);
 
-    hd_private const m(*seed, hd_private::mainnet);
-    auto const m0h = m.derive_private(hd_first_hardened_key);
-    auto const m0h1 = m0h.derive_private(1);
-    auto const m0h12h = m0h1.derive_private(2 + hd_first_hardened_key);
-    auto const m0h12h2 = m0h12h.derive_private(2);
-    auto const m0h12h2x = m0h12h2.derive_private(1000000000);
+    auto const m = hd_private::from_seed(*seed, hd_private::mainnet);
+    REQUIRE(m);
+    auto const m0h = m->derive_private(hd_first_hardened_key).value();
+    auto const m0h1 = m0h.derive_private(1).value();
+    auto const m0h12h = m0h1.derive_private(2 + hd_first_hardened_key).value();
+    auto const m0h12h2 = m0h12h.derive_private(2).value();
+    auto const m0h12h2x = m0h12h2.derive_private(1000000000).value();
 
-    hd_public m_pub = m;
-    auto const m0h_pub = m.derive_public(hd_first_hardened_key);
-    auto const m0h1_pub = m0h.derive_public(1);
-    auto const m0h12h_pub = m0h1.derive_public(2 + hd_first_hardened_key);
-    auto const m0h12h2_pub = m0h12h.derive_public(2);
-    auto const m0h12h2x_pub = m0h12h2.derive_public(1000000000);
+    hd_public m_pub = *m;
+    auto const m0h_pub = m->derive_public(hd_first_hardened_key).value();
+    auto const m0h1_pub = m0h.derive_public(1).value();
+    auto const m0h12h_pub = m0h1.derive_public(2 + hd_first_hardened_key).value();
+    auto const m0h12h2_pub = m0h12h.derive_public(2).value();
+    auto const m0h12h2x_pub = m0h12h2.derive_public(1000000000).value();
 
     REQUIRE(m_pub.to_string() == "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8");
     REQUIRE(m0h_pub.to_string() == "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw");
@@ -73,14 +75,15 @@ TEST_CASE("hd private derive private long seed expected", "[hd private tests]") 
     auto const seed = decode_base16(long_seed);
     REQUIRE(seed);
 
-    hd_private const m(*seed, hd_private::mainnet);
-    auto const m0 = m.derive_private(0);
-    auto const m0xH = m0.derive_private(2147483647 + hd_first_hardened_key);
-    auto const m0xH1 = m0xH.derive_private(1);
-    auto const m0xH1yH = m0xH1.derive_private(2147483646 + hd_first_hardened_key);
-    auto const m0xH1yH2 = m0xH1yH.derive_private(2);
+    auto const m = hd_private::from_seed(*seed, hd_private::mainnet);
+    REQUIRE(m);
+    auto const m0 = m->derive_private(0).value();
+    auto const m0xH = m0.derive_private(2147483647 + hd_first_hardened_key).value();
+    auto const m0xH1 = m0xH.derive_private(1).value();
+    auto const m0xH1yH = m0xH1.derive_private(2147483646 + hd_first_hardened_key).value();
+    auto const m0xH1yH2 = m0xH1yH.derive_private(2).value();
 
-    REQUIRE(m.to_string() == "xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U");
+    REQUIRE(m->to_string() == "xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U");
     REQUIRE(m0.to_string() == "xprv9vHkqa6EV4sPZHYqZznhT2NPtPCjKuDKGY38FBWLvgaDx45zo9WQRUT3dKYnjwih2yJD9mkrocEZXo1ex8G81dwSM1fwqWpWkeS3v86pgKt");
     REQUIRE(m0xH.to_string() == "xprv9wSp6B7kry3Vj9m1zSnLvN3xH8RdsPP1Mh7fAaR7aRLcQMKTR2vidYEeEg2mUCTAwCd6vnxVrcjfy2kRgVsFawNzmjuHc2YmYRmagcEPdU9");
     REQUIRE(m0xH1.to_string() == "xprv9zFnWC6h2cLgpmSA46vutJzBcfJ8yaJGg8cX1e5StJh45BBciYTRXSd25UEPVuesF9yog62tGAQtHjXajPPdbRCHuWS6T8XA2ECKADdw4Ef");
@@ -92,19 +95,20 @@ TEST_CASE("hd private derive public long seed expected", "[hd private tests]") {
     auto const seed = decode_base16(long_seed);
     REQUIRE(seed);
 
-    hd_private const m(*seed, hd_private::mainnet);
-    auto const m0 = m.derive_private(0);
-    auto const m0xH = m0.derive_private(2147483647 + hd_first_hardened_key);
-    auto const m0xH1 = m0xH.derive_private(1);
-    auto const m0xH1yH = m0xH1.derive_private(2147483646 + hd_first_hardened_key);
-    auto const m0xH1yH2 = m0xH1yH.derive_private(2);
+    auto const m = hd_private::from_seed(*seed, hd_private::mainnet);
+    REQUIRE(m);
+    auto const m0 = m->derive_private(0).value();
+    auto const m0xH = m0.derive_private(2147483647 + hd_first_hardened_key).value();
+    auto const m0xH1 = m0xH.derive_private(1).value();
+    auto const m0xH1yH = m0xH1.derive_private(2147483646 + hd_first_hardened_key).value();
+    auto const m0xH1yH2 = m0xH1yH.derive_private(2).value();
 
-    hd_public m_pub = m;
-    auto const m0_pub = m.derive_public(0);
-    auto const m0xH_pub = m0.derive_public(2147483647 + hd_first_hardened_key);
-    auto const m0xH1_pub = m0xH.derive_public(1);
-    auto const m0xH1yH_pub = m0xH1.derive_public(2147483646 + hd_first_hardened_key);
-    auto const m0xH1yH2_pub = m0xH1yH.derive_public(2);
+    hd_public m_pub = *m;
+    auto const m0_pub = m->derive_public(0).value();
+    auto const m0xH_pub = m0.derive_public(2147483647 + hd_first_hardened_key).value();
+    auto const m0xH1_pub = m0xH.derive_public(1).value();
+    auto const m0xH1yH_pub = m0xH1.derive_public(2147483646 + hd_first_hardened_key).value();
+    auto const m0xH1yH2_pub = m0xH1yH.derive_public(2).value();
 
     REQUIRE(m_pub.to_string() == "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB");
     REQUIRE(m0_pub.to_string() == "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH");

--- a/src/domain/test/wallet/hd_public.cpp
+++ b/src/domain/test/wallet/hd_public.cpp
@@ -21,9 +21,10 @@ TEST_CASE("hd public derive public invalid false", "[hd public tests]") {
     auto const seed = decode_base16(short_seed);
     REQUIRE(seed);
 
-    hd_private const m(*seed, hd_private::mainnet);
-    hd_public const m_pub = m;
-    REQUIRE( ! m_pub.derive_public(hd_first_hardened_key).valid());
+    auto const m = hd_private::from_seed(*seed, hd_private::mainnet);
+    REQUIRE(m);
+    hd_public const m_pub = *m;
+    REQUIRE( ! m_pub.derive_public(hd_first_hardened_key));
 }
 
 TEST_CASE("hd public encoded round trip expected", "[hd public tests]") {
@@ -37,16 +38,17 @@ TEST_CASE("hd public derive public short seed expected", "[hd public tests]") {
     auto const seed = decode_base16(short_seed);
     REQUIRE(seed);
 
-    hd_private const m(*seed, hd_private::mainnet);
-    auto const m0h = m.derive_private(hd_first_hardened_key);
-    auto const m0h1 = m0h.derive_private(1);
+    auto const m = hd_private::from_seed(*seed, hd_private::mainnet);
+    REQUIRE(m);
+    auto const m0h = m->derive_private(hd_first_hardened_key).value();
+    auto const m0h1 = m0h.derive_private(1).value();
 
-    hd_public const m_pub = m;
-    auto const m0h_pub = m.derive_public(hd_first_hardened_key);
-    auto const m0h1_pub = m0h_pub.derive_public(1);
-    auto const m0h12h_pub = m0h1.derive_public(2 + hd_first_hardened_key);
-    auto const m0h12h2_pub = m0h12h_pub.derive_public(2);
-    auto const m0h12h2x_pub = m0h12h2_pub.derive_public(1000000000);
+    hd_public const m_pub = *m;
+    auto const m0h_pub = m->derive_public(hd_first_hardened_key).value();
+    auto const m0h1_pub = m0h_pub.derive_public(1).value();
+    auto const m0h12h_pub = m0h1.derive_public(2 + hd_first_hardened_key).value();
+    auto const m0h12h2_pub = m0h12h_pub.derive_public(2).value();
+    auto const m0h12h2x_pub = m0h12h2_pub.derive_public(1000000000).value();
 
     REQUIRE(m_pub.to_string() == "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8");
     REQUIRE(m0h_pub.to_string() == "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw");
@@ -60,17 +62,18 @@ TEST_CASE("hd public derive public long seed expected", "[hd public tests]") {
     auto const seed = decode_base16(long_seed);
     REQUIRE(seed);
 
-    hd_private const m(*seed, hd_private::mainnet);
-    auto const m0 = m.derive_private(0);
-    auto const m0xH = m0.derive_private(2147483647 + hd_first_hardened_key);
-    auto const m0xH1 = m0xH.derive_private(1);
+    auto const m = hd_private::from_seed(*seed, hd_private::mainnet);
+    REQUIRE(m);
+    auto const m0 = m->derive_private(0).value();
+    auto const m0xH = m0.derive_private(2147483647 + hd_first_hardened_key).value();
+    auto const m0xH1 = m0xH.derive_private(1).value();
 
-    hd_public const m_pub = m;
-    auto const m0_pub = m_pub.derive_public(0);
-    auto const m0xH_pub = m0.derive_public(2147483647 + hd_first_hardened_key);
-    auto const m0xH1_pub = m0xH_pub.derive_public(1);
-    auto const m0xH1yH_pub = m0xH1.derive_public(2147483646 + hd_first_hardened_key);
-    auto const m0xH1yH2_pub = m0xH1yH_pub.derive_public(2);
+    hd_public const m_pub = *m;
+    auto const m0_pub = m_pub.derive_public(0).value();
+    auto const m0xH_pub = m0.derive_public(2147483647 + hd_first_hardened_key).value();
+    auto const m0xH1_pub = m0xH_pub.derive_public(1).value();
+    auto const m0xH1yH_pub = m0xH1.derive_public(2147483646 + hd_first_hardened_key).value();
+    auto const m0xH1yH2_pub = m0xH1yH_pub.derive_public(2).value();
 
     REQUIRE(m_pub.to_string() == "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB");
     REQUIRE(m0_pub.to_string() == "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH");


### PR DESCRIPTION
## Summary

Full cleanup pass on the `hd_*` wallet types. Eliminates the "possibly-invalid default-constructed sentinel" model and pushes every fallible construction path onto `expect<>` return types.

### `hd_public`

- **Drop the public default ctor** `hd_public()`.
- **Drop `.valid()` and `valid_`**. Every reachable instance was produced by a factory that validated its inputs, so accessors and serializers (`to_string`, `to_hd_key`, `chain_code`, `point`, `lineage`) are always meaningful.
- **Drop the two fallible public ctors** `hd_public(hd_key)` and `hd_public(hd_key, uint32_t)` (they delegated to internal helpers that returned an invalid sentinel on failure). Replaced by named static factories `from_hd_key(hd_key)` and `from_hd_key_with_prefix(hd_key, uint32_t)`, both returning `expect<hd_public>`.
- **Rename internal helpers to `from_key_impl`** and widen return to `expect<hd_public>`; same for `from_secret`. The five silent-sentinel failure paths in `from_key_impl(hd_key, uint32_t)` now propagate real errors.
- **Default `operator<=>`** instead of routing through `to_string()`. State is `hd_chain_code<32>` + `hd_lineage` (already defaulted) + `ec_compressed<33>` — byte-lex is a valid canonical order and skips a base58 encode + `strcmp` on every compare.
- **Widen `derive_public(index)` to `expect<hd_public>`**. The three failure paths (hardened-index rejection, `ec_add` failure, depth overflow) now surface real errors.
- Make the `(point, chain_code, lineage)` ctor `protected` and `friend hd_private` so the derived type can build a peer `hd_public` in `to_public()` without a serialization round-trip.

### `hd_private` (cascade — inheritance restructure is a follow-up PR)

- **Drop `hd_private() = default`** and the four fallible public ctors (`(data_chunk, uint64_t)`, `(hd_key)`, `(hd_key, uint32_t)`, `(hd_key, uint64_t)`). Replaced by static factories, all returning `expect<hd_private>`: `from_seed`, `from_hd_key_with_public_prefix`, `from_hd_key_with_prefixes`.
- **Widen `derive_private` → `expect<hd_private>`** and **`derive_public` → `expect<hd_public>`** — same silent-sentinel bug those had.
- Terminal ctor is now `hd_private(hd_public base, ec_secret)`; factories build the validated `hd_public` via `from_verified_secret` and pass it in. Decouples "am I on-curve?" (secret validation) from "am I a well-formed `hd_private`?" (structural correctness).
- **`to_public()` no longer round-trips through base58 + reparse**; it swaps the private-side prefix out of the packed lineage and builds a peer `hd_public` directly from the already-derived point.
- Default `<=>` and drop the string-based comparator that `hd_private` had. Base + `secret_` compare byte-lex.
- Drop the custom `operator=(hd_private)` and `swap(hd_private&, ...)`. Implicit copy/move-assign work; no callers relied on the swap.

### Cascade to callers

- `wallet_manager::create` unwraps the `from_seed` + three `derive_private` calls and propagates via `std::unexpected` through the existing `expected<wallet_data, error_code>` return.
- `clear_hd(T&)` and its four call sites go away. It swapped intermediate keys with a default-constructed temporary — no longer representable — and never zeroed anything the destructor wouldn't have re-touched anyway (compilers can elide dead-store writes on soon-destroyed locals), so its security value was cosmetic.
- Tests updated to construct via `hd_private::from_seed(...)` and unwrap successful chains with `.value()`.

C-API is intentionally left untouched — the bulk regen at the end of the split will pick up the removed ctors, removed `.valid()` methods, renamed factories, and widened `derive_*` signatures in one pass. That includes `wallet_data::xpub` (held by value) and `kth_wallet_hd_{public,private}_construct_default`.

**Inheritance (`struct hd_private : hd_public`) is intentionally retained.** Restructuring it to composition is a separate PR.

Part of the #422 split.

## Test plan

- [x] `kth_domain_test` passes locally (1_011_113 assertions in 3872 test cases)
- [ ] Bulk regen PR restores C-API build + tests