### PR TITLE
refactor(wallet): make address-returning APIs explicit

### DIFF
--- a/src/database/test/internal_database.cpp
+++ b/src/database/test/internal_database.cpp
@@ -1407,7 +1407,9 @@ REQUIRE(tx1.is_valid());
 
 for (auto const& i : tx1.inputs()) {
 
-    std::println("address HHHHHHHHHHHHHHHHH:{}", i.address());
+    if (auto const addr = i.address()) {
+        std::println("address HHHHHHHHHHHHHHHHH:{}", *addr);
+    }
 
     auto const& script = i.script();
 

--- a/src/domain/include/kth/domain/chain/input.hpp
+++ b/src/domain/include/kth/domain/chain/input.hpp
@@ -79,10 +79,11 @@ struct KD_API input {
 
     void set_sequence(uint32_t value);
 
-    /// The first payment address extracted (may be invalid).
-    /// NOTE: not cached — recomputed on every call.
+    /// The first payment address extracted from this input as a
+    /// standard script, or `nullopt` if the script has no recognised
+    /// pattern. NOTE: not cached — recomputed on every call.
     [[nodiscard]]
-    wallet::payment_address address() const;
+    std::optional<wallet::payment_address> address() const;
 
     /// The payment addresses extracted from this input as a standard script.
     /// NOTE: not cached — caller owns any caching it needs.

--- a/src/domain/include/kth/domain/chain/output.hpp
+++ b/src/domain/include/kth/domain/chain/output.hpp
@@ -98,14 +98,17 @@ struct KD_API output {
     void set_token_data(token_data_opt const& value);
     void set_token_data(token_data_opt&& value);
 
-    /// The payment address extracted from this output as a standard script.
-    /// NOTE: not cached — calling this in a hot loop recomputes each time.
+    /// The first payment address extracted from this output as a
+    /// standard script, or `nullopt` if the script has no recognised
+    /// pattern. NOTE: not cached — calling this in a hot loop
+    /// recomputes each time.
     [[nodiscard]]
-    wallet::payment_address address(bool testnet = false) const;
+    std::optional<wallet::payment_address> address(bool testnet = false) const;
 
-    /// The first payment address extracted (may be invalid).
+    /// The first payment address extracted, or `nullopt` if the
+    /// script has no recognised pattern.
     [[nodiscard]]
-    wallet::payment_address address(uint8_t p2kh_version, uint8_t p2sh_version) const;
+    std::optional<wallet::payment_address> address(uint8_t p2kh_version, uint8_t p2sh_version) const;
 
     /// The payment addresses extracted from this output as a standard script.
     /// NOTE: not cached — caller owns any caching it needs.

--- a/src/domain/include/kth/domain/wallet/bitcoin_uri.hpp
+++ b/src/domain/include/kth/domain/wallet/bitcoin_uri.hpp
@@ -64,8 +64,8 @@ struct KD_API bitcoin_uri {
     [[nodiscard]] std::string     message() const;
     [[nodiscard]] std::string     r() const;
     [[nodiscard]] std::string     address() const;
-    [[nodiscard]] payment_address payment() const;
-    [[nodiscard]] stealth_address stealth() const;
+    [[nodiscard]] expect<payment_address> payment() const;
+    [[nodiscard]] expect<stealth_address> stealth() const;
     [[nodiscard]] std::string     parameter(std::string const& key) const;
 
     /// Property setters.

--- a/src/domain/include/kth/domain/wallet/ec_private.hpp
+++ b/src/domain/include/kth/domain/wallet/ec_private.hpp
@@ -129,7 +129,7 @@ struct KD_API ec_private {
     ec_public to_public() const;
 
     [[nodiscard]]
-    payment_address to_payment_address() const;
+    expect<payment_address> to_payment_address() const;
 
 private:
     static

--- a/src/domain/include/kth/domain/wallet/ec_public.hpp
+++ b/src/domain/include/kth/domain/wallet/ec_public.hpp
@@ -98,7 +98,7 @@ struct KD_API ec_public {
     std::expected<ec_uncompressed, std::error_code> to_uncompressed() const;
 
     [[nodiscard]]
-    payment_address to_payment_address(uint8_t version = mainnet_p2kh) const;
+    expect<payment_address> to_payment_address(uint8_t version = mainnet_p2kh) const;
 
 private:
     static

--- a/src/domain/src/chain/input.cpp
+++ b/src/domain/src/chain/input.cpp
@@ -113,9 +113,12 @@ void input::set_sequence(uint32_t value) {
     sequence_ = value;
 }
 
-payment_address input::address() const {
+std::optional<payment_address> input::address() const {
     auto const value = addresses();
-    return value.empty() ? payment_address{} : value.front();
+    if (value.empty()) {
+        return std::nullopt;
+    }
+    return value.front();
 }
 
 payment_address::list input::addresses() const {

--- a/src/domain/src/chain/output.cpp
+++ b/src/domain/src/chain/output.cpp
@@ -215,16 +215,19 @@ void output::set_token_data(chain::token_data_opt&& x) {
     token_data_ = std::move(x);
 }
 
-payment_address output::address(bool testnet /*= false*/) const {
+std::optional<payment_address> output::address(bool testnet /*= false*/) const {
     if (testnet) {
         return address(wallet::payment_address::testnet_p2kh, wallet::payment_address::testnet_p2sh);
     }
     return address(wallet::payment_address::mainnet_p2kh, wallet::payment_address::mainnet_p2sh);
 }
 
-payment_address output::address(uint8_t p2kh_version, uint8_t p2sh_version) const {
+std::optional<payment_address> output::address(uint8_t p2kh_version, uint8_t p2sh_version) const {
     auto const value = addresses(p2kh_version, p2sh_version);
-    return value.empty() ? payment_address{} : value.front();
+    if (value.empty()) {
+        return std::nullopt;
+    }
+    return value.front();
 }
 
 payment_address::list output::addresses(uint8_t p2kh_version, uint8_t p2sh_version) const {

--- a/src/domain/src/wallet/bitcoin_uri.cpp
+++ b/src/domain/src/wallet/bitcoin_uri.cpp
@@ -75,12 +75,12 @@ std::string bitcoin_uri::r() const {
     return parameter(parameter_r);
 }
 
-payment_address bitcoin_uri::payment() const {
-    return payment_address::parse_from(address_).value_or(payment_address{});
+expect<payment_address> bitcoin_uri::payment() const {
+    return payment_address::parse_from(address_);
 }
 
-stealth_address bitcoin_uri::stealth() const {
-    return stealth_address::parse_from(address_).value_or(stealth_address{});
+expect<stealth_address> bitcoin_uri::stealth() const {
+    return stealth_address::parse_from(address_);
 }
 
 std::string bitcoin_uri::parameter(std::string const& key) const {

--- a/src/domain/src/wallet/ec_private.cpp
+++ b/src/domain/src/wallet/ec_private.cpp
@@ -127,8 +127,8 @@ ec_public ec_private::to_public() const {
     return ec_public{point, compressed()};
 }
 
-payment_address ec_private::to_payment_address() const {
-    return payment_address::from_ec_private(*this).value_or(payment_address{});
+expect<payment_address> ec_private::to_payment_address() const {
+    return payment_address::from_ec_private(*this);
 }
 
 } // namespace kth::domain::wallet

--- a/src/domain/src/wallet/ec_public.cpp
+++ b/src/domain/src/wallet/ec_public.cpp
@@ -126,8 +126,8 @@ std::expected<ec_uncompressed, std::error_code> ec_public::to_uncompressed() con
     return out;
 }
 
-payment_address ec_public::to_payment_address(uint8_t version) const {
-    return payment_address::from_ec_public(*this, version).value_or(payment_address{});
+expect<payment_address> ec_public::to_payment_address(uint8_t version) const {
+    return payment_address::from_ec_public(*this, version);
 }
 
 } // namespace kth::domain::wallet

--- a/src/domain/test/wallet/bitcoin_uri.cpp
+++ b/src/domain/test/wallet/bitcoin_uri.cpp
@@ -186,7 +186,7 @@ TEST_CASE("bitcoin uri payment valid expected", "[bitcoin uri]") {
     auto const expected_uri = std::string("bitcoin:") + expected_payment;
     auto const uri = bitcoin_uri::parse_from(expected_uri);
     REQUIRE(uri);
-    REQUIRE(uri->payment().encoded_legacy() == expected_payment);
+    REQUIRE(uri->payment()->encoded_legacy() == expected_payment);
 }
 
 TEST_CASE("bitcoin uri stealth valid expected", "[bitcoin uri]") {
@@ -194,7 +194,7 @@ TEST_CASE("bitcoin uri stealth valid expected", "[bitcoin uri]") {
     auto const expected_uri = std::string("bitcoin:") + expected_stealth;
     auto const uri = bitcoin_uri::parse_from(expected_uri);
     REQUIRE(uri);
-    REQUIRE(uri->stealth().encoded() == expected_stealth);
+    REQUIRE(uri->stealth()->encoded() == expected_stealth);
 }
 
 TEST_CASE("bitcoin uri address payment expected", "[bitcoin uri]") {

--- a/src/domain/test/wallet/uri_reader.cpp
+++ b/src/domain/test/wallet/uri_reader.cpp
@@ -94,7 +94,7 @@ private:
 TEST_CASE("uri reader parse typical uri test", "[uri reader]") {
     auto const uri = parse("bitcoin:113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD?amount=0.1");
     REQUIRE(uri.valid());
-    REQUIRE(uri.payment().encoded_legacy() == "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
+    REQUIRE(uri.payment()->encoded_legacy() == "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
     REQUIRE(uri.amount() == 10000000u);
     REQUIRE(uri.label().empty());
     REQUIRE(uri.message().empty());
@@ -142,7 +142,7 @@ TEST_CASE("uri reader parse negative unknown required parameter test", "[uri rea
 TEST_CASE("uri reader parse address test", "[uri reader]") {
     auto const uri = parse("bitcoin:113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
     REQUIRE(uri.valid());
-    REQUIRE(uri.payment().encoded_legacy() == "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
+    REQUIRE(uri.payment()->encoded_legacy() == "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
     REQUIRE(uri.amount() == 0);
     REQUIRE(uri.label().empty());
     REQUIRE(uri.message().empty());
@@ -152,7 +152,7 @@ TEST_CASE("uri reader parse address test", "[uri reader]") {
 TEST_CASE("uri reader parse uri encoded address test", "[uri reader]") {
     auto const uri = parse("bitcoin:%3113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
     REQUIRE(uri.valid());
-    REQUIRE(uri.payment().encoded_legacy() == "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
+    REQUIRE(uri.payment()->encoded_legacy() == "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
 }
 
 TEST_CASE("uri reader parse negative address test", "[uri reader]") {
@@ -164,7 +164,7 @@ TEST_CASE("uri reader parse negative address test", "[uri reader]") {
 TEST_CASE("uri reader parse amount only test", "[uri reader]") {
     auto const uri = parse("bitcoin:?amount=4.2");
     REQUIRE(uri.valid());
-    REQUIRE( ! uri.payment().valid());
+    REQUIRE( ! uri.payment());
     REQUIRE(uri.amount() == 420000000u);
     REQUIRE(uri.label().empty());
     REQUIRE(uri.message().empty());
@@ -185,7 +185,7 @@ TEST_CASE("uri reader parse invalid amount test", "[uri reader]") {
 TEST_CASE("uri reader parse label only test", "[uri reader]") {
     auto const uri = parse("bitcoin:?label=test");
     REQUIRE(uri.valid());
-    REQUIRE( ! uri.payment().valid());
+    REQUIRE( ! uri.payment());
     REQUIRE(uri.amount() == 0);
     REQUIRE(uri.label() == "test");
     REQUIRE(uri.message().empty());
@@ -218,7 +218,7 @@ TEST_CASE("uri reader parse negative strict encoded multibyte utf8 with unencode
 
 TEST_CASE("uri reader parse message only test", "[uri reader]") {
     auto const uri = parse("bitcoin:?message=Hi%20Alice");
-    REQUIRE( ! uri.payment().valid());
+    REQUIRE( ! uri.payment());
     REQUIRE(uri.amount() == 0);
     REQUIRE(uri.label().empty());
     REQUIRE(uri.message() == "Hi Alice");
@@ -227,7 +227,7 @@ TEST_CASE("uri reader parse message only test", "[uri reader]") {
 
 TEST_CASE("uri reader parse payment protocol only test", "[uri reader]") {
     auto const uri = parse("bitcoin:?r=http://www.example.com?purchase%3Dshoes");
-    REQUIRE( ! uri.payment().valid());
+    REQUIRE( ! uri.payment());
     REQUIRE(uri.amount() == 0);
     REQUIRE(uri.label().empty());
     REQUIRE(uri.message().empty());


### PR DESCRIPTION
## Summary

The five APIs that hand back a `payment_address` (or a `stealth_address`) but silently substituted a default-constructed sentinel on failure — matching the same pre-#422 pattern the `hd_*` refactors cleaned up — now return `std::optional<>` or `expect<>` at the boundary, forcing callers to face fallibility.

- **`chain::output::address(bool)` and `chain::output::address(uint8_t, uint8_t)` → `std::optional<payment_address>`**. Extracting from a script with no recognised pattern (OP_RETURN, bare multisig, BCH-2026 `pay_to_script`) is a genuine absence, not an error — `optional` matches the semantics; inventing an error code for "your script doesn't have an address" would be noise.
- **`chain::input::address()` → `std::optional<payment_address>`**, same rationale.
- **`wallet::ec_public::to_payment_address(uint8_t)` and `wallet::ec_private::to_payment_address()` → `expect<payment_address>`**. These forward the underlying `payment_address::from_ec_public / from_ec_private` factory (both `expect<>`); the old bodies were `.value_or(payment_address{})`, silently trading real error codes for an invalid sentinel.
- **`wallet::bitcoin_uri::payment()` and `wallet::bitcoin_uri::stealth()` → `expect<payment_address>` / `expect<stealth_address>`**. Both parsed the URI's `address_` string via a factory that already returned `expect<>`; the old body dropped the error code the same way with `.value_or(...)`.

Two non-test callers had to move: `internal_database.cpp` gates the `std::println` on the returned `optional` instead of formatting a default `payment_address`; `blockchain::interface::block_chain.cpp` is untouched — its `tx_address.valid()` checks run against the list returned by `payment_address::extract`, which is orthogonal to the new `input::address()`/`output::address()` signatures.

Test updates: `uri_reader.cpp` and `bitcoin_uri.cpp` swap `.payment().encoded_legacy()` for `.payment()->encoded_legacy()` and `! .payment().valid()` for `! .payment()`.

**`payment_address` itself keeps its default ctor + `.valid()` for now** — dropping them cascades through eight `cashtoken_minting` param structs that hold `payment_address destination` by value and would have to become `std::optional`, plus a rewrite of the associated tests and internal `.valid()` checks. That is its own PR.

C-API surface for `output`, `input`, `ec_public`, `ec_private`, and `bitcoin_uri` is intentionally left untouched — the bulk regen at the end of the split picks up the new return shapes in one pass.

Part of the #422 split.

## Test plan

- [x] `kth_domain_test` passes locally (1_011_125 assertions in 3874 test cases)
- [ ] Bulk regen PR restores C-API build + tests