### PR TITLE
refactor(wallet): drop hd_private inheritance, use composition

### DIFF
--- a/src/domain/include/kth/domain/wallet/hd_private.hpp
+++ b/src/domain/include/kth/domain/wallet/hd_private.hpp
@@ -23,9 +23,13 @@ uint64_t to_prefixes(uint32_t private_prefix, uint32_t public_prefix) {
 }
 
 /// BIP32 extended private key. Valid-by-construction: every reachable
-/// instance was produced by a factory that validated its inputs, so
-/// accessors and derivations are always meaningful.
-struct KD_API hd_private : hd_public {
+/// instance was produced by a factory that validated its inputs.
+///
+/// Holds an `hd_public` by composition (not inheritance); the base
+/// hd_public carries the derived `point`, `chain_code`, and packed
+/// `lineage` (private-side prefix in the high 32 bits, public-side
+/// in the low 32 bits — see `to_public()`).
+struct KD_API hd_private {
     static constexpr uint64_t mainnet = to_prefixes(76066276, hd_public::mainnet);
     static constexpr uint64_t testnet = to_prefixes(70615956, hd_public::testnet);
 
@@ -85,6 +89,22 @@ struct KD_API hd_private : hd_public {
     [[nodiscard]]
     ec_secret const& secret() const noexcept { return secret_; }
 
+    /// Read-only view of the composed public-side key. Note that its
+    /// `lineage().prefixes` still carries the private+public pair
+    /// packed together; use `to_public()` to obtain a peer with the
+    /// prefix rewritten to the public-only view.
+    [[nodiscard]]
+    hd_public const& public_key() const noexcept { return public_; }
+
+    [[nodiscard]]
+    hd_chain_code const& chain_code() const noexcept { return public_.chain_code(); }
+
+    [[nodiscard]]
+    hd_lineage const& lineage() const noexcept { return public_.lineage(); }
+
+    [[nodiscard]]
+    ec_compressed const& point() const noexcept { return public_.point(); }
+
     /// Base58 encoding used by `fmt::formatter<hd_private>`.
     [[nodiscard]]
     std::string to_string() const;
@@ -92,6 +112,9 @@ struct KD_API hd_private : hd_public {
     [[nodiscard]]
     hd_key to_hd_key() const;
 
+    /// Peer `hd_public` — same point / chain / depth / fingerprint,
+    /// with the packed lineage prefix collapsed to just the public
+    /// half. Infallible.
     [[nodiscard]]
     hd_public to_public() const;
 
@@ -101,8 +124,9 @@ struct KD_API hd_private : hd_public {
     [[nodiscard]]
     expect<hd_public> derive_public(uint32_t index) const;
 
-    /// Overwrite every field (including `secret_`) with zero for
-    /// security-sensitive teardown. Extends `hd_public::wipe()`.
+    /// Overwrite the composed public part and the private `secret_`
+    /// with zero for security-sensitive teardown. Wraps
+    /// `hd_public::wipe()`.
     void wipe() noexcept;
 
 private:
@@ -114,6 +138,7 @@ private:
 
     hd_private(hd_public base, ec_secret const& secret);
 
+    hd_public public_;
     ec_secret secret_ {null_hash};
 };
 

--- a/src/domain/include/kth/domain/wallet/hd_public.hpp
+++ b/src/domain/include/kth/domain/wallet/hd_public.hpp
@@ -28,14 +28,10 @@ using hd_chain_code = byte_array<hd_chain_code_size>;
 static constexpr size_t hd_key_size = 82;
 using hd_key = byte_array<hd_key_size>;
 
-class hd_private;
-
 /// BIP32 extended public key. Valid-by-construction: every reachable
 /// instance was produced by a factory that validated its inputs, so
 /// accessors and serializers are always meaningful.
 struct KD_API hd_public {
-    friend class hd_private;
-
     static constexpr uint32_t mainnet = 76067358;
     static constexpr uint32_t testnet = 70617039;
 
@@ -64,6 +60,21 @@ struct KD_API hd_public {
     static
     expect<hd_public> from_hd_key_with_prefix(hd_key const& key, uint32_t prefix);
 
+    /// Derive the public counterpart of an ec_secret and wrap it
+    /// with a caller-supplied chain code / lineage. Fails when
+    /// `secret` cannot be lifted to the curve.
+    [[nodiscard]]
+    static
+    expect<hd_public> from_secret(ec_secret const& secret, hd_chain_code const& chain_code, hd_lineage const& lineage);
+
+    /// Package a triple that has already been validated (or produced
+    /// by an internal derivation step) into an `hd_public`. Caller is
+    /// responsible for the on-curve invariant of `point`; no checks
+    /// are performed here.
+    [[nodiscard]]
+    static
+    hd_public from_verified_components(ec_compressed const& point, hd_chain_code const& chain_code, hd_lineage const& lineage);
+
     [[nodiscard]]
     friend auto operator<=>(hd_public const& a, hd_public const& b) = default;
 
@@ -86,30 +97,29 @@ struct KD_API hd_public {
     [[nodiscard]]
     expect<hd_public> derive_public(uint32_t index) const;
 
+    /// Fingerprint of this key: leading 4 bytes of `HASH160(point)`.
+    /// Used as `parent_fingerprint` when this key acts as a parent
+    /// in BIP32 derivation.
+    uint32_t fingerprint() const;
+
     /// Overwrite every field with zero for security-sensitive
     /// teardown (before scope exit). After `wipe()` the accessors
     /// return well-formed but semantically meaningless data; further
     /// use of the object is a caller error.
     void wipe() noexcept;
 
-protected:
+private:
     hd_public(ec_compressed const& point, hd_chain_code const& chain_code, hd_lineage const& lineage);
 
-    static
-    expect<hd_public> from_secret(ec_secret const& secret, hd_chain_code const& chain_code, hd_lineage const& lineage);
-
-    uint32_t fingerprint() const;
-
-    hd_chain_code chain_;
-    hd_lineage lineage_;
-    ec_compressed point_;
-
-private:
     static
     expect<hd_public> from_key_impl(hd_key const& key);
 
     static
     expect<hd_public> from_key_impl(hd_key const& key, uint32_t prefix);
+
+    hd_chain_code chain_;
+    hd_lineage lineage_;
+    ec_compressed point_;
 };
 
 } // namespace kth::domain::wallet

--- a/src/domain/src/wallet/hd_private.cpp
+++ b/src/domain/src/wallet/hd_private.cpp
@@ -25,7 +25,7 @@
 namespace kth::domain::wallet {
 
 hd_private::hd_private(hd_public base, ec_secret const& secret)
-    : hd_public(std::move(base))
+    : public_(std::move(base))
     , secret_(secret)
 {}
 
@@ -176,14 +176,16 @@ std::string hd_private::to_string() const {
 hd_key hd_private::to_hd_key() const {
     static constexpr uint8_t private_key_padding = 0x00;
 
+    auto const& lineage = public_.lineage();
+
     hd_key out;
     build_checked_array(out,
     {
-        to_big_endian(to_prefix(lineage_.prefixes)),
-        to_array(lineage_.depth),
-        to_big_endian(lineage_.parent_fingerprint),
-        to_big_endian(lineage_.child_number),
-        chain_,
+        to_big_endian(to_prefix(lineage.prefixes)),
+        to_array(lineage.depth),
+        to_big_endian(lineage.parent_fingerprint),
+        to_big_endian(lineage.child_number),
+        public_.chain_code(),
         to_array(private_key_padding),
         secret_
     });
@@ -192,22 +194,23 @@ hd_key hd_private::to_hd_key() const {
 }
 
 hd_public hd_private::to_public() const {
-    // Swap the private-side prefix out for the public-side prefix
-    // stored in the low 32 bits, then build directly from the
-    // already-derived point (no serialization round-trip).
-    hd_lineage adjusted = lineage_;
-    adjusted.prefixes = hd_public::to_prefix(lineage_.prefixes);
-    return hd_public(point_, chain_, adjusted);
+    // Rewrite the packed private+public prefix pair down to just the
+    // public half; the point and chain are already the derived ones.
+    hd_lineage adjusted = public_.lineage();
+    adjusted.prefixes = hd_public::to_prefix(adjusted.prefixes);
+    return hd_public::from_verified_components(public_.point(), public_.chain_code(), adjusted);
 }
 
 expect<hd_private> hd_private::derive_private(uint32_t index) const {
     constexpr uint8_t depth = 0;
 
+    auto const& lineage = public_.lineage();
+
     auto const data = (index >= hd_first_hardened_key) ?
         splice(to_array(depth), secret_, to_big_endian(index)) :
-        splice(point_, to_big_endian(index));
+        splice(public_.point(), to_big_endian(index));
 
-    auto const intermediate = split(hmac_sha512_hash(data, chain_));
+    auto const intermediate = split(hmac_sha512_hash(data, public_.chain_code()));
 
     // The child key ki is (parse256(IL) + kpar) mod n:
     auto child = secret_;
@@ -215,18 +218,18 @@ expect<hd_private> hd_private::derive_private(uint32_t index) const {
         return std::unexpected(kth::error::illegal_value);
     }
 
-    if (lineage_.depth == max_uint8) {
+    if (lineage.depth == max_uint8) {
         return std::unexpected(kth::error::illegal_value);
     }
 
-    hd_lineage const lineage {
-        lineage_.prefixes,
-        uint8_t(lineage_.depth + 1),
-        fingerprint(),
+    hd_lineage const child_lineage {
+        lineage.prefixes,
+        uint8_t(lineage.depth + 1),
+        public_.fingerprint(),
         index
     };
 
-    return from_verified_secret(child, intermediate.right, lineage);
+    return from_verified_secret(child, intermediate.right, child_lineage);
 }
 
 expect<hd_public> hd_private::derive_public(uint32_t index) const {
@@ -238,7 +241,7 @@ expect<hd_public> hd_private::derive_public(uint32_t index) const {
 }
 
 void hd_private::wipe() noexcept {
-    hd_public::wipe();
+    public_.wipe();
     secret_.fill(0);
 }
 

--- a/src/domain/src/wallet/hd_public.cpp
+++ b/src/domain/src/wallet/hd_public.cpp
@@ -63,6 +63,11 @@ hd_public::hd_public(ec_compressed const& point, hd_chain_code const& chain_code
 // ----------------------------------------------------------------------------
 
 // static
+hd_public hd_public::from_verified_components(ec_compressed const& point, hd_chain_code const& chain_code, hd_lineage const& lineage) {
+    return hd_public(point, chain_code, lineage);
+}
+
+// static
 expect<hd_public> hd_public::from_secret(ec_secret const& secret, hd_chain_code const& chain_code, hd_lineage const& lineage) {
     ec_compressed point;
     if ( ! secret_to_public(point, secret)) {

--- a/src/domain/test/wallet/hd_private.cpp
+++ b/src/domain/test/wallet/hd_private.cpp
@@ -86,7 +86,7 @@ TEST_CASE("hd private derive public short seed expected", "[hd private tests]") 
     auto const m0h12h2 = m0h12h.derive_private(2).value();
     auto const m0h12h2x = m0h12h2.derive_private(1000000000).value();
 
-    hd_public m_pub = *m;
+    hd_public m_pub = m->to_public();
     auto const m0h_pub = m->derive_public(hd_first_hardened_key).value();
     auto const m0h1_pub = m0h.derive_public(1).value();
     auto const m0h12h_pub = m0h1.derive_public(2 + hd_first_hardened_key).value();
@@ -133,7 +133,7 @@ TEST_CASE("hd private derive public long seed expected", "[hd private tests]") {
     auto const m0xH1yH = m0xH1.derive_private(2147483646 + hd_first_hardened_key).value();
     auto const m0xH1yH2 = m0xH1yH.derive_private(2).value();
 
-    hd_public m_pub = *m;
+    hd_public m_pub = m->to_public();
     auto const m0_pub = m->derive_public(0).value();
     auto const m0xH_pub = m0.derive_public(2147483647 + hd_first_hardened_key).value();
     auto const m0xH1_pub = m0xH.derive_public(1).value();

--- a/src/domain/test/wallet/hd_public.cpp
+++ b/src/domain/test/wallet/hd_public.cpp
@@ -23,7 +23,7 @@ TEST_CASE("hd public derive public invalid false", "[hd public tests]") {
 
     auto const m = hd_private::from_seed(*seed, hd_private::mainnet);
     REQUIRE(m);
-    hd_public const m_pub = *m;
+    hd_public const m_pub = m->to_public();
     REQUIRE( ! m_pub.derive_public(hd_first_hardened_key));
 }
 
@@ -43,7 +43,7 @@ TEST_CASE("hd public derive public short seed expected", "[hd public tests]") {
     auto const m0h = m->derive_private(hd_first_hardened_key).value();
     auto const m0h1 = m0h.derive_private(1).value();
 
-    hd_public const m_pub = *m;
+    hd_public const m_pub = m->to_public();
     auto const m0h_pub = m->derive_public(hd_first_hardened_key).value();
     auto const m0h1_pub = m0h_pub.derive_public(1).value();
     auto const m0h12h_pub = m0h1.derive_public(2 + hd_first_hardened_key).value();
@@ -68,7 +68,7 @@ TEST_CASE("hd public derive public long seed expected", "[hd public tests]") {
     auto const m0xH = m0.derive_private(2147483647 + hd_first_hardened_key).value();
     auto const m0xH1 = m0xH.derive_private(1).value();
 
-    hd_public const m_pub = *m;
+    hd_public const m_pub = m->to_public();
     auto const m0_pub = m_pub.derive_public(0).value();
     auto const m0xH_pub = m0.derive_public(2147483647 + hd_first_hardened_key).value();
     auto const m0xH1_pub = m0xH_pub.derive_public(1).value();


### PR DESCRIPTION
## Summary

`hd_private` no longer inherits from `hd_public` — it composes one by value plus its own `ec_secret`. Same-observable behaviour, no implicit slicing, cleaner is-a-relationship (a private key HAS a public counterpart; it doesn't IS one).

### `hd_public`

- **`hd_public(ec_compressed, hd_chain_code, hd_lineage)` ctor moves from protected to private** — there is no longer a derived class reaching into it via inheritance, and the two callers it still has (both `hd_public`'s own factories and `hd_private::to_public`) now go through a named factory.
- **Add `hd_public::from_verified_components(point, chain_code, lineage)`** — public static factory that packages a triple the caller has already validated (or produced by an internal derivation step) into an `hd_public`. Explicit name so the "trust me" contract is visible at the call site; no on-curve check here.
- **Promote `from_secret` and `fingerprint` from protected to public**. Both were protected only for the inheritance access pattern — `from_secret` returns `expect<hd_public>` and is fully validated; `fingerprint` is a pure derivation of `HASH160(point).prefix()`. Neither leaks state beyond what `point()` already exposes.
- **Drop `friend class hd_private;`** — no longer needed.

### `hd_private`

- **`struct hd_private : hd_public` becomes `struct hd_private`** with members `hd_public public_` and `ec_secret secret_`. Terminal private ctor unchanged in signature — still `hd_private(hd_public, ec_secret)` — only the init list swaps `hd_public(std::move(base))` for `public_(std::move(base))`.
- **Add `public_key() const noexcept -> hd_public const&`** — read-only view of the composed public part, retaining the packed private+public prefix pair on `.lineage().prefixes`. `to_public()` is still the way to get a peer with the prefix rewritten to the public-only view.
- Forward `chain_code()`, `lineage()`, and `point()` accessors to `public_.` so existing callers don't need to change.
- **`to_public()` no longer needs the friended private ctor** — swaps the private-side prefix out of the packed lineage and calls `hd_public::from_verified_components(point, chain, adjusted)`.
- `derive_private` and the ctor path use `public_.fingerprint()` and `public_.chain_code()` / `public_.point()` / `public_.lineage()` instead of the previously-inherited protected members.
- `wipe()` becomes `public_.wipe(); secret_.fill(0);`.
- Defaulted `operator<=>` continues to work — the compiler compares `public_` (via `hd_public`'s defaulted `<=>`) then `secret_`.

### Callers

The only non-C-API callers that relied on implicit `hd_private → hd_public` slicing were the wallet tests:

```cpp
hd_public const m_pub = *m;   // slice: copies base subobject
```

Updated to the explicit `to_public()` conversion:

```cpp
hd_public const m_pub = m->to_public();
```

That is a semantic fix as well as a syntactic one — the sliced `hd_public` carried the packed private+public prefix pair on its lineage, which `to_string()` happened to mask off but any downstream consumer that read `lineage().prefixes` directly would have seen the private prefix in the high bits. `to_public()` collapses it.

C-API is intentionally left untouched — the bulk regen at the end of the split picks up the reshuffled protected/private surface, the removed inheritance, and any `kth_hd_public_construct_from_hd_private` sliced-copy shim in one pass.

Part of the #422 split.

## Test plan

- [x] `kth_domain_test` passes locally (1_011_125 assertions in 3874 test cases)
- [ ] Bulk regen PR restores C-API build + tests