### PR TITLE
refactor(wallet): add hd_private::from_hd_key + wipe() on both hd types

### DIFF
--- a/src/domain/include/kth/domain/wallet/hd_private.hpp
+++ b/src/domain/include/kth/domain/wallet/hd_private.hpp
@@ -58,6 +58,12 @@ struct KD_API hd_private : hd_public {
     static
     expect<hd_private> from_seed(data_chunk const& seed, uint64_t prefixes);
 
+    /// Wrap an already-decoded 82-byte hd key using the default
+    /// mainnet public prefix. Parallel to `parse_from(string_view)`.
+    [[nodiscard]]
+    static
+    expect<hd_private> from_hd_key(hd_key const& private_key);
+
     /// Wrap an already-decoded 82-byte hd key, reading its private
     /// prefix off the wire and pairing it with a caller-supplied
     /// public prefix. Named distinctly from `from_hd_key_with_prefixes`
@@ -94,6 +100,10 @@ struct KD_API hd_private : hd_public {
 
     [[nodiscard]]
     expect<hd_public> derive_public(uint32_t index) const;
+
+    /// Overwrite every field (including `secret_`) with zero for
+    /// security-sensitive teardown. Extends `hd_public::wipe()`.
+    void wipe() noexcept;
 
 private:
     static expect<hd_private> from_seed_impl(byte_span seed, uint64_t prefixes);

--- a/src/domain/include/kth/domain/wallet/hd_public.hpp
+++ b/src/domain/include/kth/domain/wallet/hd_public.hpp
@@ -86,6 +86,12 @@ struct KD_API hd_public {
     [[nodiscard]]
     expect<hd_public> derive_public(uint32_t index) const;
 
+    /// Overwrite every field with zero for security-sensitive
+    /// teardown (before scope exit). After `wipe()` the accessors
+    /// return well-formed but semantically meaningless data; further
+    /// use of the object is a caller error.
+    void wipe() noexcept;
+
 protected:
     hd_public(ec_compressed const& point, hd_chain_code const& chain_code, hd_lineage const& lineage);
 

--- a/src/domain/src/wallet/hd_private.cpp
+++ b/src/domain/src/wallet/hd_private.cpp
@@ -61,6 +61,11 @@ expect<hd_private> hd_private::from_seed(data_chunk const& seed, uint64_t prefix
 }
 
 // static
+expect<hd_private> hd_private::from_hd_key(hd_key const& private_key) {
+    return from_key_impl(private_key, hd_public::mainnet);
+}
+
+// static
 expect<hd_private> hd_private::from_hd_key_with_public_prefix(hd_key const& private_key, uint32_t public_prefix) {
     return from_key_impl(private_key, public_prefix);
 }
@@ -230,6 +235,11 @@ expect<hd_public> hd_private::derive_public(uint32_t index) const {
         return std::unexpected(priv.error());
     }
     return priv->to_public();
+}
+
+void hd_private::wipe() noexcept {
+    hd_public::wipe();
+    secret_.fill(0);
 }
 
 } // namespace kth::domain::wallet

--- a/src/domain/src/wallet/hd_public.cpp
+++ b/src/domain/src/wallet/hd_public.cpp
@@ -178,6 +178,12 @@ expect<hd_public> hd_public::derive_public(uint32_t index) const {
     return hd_public(combined, intermediate.right, lineage);
 }
 
+void hd_public::wipe() noexcept {
+    chain_.fill(0);
+    lineage_ = {0, 0, 0, 0};
+    point_.fill(0);
+}
+
 // Helpers.
 // ----------------------------------------------------------------------------
 

--- a/src/domain/src/wallet/wallet_manager.cpp
+++ b/src/domain/src/wallet/wallet_manager.cpp
@@ -73,6 +73,11 @@ create(
 
     hd_public pub = m44h145h0h->to_public();
 
+    m->wipe();
+    m44h->wipe();
+    m44h145h->wipe();
+    m44h145h0h->wipe();
+
     auto const salt = generate_salt();
     auto const iv = generate_salt<default_iv_size>();
     auto aes_key = derive_key(password, salt);

--- a/src/domain/test/wallet/hd_private.cpp
+++ b/src/domain/test/wallet/hd_private.cpp
@@ -24,6 +24,36 @@ TEST_CASE("hd private encoded round trip expected", "[hd private tests]") {
     REQUIRE(key->to_string() == encoded);
 }
 
+TEST_CASE("hd private from_hd_key mainnet round trip expected", "[hd private tests]") {
+    static auto const encoded = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi";
+    auto const parsed = hd_private::parse_from(encoded);
+    REQUIRE(parsed);
+    auto const rewrapped = hd_private::from_hd_key(parsed->to_hd_key());
+    REQUIRE(rewrapped);
+    REQUIRE(rewrapped->to_string() == encoded);
+}
+
+TEST_CASE("hd private wipe zeroes every field", "[hd private tests]") {
+    auto const seed = decode_base16(short_seed);
+    REQUIRE(seed);
+
+    auto m = hd_private::from_seed(*seed, hd_private::mainnet);
+    REQUIRE(m);
+
+    m->wipe();
+
+    hd_chain_code const zero_chain {};
+    ec_compressed const zero_point {};
+    ec_secret const zero_secret {};
+    REQUIRE(m->chain_code() == zero_chain);
+    REQUIRE(m->point() == zero_point);
+    REQUIRE(m->secret() == zero_secret);
+    REQUIRE(m->lineage().prefixes == 0);
+    REQUIRE(m->lineage().depth == 0);
+    REQUIRE(m->lineage().parent_fingerprint == 0);
+    REQUIRE(m->lineage().child_number == 0);
+}
+
 TEST_CASE("hd private derive private short seed expected", "[hd private tests]") {
     auto const seed = decode_base16(short_seed);
     REQUIRE(seed);

--- a/src/domain/test/wallet/transaction_functions.cpp
+++ b/src/domain/test/wallet/transaction_functions.cpp
@@ -24,9 +24,10 @@ constexpr char complete_tx[] = "01000000019373b022dfb99400ee40b8987586aea9e158f3
 
 kth::ec_secret create_secret_from_seed(std::string const& seed_str) {
     auto seed = kth::decode_base16(seed_str);
-    hd_private const key(*seed);
+    auto const key = hd_private::from_seed(*seed, hd_private::mainnet);
+    REQUIRE(key);
     // Secret key
-    kth::ec_secret secret_key(key.secret());
+    kth::ec_secret secret_key(key->secret());
     return secret_key;
 }
 


### PR DESCRIPTION
## Summary

Follow-up polish on top of #427:

- **Add `hd_private::from_hd_key(hd_key)`** — mainnet-default convenience factory, symmetric to `hd_private::parse_from(string_view)` which already hardcodes mainnet. All other `from_hd_key_*` variants stay explicit; the single-arg name matches `hd_public::from_hd_key`.
- **Add `void hd_public::wipe() noexcept`** — overwrites `chain_`, `lineage_`, and `point_` with zeros. Used for security-sensitive teardown (before scope exit); documented that further use after `wipe()` is a caller error.
- **Add `void hd_private::wipe() noexcept`** — extends `hd_public::wipe()` and additionally zeros `secret_`. `wallet_manager::create` wipes the four intermediate `hd_private` keys (m, m/44', m/44'/145', m/44'/145'/0') after the leaf public key is captured. Restores the clearing hygiene that the old `clear_hd<T>` template gave up when #427 dropped it.
- **Fix a stale caller in `test/wallet/transaction_functions.cpp`** — the file was left disabled in `CMakeLists.txt` so #427 didn't notice the removed `hd_private(hd_key)` ctor. Now uses `from_seed` + `REQUIRE(key)`, so the file compiles again if someone flips it on.
- **New tests** for the round-trip of `from_hd_key` and the post-`wipe()` state (all fields zero).

Part of the #422 split.

## Test plan

- [x] `kth_domain_test` passes locally (1_011_125 assertions in 3874 test cases; +2 test cases vs #427)
- [ ] Bulk regen PR restores C-API build + tests