### PR TITLE
refactor(wallet): make payment_address valid-by-construction

### DIFF
--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -1493,7 +1493,7 @@ std::vector<mempool_transaction_summary> block_chain::get_mempool_transactions(
             auto const tx_addresses = kth::domain::wallet::payment_address::extract(
                 output.script(), encoding_p2kh, encoding_p2sh);
             for (auto const tx_address : tx_addresses) {
-                if (tx_address.valid() && addrs.find(tx_address) != addrs.end()) {
+                if (addrs.find(tx_address) != addrs.end()) {
                     ret.push_back(mempool_transaction_summary(
                         tx_address.encoded_cashaddr(false), kth::encode_hash(tx.hash()), "",
                         "", std::to_string(output.value()), i, tx_res.arrival_time()));
@@ -1507,7 +1507,7 @@ std::vector<mempool_transaction_summary> block_chain::get_mempool_transactions(
             auto const tx_addresses = kth::domain::wallet::payment_address::extract(
                 input.script(), encoding_p2kh, encoding_p2sh);
             for (auto const tx_address : tx_addresses) {
-                if (tx_address.valid() && addrs.find(tx_address) != addrs.end()) {
+                if (addrs.find(tx_address) != addrs.end()) {
                     auto const prev_tx = database_.internal_db().get_transaction(
                         input.previous_output().hash(), max_size_t);
                     if (prev_tx) {

--- a/src/domain/include/kth/domain/wallet/payment_address.hpp
+++ b/src/domain/include/kth/domain/wallet/payment_address.hpp
@@ -31,15 +31,13 @@ size_t payment_size = 1U + short_hash_size + checksum_size;  // 1 + 20 + sizeof(
 
 using payment = byte_array<payment_size>;
 
-/**
- * Non-stealth payment address (P2PKH, P2SH, or 32-byte hash variants).
- *
- * Default-constructible so callers that hold `payment_address` as a
- * struct member (e.g. `stealth_sender::address_`,
- * `cashtoken_minting::*::destination`) can fill it later via
- * assignment; fallible construction goes through the `parse_from`
- * / `from_*` named factories, each returning `expect<payment_address>`.
- */
+/// Non-stealth payment address (P2PKH, P2SH, or 32-byte hash variants).
+/// Valid-by-construction: every reachable instance was produced by a
+/// factory returning `expect<>` or an infallible ctor over already-
+/// validated components. Callers that hold `payment_address` as a
+/// struct member and fill it later wrap it in `std::optional<>`
+/// (see e.g. `stealth_sender::address_` and the `cashtoken_minting`
+/// param structs).
 struct KD_API payment_address {
 
 #if defined(KTH_CURRENCY_LTC)
@@ -108,8 +106,6 @@ struct KD_API payment_address {
     static
     expect<payment_address> from_pay_public_key_hash_script(chain::script const& script, uint8_t version);
 
-    payment_address() = default;
-
     /// Wrap a 20-byte hash160 payload directly. Infallible.
     payment_address(short_hash const& short_hash, uint8_t version);
 
@@ -117,17 +113,7 @@ struct KD_API payment_address {
     payment_address(hash_digest const& hash, uint8_t version);
 
     [[nodiscard]]
-    friend bool operator==(payment_address const&, payment_address const&) = default;
-
-    /// Canonical order matches the canonical `to_string()`: cashaddr
-    /// (token-unaware) under BCH, legacy base58 otherwise.
-    [[nodiscard]]
-    friend auto operator<=>(payment_address const& a, payment_address const& b) {
-        return a.to_string() <=> b.to_string();
-    }
-
-    [[nodiscard]]
-    bool valid() const noexcept { return valid_; }
+    friend auto operator<=>(payment_address const&, payment_address const&) = default;
 
     /// Canonical string form. Used by `fmt::formatter<payment_address>`.
     /// Cashaddr (token-unaware) under BCH; legacy base58 otherwise.
@@ -199,7 +185,6 @@ private:
     std::optional<config::network> detect_cashaddr_network(std::string const& address);
 #endif  //KTH_CURRENCY_BCH
 
-    bool valid_{false};
     uint8_t version_{0};
     hash_digest hash_data_{null_hash};
     size_t hash_size_{0};

--- a/src/domain/include/kth/domain/wallet/stealth_sender.hpp
+++ b/src/domain/include/kth/domain/wallet/stealth_sender.hpp
@@ -6,6 +6,7 @@
 #define KTH_WALLET_STEALTH_SENDER_HPP
 
 #include <cstdint>
+#include <optional>
 
 #include <kth/domain/chain/script.hpp>
 #include <kth/domain/define.hpp>
@@ -49,7 +50,7 @@ private:
 
     uint8_t const version_;
     chain::script script_;
-    wallet::payment_address address_;
+    std::optional<wallet::payment_address> address_;
 };
 
 } // namespace kth::domain::wallet

--- a/src/domain/src/wallet/cashtoken_minting.cpp
+++ b/src/domain/src/wallet/cashtoken_minting.cpp
@@ -114,15 +114,7 @@ chain::output create_combined_token_output(
 
 std::expected<prepare_genesis_result, std::error_code>
 prepare_genesis_utxo(prepare_genesis_params const& params) {
-    if ( ! params.destination.valid()) {
-        return std::unexpected(kth::error::operation_failed);
-    }
 
-    // An explicit `change_address`, if set, must be a valid address —
-    // otherwise the optional BCH change output would be unspendable.
-    if (params.change_address.has_value() && ! params.change_address->valid()) {
-        return std::unexpected(kth::error::invalid_change);
-    }
 
     // The funding UTXO is spent for its BCH only; a token-bearing
     // input here would be consumed without re-emitting its tokens,
@@ -216,17 +208,6 @@ prepare_genesis_utxo(prepare_genesis_params const& params) {
 
 std::expected<token_genesis_result, std::error_code>
 create_token_genesis(token_genesis_params const& params) {
-    // Destination address must be valid — silently building a TX with a
-    // default-constructed address would produce an unspendable output.
-    if ( ! params.destination.valid()) {
-        return std::unexpected(kth::error::operation_failed);
-    }
-
-    // An explicit `change_address`, if set, must also be valid.
-    if (params.change_address.has_value() && ! params.change_address->valid()) {
-        return std::unexpected(kth::error::invalid_change);
-    }
-
     // CashTokens CHIP: the token genesis input MUST spend output index 0
     // of its parent transaction. The resulting category ID equals the
     // hash of that parent transaction.
@@ -407,13 +388,6 @@ create_token_mint(token_mint_params const& params) {
         return std::unexpected(kth::error::operation_failed);
     }
 
-    // Destinations (one per requested NFT) must all be valid addresses.
-    for (auto const& req : params.nfts) {
-        if ( ! req.destination.valid()) {
-            return std::unexpected(kth::error::operation_failed);
-        }
-    }
-
     // Each request's capability byte must be one of the three valid
     // values (none/mut/minting). `capability_t` can hold any `uint8_t`
     // via casts, so this is the first line of defence before the
@@ -424,10 +398,6 @@ create_token_mint(token_mint_params const& params) {
         }
     }
 
-    // An explicit `change_address`, if set, must be a valid address.
-    if (params.change_address.has_value() && ! params.change_address->valid()) {
-        return std::unexpected(kth::error::invalid_change);
-    }
 
     // Validate each NFT commitment against the cap that applies under
     // the active script flags.
@@ -590,9 +560,6 @@ create_token_mint(token_mint_params const& params) {
         return std::unexpected(kth::error::operation_failed);
     }
     payment_address const minting_dest = *params.minting_destination;
-    if ( ! minting_dest.valid()) {
-        return std::unexpected(kth::error::operation_failed);
-    }
 
     // Assemble outputs: 1 preserved + N minted + optional BCH change.
     chain::output::list outputs;
@@ -659,9 +626,6 @@ create_token_mint(token_mint_params const& params) {
 
 std::expected<token_tx_result, std::error_code>
 create_token_transfer(token_transfer_params const& params) {
-    if ( ! params.destination.valid()) {
-        return std::unexpected(kth::error::operation_failed);
-    }
 
     // Exactly one of ft_amount / nft must be requested. Requesting both
     // would ambiguate whether the same output carries them together or
@@ -792,15 +756,12 @@ create_token_transfer(token_transfer_params const& params) {
     // be valid — an optional wrapping a default-constructed address
     // would otherwise slip past `has_value()` and produce unspendable
     // token-carrying outputs, permanently burning those tokens.
-    payment_address token_change_addr;
+    std::optional<payment_address> token_change_addr;
     if (emit_ft_change || n_carried_nft_outs > 0) {
         if ( ! params.token_change_address.has_value()) {
             return std::unexpected(kth::error::invalid_change);
         }
-        token_change_addr = *params.token_change_address;
-        if ( ! token_change_addr.valid()) {
-            return std::unexpected(kth::error::invalid_change);
-        }
+        token_change_addr = params.token_change_address;
     }
 
     // ---------------------------------------------------------------
@@ -873,18 +834,17 @@ create_token_transfer(token_transfer_params const& params) {
     // Prefer an explicit BCH change address; fall back to the token
     // change address if any, and ultimately to the destination as a
     // safe default so a valid transfer never fails on missing change
-    // metadata. The resolved address must be valid for the same reason
-    // explained above (avoid burning change to an unspendable output).
-    payment_address bch_change_addr;
+    // metadata.
+    std::optional<payment_address> bch_change_addr;
     if (emit_bch_change) {
         if (params.bch_change_address.has_value()) {
-            bch_change_addr = *params.bch_change_address;
+            bch_change_addr = params.bch_change_address;
         } else if (params.token_change_address.has_value()) {
-            bch_change_addr = *params.token_change_address;
+            bch_change_addr = params.token_change_address;
         } else {
             bch_change_addr = params.destination;
         }
-        if ( ! bch_change_addr.valid()) {
+        if ( ! bch_change_addr.has_value()) {
             return std::unexpected(kth::error::invalid_change);
         }
     }
@@ -924,7 +884,7 @@ create_token_transfer(token_transfer_params const& params) {
     if (emit_ft_change) {
         outputs.emplace_back(
             per_token_output_sats,
-            p2pkh(token_change_addr),
+            p2pkh(*token_change_addr),
             chain::token_data_opt{chain::make_fungible(category_id, ft_change)}
         );
     }
@@ -934,7 +894,7 @@ create_token_transfer(token_transfer_params const& params) {
     for (auto const& nft : carried_nfts) {
         outputs.emplace_back(
             per_token_output_sats,
-            p2pkh(token_change_addr),
+            p2pkh(*token_change_addr),
             chain::token_data_opt{chain::make_non_fungible(
                 category_id,
                 nft.capability,
@@ -947,7 +907,7 @@ create_token_transfer(token_transfer_params const& params) {
     if (emit_bch_change) {
         outputs.emplace_back(
             bch_change,
-            p2pkh(bch_change_addr),
+            p2pkh(*bch_change_addr),
             chain::token_data_opt{}
         );
     }
@@ -982,16 +942,9 @@ create_token_transfer(token_transfer_params const& params) {
 
 std::expected<token_tx_result, std::error_code>
 create_token_burn(token_burn_params const& params) {
-    if ( ! params.destination.valid()) {
-        return std::unexpected(kth::error::operation_failed);
-    }
 
-    // An explicit `change_address`, if set, must be a valid address —
     // otherwise `value_or(destination)` would happily emit BCH change
     // to an unspendable output.
-    if (params.change_address.has_value() && ! params.change_address->valid()) {
-        return std::unexpected(kth::error::invalid_change);
-    }
 
     if ( ! params.token_utxo.token_data().has_value()) {
         return std::unexpected(kth::error::token_invalid_category);
@@ -1194,19 +1147,20 @@ create_ft(ft_params const& params) {
     // for the two most common flows — creating a pure FT with fixed
     // supply, or a FT paired with a minting NFT so the creator can
     // later mint NFTs of the same category.
-    token_genesis_params gp{};
-    gp.genesis_utxo = params.genesis_utxo;
-    gp.destination = params.destination;
-    gp.ft_amount = params.total_supply;
+    token_genesis_params gp{
+        .genesis_utxo = params.genesis_utxo,
+        .destination = params.destination,
+        .ft_amount = params.total_supply,
+        .fee_utxos = params.fee_utxos,
+        .change_address = params.change_address,
+        .script_flags = params.script_flags,
+    };
     if (params.with_minting_nft) {
         gp.nft = nft_spec{
             chain::capability_t::minting,
             data_chunk{0x00}
         };
     }
-    gp.fee_utxos = params.fee_utxos;
-    gp.change_address = params.change_address;
-    gp.script_flags = params.script_flags;
     return create_token_genesis(gp);
 }
 
@@ -1219,45 +1173,32 @@ create_nft_collection(nft_collection_params const& params) {
         return std::unexpected(kth::error::operation_failed);
     }
 
-    // Validate every NFT commitment and destination up front — under
-    // the active script flags' cap — so a later batch failure doesn't
-    // leave the caller with a half-executed plan on-chain. Destinations
-    // are checked for the same reason: an explicit optional wrapping a
-    // default-constructed address would pass `has_value()`, survive
-    // `value_or`, and only blow up inside `create_token_mint` for that
-    // batch — after earlier batches may have been broadcast.
+    // Validate every NFT commitment up front — under the active script
+    // flags' cap — so a later batch failure doesn't leave the caller
+    // with a half-executed plan on-chain.
     size_t const commitment_cap = chain::max_token_commitment_length(params.script_flags);
     for (auto const& item : params.nfts) {
         if (item.commitment.size() > commitment_cap) {
             return std::unexpected(kth::error::token_commitment_oversized);
         }
-        if (item.destination.has_value() && ! item.destination->valid()) {
-            return std::unexpected(kth::error::operation_failed);
-        }
-    }
-    // The fallback for per-item destinations is `creator_address`; if
-    // any item omits its destination, `creator_address` must be valid
-    // so it produces spendable mint outputs. (Also re-validated by
-    // `create_token_genesis` below for its own use.)
-    if ( ! params.creator_address.valid()) {
-        return std::unexpected(kth::error::operation_failed);
     }
 
     // Step 1: build the genesis TX. The minting NFT starts with
     // commitment `{0x00}` which doubles as a "next NFT index = 0"
     // counter — callers who want a meaningful counter can reinterpret
     // the commitment in subsequent mints via `new_minting_commitment`.
-    token_genesis_params gp{};
-    gp.genesis_utxo = params.genesis_utxo;
-    gp.destination = params.creator_address;
-    gp.ft_amount = params.ft_amount;
-    gp.nft = nft_spec{
-        chain::capability_t::minting,
-        data_chunk{0x00}
+    token_genesis_params gp{
+        .genesis_utxo = params.genesis_utxo,
+        .destination = params.creator_address,
+        .ft_amount = params.ft_amount,
+        .nft = nft_spec{
+            chain::capability_t::minting,
+            data_chunk{0x00}
+        },
+        .fee_utxos = params.fee_utxos,
+        .change_address = params.change_address,
+        .script_flags = params.script_flags,
     };
-    gp.fee_utxos = params.fee_utxos;
-    gp.change_address = params.change_address;
-    gp.script_flags = params.script_flags;
 
     auto genesis = create_token_genesis(gp);
     if ( ! genesis.has_value()) {
@@ -1274,12 +1215,11 @@ create_nft_collection(nft_collection_params const& params) {
         nft_collection_batch batch{};
         batch.mint_requests.reserve(end - i);
         for (size_t j = i; j < end; ++j) {
-            nft_mint_request req{};
-            req.destination = params.nfts[j].destination.value_or(params.creator_address);
-            req.commitment = params.nfts[j].commitment;
-            req.capability = chain::capability_t::none;   // minted NFTs are immutable
-            req.satoshis = token_dust_limit;
-            batch.mint_requests.push_back(std::move(req));
+            batch.mint_requests.emplace_back(
+                params.nfts[j].destination.value_or(params.creator_address),
+                params.nfts[j].commitment,
+                chain::capability_t::none,   // minted NFTs are immutable
+                token_dust_limit);
         }
         batches.push_back(std::move(batch));
     }

--- a/src/domain/src/wallet/payment_address.cpp
+++ b/src/domain/src/wallet/payment_address.cpp
@@ -34,16 +34,14 @@ using namespace kth::domain::wallet;
 namespace kth::domain::wallet {
 
 payment_address::payment_address(short_hash const& short_hash, uint8_t version)
-    : valid_(true)
-    , version_(version)
+    : version_(version)
     , hash_size_(short_hash.size())
 {
     std::copy_n(short_hash.begin(), short_hash.size(), hash_data_.begin());
 }
 
 payment_address::payment_address(hash_digest const& hash, uint8_t version)
-    : valid_(true)
-    , version_(version)
+    : version_(version)
     , hash_data_(hash)
     , hash_size_(hash.size())
 {}

--- a/src/domain/src/wallet/stealth_sender.cpp
+++ b/src/domain/src/wallet/stealth_sender.cpp
@@ -35,7 +35,7 @@ stealth_sender::stealth_sender(ec_secret const& ephemeral_private,
 }
 
 stealth_sender::operator bool() const {
-    return address_.valid();
+    return address_.has_value();
 }
 
 // private
@@ -72,9 +72,9 @@ chain::script const& stealth_sender::stealth_script() const {
     return script_;
 }
 
-// Will be invalid if construct fails.
+// Precondition: `operator bool()` returned true.
 const wallet::payment_address& stealth_sender::payment_address() const {
-    return address_;
+    return *address_;
 }
 
 } // namespace kth::domain::wallet

--- a/src/domain/test/wallet/bitcoin_uri.cpp
+++ b/src/domain/test/wallet/bitcoin_uri.cpp
@@ -92,7 +92,6 @@ TEST_CASE("bitcoin uri set path reset stealth after payment expected encoding", 
 
     bitcoin_uri uri;
     auto const payment = payment_address::parse_from("113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD").value();
-    REQUIRE(payment.valid());
     uri.set_address(payment);
     auto const stealth = stealth_address::parse_from(expected_stealth);
     REQUIRE(stealth);

--- a/src/domain/test/wallet/cashtoken_minting.cpp
+++ b/src/domain/test/wallet/cashtoken_minting.cpp
@@ -190,9 +190,8 @@ TEST_CASE("create_combined_token_output carries both FT and NFT in one output", 
 // ===========================================================================
 
 TEST_CASE("prepare_genesis_utxo produces a TX with output 0 at the requested amount", "[cashtoken_minting]") {
-    prepare_genesis_params params{};
+    prepare_genesis_params params{.destination = make_addr(0x11)};
     params.utxo = make_bch_utxo(parent_tx_a, 3, 50000);
-    params.destination = make_addr(0x11);
     params.satoshis = 10000;
 
     auto result = prepare_genesis_utxo(params);
@@ -207,9 +206,8 @@ TEST_CASE("prepare_genesis_utxo produces a TX with output 0 at the requested amo
 }
 
 TEST_CASE("prepare_genesis_utxo rejects dust-level requested amount", "[cashtoken_minting]") {
-    prepare_genesis_params params{};
+    prepare_genesis_params params{.destination = make_addr(0x11)};
     params.utxo = make_bch_utxo(parent_tx_a, 0, 50000);
-    params.destination = make_addr(0x11);
     params.satoshis = 100;                // below bch_dust_limit
 
     auto result = prepare_genesis_utxo(params);
@@ -217,9 +215,8 @@ TEST_CASE("prepare_genesis_utxo rejects dust-level requested amount", "[cashtoke
 }
 
 TEST_CASE("prepare_genesis_utxo rejects insufficient input funds", "[cashtoken_minting]") {
-    prepare_genesis_params params{};
+    prepare_genesis_params params{.destination = make_addr(0x11)};
     params.utxo = make_bch_utxo(parent_tx_a, 0, 1000);   // barely above the request
-    params.destination = make_addr(0x11);
     params.satoshis = 10000;
 
     auto result = prepare_genesis_utxo(params);
@@ -231,9 +228,8 @@ TEST_CASE("prepare_genesis_utxo rejects insufficient input funds", "[cashtoken_m
 // ===========================================================================
 
 TEST_CASE("create_token_genesis requires the genesis UTXO to spend output index 0", "[cashtoken_minting]") {
-    token_genesis_params params{};
+    token_genesis_params params{.destination = make_addr(0x11)};
     params.genesis_utxo = make_bch_utxo(parent_tx_a, /*index=*/3, 50000);
-    params.destination = make_addr(0x11);
     params.ft_amount = 1000;
 
     auto result = create_token_genesis(params);
@@ -242,9 +238,8 @@ TEST_CASE("create_token_genesis requires the genesis UTXO to spend output index 
 }
 
 TEST_CASE("create_token_genesis requires at least one payload kind", "[cashtoken_minting]") {
-    token_genesis_params params{};
+    token_genesis_params params{.destination = make_addr(0x11)};
     params.genesis_utxo = make_bch_utxo(parent_tx_a, 0, 50000);
-    params.destination = make_addr(0x11);
     // neither ft_amount nor nft set
 
     auto result = create_token_genesis(params);
@@ -252,9 +247,8 @@ TEST_CASE("create_token_genesis requires at least one payload kind", "[cashtoken
 }
 
 TEST_CASE("create_token_genesis creates a pure-fungible genesis output", "[cashtoken_minting]") {
-    token_genesis_params params{};
+    token_genesis_params params{.destination = make_addr(0x11)};
     params.genesis_utxo = make_bch_utxo(parent_tx_a, 0, 50000);
-    params.destination = make_addr(0x11);
     params.ft_amount = 1'000'000;
 
     auto result = create_token_genesis(params);
@@ -271,9 +265,8 @@ TEST_CASE("create_token_genesis creates a pure-fungible genesis output", "[casht
 }
 
 TEST_CASE("create_token_genesis creates a minting NFT (nft-only, minting capability)", "[cashtoken_minting]") {
-    token_genesis_params params{};
+    token_genesis_params params{.destination = make_addr(0x11)};
     params.genesis_utxo = make_bch_utxo(parent_tx_a, 0, 50000);
-    params.destination = make_addr(0x11);
     params.nft = nft_spec{capability_t::minting, data_chunk{0x00}};
 
     auto result = create_token_genesis(params);
@@ -284,9 +277,8 @@ TEST_CASE("create_token_genesis creates a minting NFT (nft-only, minting capabil
 }
 
 TEST_CASE("create_token_genesis creates FT + minting NFT combined output", "[cashtoken_minting]") {
-    token_genesis_params params{};
+    token_genesis_params params{.destination = make_addr(0x11)};
     params.genesis_utxo = make_bch_utxo(parent_tx_a, 0, 50000);
-    params.destination = make_addr(0x11);
     params.ft_amount = 1000;
     params.nft = nft_spec{capability_t::minting, data_chunk{0x00}};
 
@@ -299,9 +291,8 @@ TEST_CASE("create_token_genesis creates FT + minting NFT combined output", "[cas
 }
 
 TEST_CASE("create_token_genesis rejects oversized NFT commitment (>40 bytes)", "[cashtoken_minting]") {
-    token_genesis_params params{};
+    token_genesis_params params{.destination = make_addr(0x11)};
     params.genesis_utxo = make_bch_utxo(parent_tx_a, 0, 50000);
-    params.destination = make_addr(0x11);
     params.nft = nft_spec{
         capability_t::none,
         data_chunk(41, 0xAB)
@@ -313,9 +304,8 @@ TEST_CASE("create_token_genesis rejects oversized NFT commitment (>40 bytes)", "
 }
 
 TEST_CASE("create_token_genesis rejects zero fungible amount", "[cashtoken_minting]") {
-    token_genesis_params params{};
+    token_genesis_params params{.destination = make_addr(0x11)};
     params.genesis_utxo = make_bch_utxo(parent_tx_a, 0, 50000);
-    params.destination = make_addr(0x11);
     params.ft_amount = 0;
 
     auto result = create_token_genesis(params);
@@ -324,9 +314,8 @@ TEST_CASE("create_token_genesis rejects zero fungible amount", "[cashtoken_minti
 }
 
 TEST_CASE("create_token_genesis rejects fungible amount above INT64_MAX", "[cashtoken_minting]") {
-    token_genesis_params params{};
+    token_genesis_params params{.destination = make_addr(0x11)};
     params.genesis_utxo = make_bch_utxo(parent_tx_a, 0, 50000);
-    params.destination = make_addr(0x11);
     params.ft_amount = static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1;
 
     auto result = create_token_genesis(params);
@@ -430,10 +419,9 @@ TEST_CASE("create_token_mint updates the minting NFT commitment when requested",
 // ===========================================================================
 
 TEST_CASE("create_token_transfer sends a fungible amount and emits token change", "[cashtoken_minting]") {
-    token_transfer_params params{};
+    token_transfer_params params{.destination = make_addr(0x22)};
     params.token_utxos.push_back(make_ft_utxo(parent_tx_a, 0, category_a, 1000, 800));
     params.fee_utxos.push_back(make_bch_utxo(parent_tx_b, 0, 50000));
-    params.destination = make_addr(0x22);
     params.ft_amount = 300;
     params.token_change_address = make_addr(0x11);
     params.bch_change_address = make_addr(0x11);
@@ -451,10 +439,9 @@ TEST_CASE("create_token_transfer sends a fungible amount and emits token change"
 }
 
 TEST_CASE("create_token_transfer rejects insufficient fungible supply", "[cashtoken_minting]") {
-    token_transfer_params params{};
+    token_transfer_params params{.destination = make_addr(0x22)};
     params.token_utxos.push_back(make_ft_utxo(parent_tx_a, 0, category_a, 100));
     params.fee_utxos.push_back(make_bch_utxo(parent_tx_b, 0, 50000));
-    params.destination = make_addr(0x22);
     params.ft_amount = 1000;
     params.token_change_address = make_addr(0x11);
 
@@ -464,10 +451,9 @@ TEST_CASE("create_token_transfer rejects insufficient fungible supply", "[cashto
 }
 
 TEST_CASE("create_token_transfer rejects zero fungible amount", "[cashtoken_minting]") {
-    token_transfer_params params{};
+    token_transfer_params params{.destination = make_addr(0x22)};
     params.token_utxos.push_back(make_ft_utxo(parent_tx_a, 0, category_a, 1000));
     params.fee_utxos.push_back(make_bch_utxo(parent_tx_b, 0, 50000));
-    params.destination = make_addr(0x22);
     params.ft_amount = 0;
     params.token_change_address = make_addr(0x11);
 
@@ -483,10 +469,9 @@ TEST_CASE("create_token_transfer rejects fungible amount above INT64_MAX", "[cas
     // validation — returning a clear API error here is the difference
     // between a loud compile-time-quality rejection and a silent
     // unrelayable TX handed back to the caller.
-    token_transfer_params params{};
+    token_transfer_params params{.destination = make_addr(0x22)};
     params.token_utxos.push_back(make_ft_utxo(parent_tx_a, 0, category_a, 1000));
     params.fee_utxos.push_back(make_bch_utxo(parent_tx_b, 0, 50000));
-    params.destination = make_addr(0x22);
     params.ft_amount = static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1;
     params.token_change_address = make_addr(0x11);
 
@@ -499,11 +484,10 @@ TEST_CASE("create_token_transfer rejects UTXOs from different categories", "[cas
     hash_digest category_b = {{0xBB, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x02}};
 
-    token_transfer_params params{};
+    token_transfer_params params{.destination = make_addr(0x22)};
     params.token_utxos.push_back(make_ft_utxo(parent_tx_a, 0, category_a, 100));
     params.token_utxos.push_back(make_ft_utxo(parent_tx_a, 1, category_b, 100));
     params.fee_utxos.push_back(make_bch_utxo(parent_tx_b, 0, 50000));
-    params.destination = make_addr(0x22);
     params.ft_amount = 50;
     params.token_change_address = make_addr(0x11);
 
@@ -514,11 +498,10 @@ TEST_CASE("create_token_transfer rejects UTXOs from different categories", "[cas
 
 TEST_CASE("create_token_transfer transfers an NFT identified by commitment", "[cashtoken_minting]") {
     data_chunk target{0xDE, 0xAD};
-    token_transfer_params params{};
+    token_transfer_params params{.destination = make_addr(0x22)};
     params.token_utxos.push_back(make_nft_utxo(
         parent_tx_a, 0, category_a, capability_t::none, target));
     params.fee_utxos.push_back(make_bch_utxo(parent_tx_b, 0, 50000));
-    params.destination = make_addr(0x22);
     params.nft = nft_spec{capability_t::none, target};
 
     auto result = create_token_transfer(params);
@@ -529,11 +512,10 @@ TEST_CASE("create_token_transfer transfers an NFT identified by commitment", "[c
 }
 
 TEST_CASE("create_token_transfer rejects NFT not present in inputs", "[cashtoken_minting]") {
-    token_transfer_params params{};
+    token_transfer_params params{.destination = make_addr(0x22)};
     params.token_utxos.push_back(make_nft_utxo(
         parent_tx_a, 0, category_a, capability_t::none, data_chunk{0x01}));
     params.fee_utxos.push_back(make_bch_utxo(parent_tx_b, 0, 50000));
-    params.destination = make_addr(0x22);
     params.nft = nft_spec{capability_t::none, data_chunk{0xFF}};
 
     auto result = create_token_transfer(params);
@@ -545,10 +527,9 @@ TEST_CASE("create_token_transfer rejects NFT not present in inputs", "[cashtoken
 // ===========================================================================
 
 TEST_CASE("create_token_burn destroys all fungible tokens when amount == balance", "[cashtoken_minting]") {
-    token_burn_params params{};
+    token_burn_params params{.destination = make_addr(0x22)};
     params.token_utxo = make_ft_utxo(parent_tx_a, 0, category_a, 1000, 800);
     params.fee_utxos.push_back(make_bch_utxo(parent_tx_b, 0, 50000));
-    params.destination = make_addr(0x22);
     params.burn_ft_amount = 1000;
 
     auto result = create_token_burn(params);
@@ -559,10 +540,9 @@ TEST_CASE("create_token_burn destroys all fungible tokens when amount == balance
 }
 
 TEST_CASE("create_token_burn destroys part of the FT supply and keeps the rest", "[cashtoken_minting]") {
-    token_burn_params params{};
+    token_burn_params params{.destination = make_addr(0x22)};
     params.token_utxo = make_ft_utxo(parent_tx_a, 0, category_a, 1000, 800);
     params.fee_utxos.push_back(make_bch_utxo(parent_tx_b, 0, 50000));
-    params.destination = make_addr(0x22);
     params.burn_ft_amount = 300;
 
     auto result = create_token_burn(params);
@@ -573,10 +553,9 @@ TEST_CASE("create_token_burn destroys part of the FT supply and keeps the rest",
 }
 
 TEST_CASE("create_token_burn refuses to burn more FT than the UTXO holds", "[cashtoken_minting]") {
-    token_burn_params params{};
+    token_burn_params params{.destination = make_addr(0x22)};
     params.token_utxo = make_ft_utxo(parent_tx_a, 0, category_a, 100, 800);
     params.fee_utxos.push_back(make_bch_utxo(parent_tx_b, 0, 50000));
-    params.destination = make_addr(0x22);
     params.burn_ft_amount = 1000;
 
     auto result = create_token_burn(params);
@@ -585,12 +564,11 @@ TEST_CASE("create_token_burn refuses to burn more FT than the UTXO holds", "[cas
 }
 
 TEST_CASE("create_token_burn burns the NFT while keeping the FT side of a both-kinds UTXO", "[cashtoken_minting]") {
-    token_burn_params params{};
+    token_burn_params params{.destination = make_addr(0x22)};
     params.token_utxo = make_both_utxo(
         parent_tx_a, 0, category_a, 500,
         capability_t::minting, data_chunk{0x00}, 10000);
     params.fee_utxos.push_back(make_bch_utxo(parent_tx_b, 0, 50000));
-    params.destination = make_addr(0x22);
     params.burn_nft = true;
 
     auto result = create_token_burn(params);
@@ -603,9 +581,8 @@ TEST_CASE("create_token_burn burns the NFT while keeping the FT side of a both-k
 }
 
 TEST_CASE("create_token_burn refuses a no-op burn request", "[cashtoken_minting]") {
-    token_burn_params params{};
+    token_burn_params params{.destination = make_addr(0x22)};
     params.token_utxo = make_ft_utxo(parent_tx_a, 0, category_a, 1000, 800);
-    params.destination = make_addr(0x22);
     // neither burn_ft_amount nor burn_nft
 
     auto result = create_token_burn(params);
@@ -613,10 +590,9 @@ TEST_CASE("create_token_burn refuses a no-op burn request", "[cashtoken_minting]
 }
 
 TEST_CASE("create_token_burn attaches an OP_RETURN message when provided", "[cashtoken_minting]") {
-    token_burn_params params{};
+    token_burn_params params{.destination = make_addr(0x22)};
     params.token_utxo = make_ft_utxo(parent_tx_a, 0, category_a, 1000, 800);
     params.fee_utxos.push_back(make_bch_utxo(parent_tx_b, 0, 50000));
-    params.destination = make_addr(0x22);
     params.burn_ft_amount = 1000;
     params.message = std::string{"final supply close"};
 
@@ -633,9 +609,8 @@ TEST_CASE("create_token_burn attaches an OP_RETURN message when provided", "[cas
 // ===========================================================================
 
 TEST_CASE("create_ft builds a simple FT genesis", "[cashtoken_minting]") {
-    ft_params params{};
+    ft_params params{.destination = make_addr(0x11)};
     params.genesis_utxo = make_bch_utxo(parent_tx_a, 0, 50000);
-    params.destination = make_addr(0x11);
     params.total_supply = 21'000'000;
 
     auto result = create_ft(params);
@@ -646,9 +621,8 @@ TEST_CASE("create_ft builds a simple FT genesis", "[cashtoken_minting]") {
 }
 
 TEST_CASE("create_ft with_minting_nft produces both FT and minting NFT", "[cashtoken_minting]") {
-    ft_params params{};
+    ft_params params{.destination = make_addr(0x11)};
     params.genesis_utxo = make_bch_utxo(parent_tx_a, 0, 50000);
-    params.destination = make_addr(0x11);
     params.total_supply = 1'000'000;
     params.with_minting_nft = true;
 
@@ -664,9 +638,8 @@ TEST_CASE("create_ft with_minting_nft produces both FT and minting NFT", "[casht
 // ===========================================================================
 
 TEST_CASE("create_nft_collection partitions NFTs into batches and returns a plan", "[cashtoken_minting]") {
-    nft_collection_params params{};
+    nft_collection_params params{.creator_address = make_addr(0x11)};
     params.genesis_utxo = make_bch_utxo(parent_tx_a, 0, 1'000'000);
-    params.creator_address = make_addr(0x11);
     for (uint8_t i = 0; i < 12; ++i) {
         params.nfts.push_back({data_chunk{uint8_t(i + 1)}, std::nullopt});
     }
@@ -684,9 +657,8 @@ TEST_CASE("create_nft_collection partitions NFTs into batches and returns a plan
 }
 
 TEST_CASE("create_nft_collection honours keep_minting_token", "[cashtoken_minting]") {
-    nft_collection_params params{};
+    nft_collection_params params{.creator_address = make_addr(0x11)};
     params.genesis_utxo = make_bch_utxo(parent_tx_a, 0, 1'000'000);
-    params.creator_address = make_addr(0x11);
     params.nfts.push_back({data_chunk{0x01}, std::nullopt});
     params.keep_minting_token = true;
 
@@ -696,9 +668,8 @@ TEST_CASE("create_nft_collection honours keep_minting_token", "[cashtoken_mintin
 }
 
 TEST_CASE("create_nft_collection rejects oversized commitments upfront", "[cashtoken_minting]") {
-    nft_collection_params params{};
+    nft_collection_params params{.creator_address = make_addr(0x11)};
     params.genesis_utxo = make_bch_utxo(parent_tx_a, 0, 1'000'000);
-    params.creator_address = make_addr(0x11);
     // second NFT has an oversized commitment; the whole plan must be rejected.
     params.nfts.push_back({data_chunk{0x01}, std::nullopt});
     params.nfts.push_back({data_chunk(41, 0xAB), std::nullopt});
@@ -709,9 +680,8 @@ TEST_CASE("create_nft_collection rejects oversized commitments upfront", "[casht
 }
 
 TEST_CASE("create_nft_collection rejects an empty NFT list", "[cashtoken_minting]") {
-    nft_collection_params params{};
+    nft_collection_params params{.creator_address = make_addr(0x11)};
     params.genesis_utxo = make_bch_utxo(parent_tx_a, 0, 1'000'000);
-    params.creator_address = make_addr(0x11);
 
     auto result = create_nft_collection(params);
     REQUIRE( ! result.has_value());
@@ -721,20 +691,9 @@ TEST_CASE("create_nft_collection rejects an empty NFT list", "[cashtoken_minting
 // Safety guards added in response to review feedback
 // ===========================================================================
 
-TEST_CASE("prepare_genesis_utxo rejects a default-constructed destination", "[cashtoken_minting]") {
-    prepare_genesis_params params{};
-    params.utxo = make_bch_utxo(parent_tx_a, 0, 50000);
-    // params.destination intentionally default-constructed
-    params.satoshis = 10000;
-
-    auto result = prepare_genesis_utxo(params);
-    REQUIRE( ! result.has_value());
-}
-
 TEST_CASE("create_token_genesis rejects token-carrying fee UTXOs (would burn tokens)", "[cashtoken_minting]") {
-    token_genesis_params params{};
+    token_genesis_params params{.destination = make_addr(0x11)};
     params.genesis_utxo = make_bch_utxo(parent_tx_a, 0, 50000);
-    params.destination = make_addr(0x11);
     params.ft_amount = 1000;
     // A token-bearing UTXO in fee_utxos would be silently burned.
     params.fee_utxos.push_back(make_ft_utxo(parent_tx_b, 1, category_a, 500));
@@ -794,10 +753,9 @@ TEST_CASE("create_token_mint rejects a minting UTXO below the token dust limit",
 }
 
 TEST_CASE("create_token_burn rejects a message above the OP_RETURN standardness limit", "[cashtoken_minting]") {
-    token_burn_params params{};
+    token_burn_params params{.destination = make_addr(0x22)};
     params.token_utxo = make_ft_utxo(parent_tx_a, 0, category_a, 1000, 800);
     params.fee_utxos.push_back(make_bch_utxo(parent_tx_b, 0, 50000));
-    params.destination = make_addr(0x22);
     params.burn_ft_amount = 1000;
     params.message = std::string(max_op_return_payload_size + 1, 'X');
 
@@ -806,10 +764,9 @@ TEST_CASE("create_token_burn rejects a message above the OP_RETURN standardness 
 }
 
 TEST_CASE("create_token_burn accepts a message at the OP_RETURN standardness boundary", "[cashtoken_minting]") {
-    token_burn_params params{};
+    token_burn_params params{.destination = make_addr(0x22)};
     params.token_utxo = make_ft_utxo(parent_tx_a, 0, category_a, 1000, 800);
     params.fee_utxos.push_back(make_bch_utxo(parent_tx_b, 0, 50000));
-    params.destination = make_addr(0x22);
     params.burn_ft_amount = 1000;
     params.message = std::string(max_op_return_payload_size, 'X');
 

--- a/src/domain/test/wallet/payment_address.cpp
+++ b/src/domain/test/wallet/payment_address.cpp
@@ -46,22 +46,7 @@ constexpr char payment_hex[] = "0575566c599452b7bcb7f8cd4087bde9686fa9c52d8c2a7d
 // $ bx script-to-address "dup hash160 [18c0bd8d1818f1bf99cb1df2269c645318ef7b73] equalverify checksig" -v 196 | bx base58-decode
 constexpr char payment_testnet[] = "c475566c599452b7bcb7f8cd4087bde9686fa9c52d2fba2898";
 
-// $ bx base58-decode 1111111111111111111114oLvT2 | bx wrap-decode
-// wrapper
-// {
-//     checksum 285843604
-//     payload 0000000000000000000000000000000000000000
-//     version 0
-// }
-constexpr char uninitialized_address[] = "1111111111111111111114oLvT2";
-
 // negative tests:
-
-TEST_CASE("payment_address construct default invalid", "[payment_address]") {
-    payment_address const address;
-    REQUIRE( ! address.valid());
-    REQUIRE(address.encoded_legacy() == uninitialized_address);
-}
 
 TEST_CASE("payment_address construct string invalid invalid", "[payment_address]") {
     REQUIRE( ! payment_address::parse_from("bogus"));
@@ -73,7 +58,6 @@ TEST_CASE("payment_address construct secret valid expected", "[payment_address]"
     auto const secret = decode_base16<ec_secret_size>(secret_hex);
     REQUIRE(secret);
     payment_address const address = payment_address::from_ec_private(ec_private{*secret}).value();
-    REQUIRE(address.valid());
     REQUIRE(address.encoded_legacy() == address_compressed);
 }
 
@@ -84,7 +68,6 @@ TEST_CASE("payment_address construct secret testnet valid expected", "[payment_a
     // MSVC CTP loses the MSB (WIF prefix) byte of the literal version when
     // using this initializer, but the MSB isn't used by payment_address.
     payment_address const address = payment_address::from_ec_private(ec_private{*secret, 0x806f}).value();
-    REQUIRE(address.valid());
     REQUIRE(address.encoded_legacy() == address_compressed_testnet);
 }
 
@@ -92,7 +75,6 @@ TEST_CASE("payment_address construct secret mainnet uncompressed valid expected"
     auto const secret = decode_base16<ec_secret_size>(secret_hex);
     REQUIRE(secret);
     payment_address const address = payment_address::from_ec_private(ec_private{*secret, payment_address::mainnet_p2kh, false}).value();
-    REQUIRE(address.valid());
     REQUIRE(address.encoded_legacy() == address_uncompressed);
 }
 
@@ -103,7 +85,6 @@ TEST_CASE("payment_address construct secret testnet uncompressed valid expected"
     // MSVC CTP loses the MSB (WIF prefix) byte of the literal version when
     // using this initializer, but the MSB isn't used by payment_address.
     payment_address const address = payment_address::from_ec_private(ec_private{*secret, 0x806f, false}).value();
-    REQUIRE(address.valid());
     REQUIRE(address.encoded_legacy() == address_uncompressed_testnet);
 }
 
@@ -111,25 +92,21 @@ TEST_CASE("payment_address construct secret testnet uncompressed valid expected"
 
 TEST_CASE("payment_address construct public valid expected", "[payment_address]") {
     payment_address const address = payment_address::from_ec_public(ec_public::parse_from(compressed_pubkey).value(), payment_address::mainnet_p2kh).value();
-    REQUIRE(address.valid());
     REQUIRE(address.encoded_legacy() == address_compressed);
 }
 
 TEST_CASE("payment_address construct public testnet valid expected", "[payment_address]") {
     payment_address const address = payment_address::from_ec_public(ec_public::parse_from(compressed_pubkey).value(), 0x6f).value();
-    REQUIRE(address.valid());
     REQUIRE(address.encoded_legacy() == address_compressed_testnet);
 }
 
 TEST_CASE("payment_address construct public uncompressed valid expected", "[payment_address]") {
     payment_address const address = payment_address::from_ec_public(ec_public::parse_from(uncompressed_pubkey).value(), payment_address::mainnet_p2kh).value();
-    REQUIRE(address.valid());
     REQUIRE(address.encoded_legacy() == address_uncompressed);
 }
 
 TEST_CASE("payment_address construct public testnet uncompressed valid expected", "[payment_address]") {
     payment_address const address = payment_address::from_ec_public(ec_public::parse_from(uncompressed_pubkey).value(), 0x6f).value();
-    REQUIRE(address.valid());
     REQUIRE(address.encoded_legacy() == address_uncompressed_testnet);
 }
 
@@ -139,7 +116,6 @@ TEST_CASE("payment_address construct public compressed from uncompressed testnet
     auto const pub = ec_public::from_point(*point, true);
     REQUIRE(pub);
     payment_address const address = payment_address::from_ec_public(*pub, 0x6f).value();
-    REQUIRE(address.valid());
     REQUIRE(address.encoded_legacy() == address_compressed_testnet);
 }
 
@@ -147,7 +123,6 @@ TEST_CASE("payment_address construct public uncompressed from compressed testnet
     auto const point = decode_base16<ec_compressed_size>(compressed_pubkey);
     REQUIRE(point);
     payment_address const address = payment_address::from_ec_public(ec_public{*point, false}, 0x6f).value();
-    REQUIRE(address.valid());
     REQUIRE(address.encoded_legacy() == address_uncompressed_testnet);
 }
 
@@ -157,7 +132,6 @@ TEST_CASE("payment_address construct hash valid expected", "[payment_address]") 
     auto const hash = decode_base16<short_hash_size>(compressed_hash);
     REQUIRE(hash);
     payment_address const address(*hash, payment_address::mainnet_p2kh);
-    REQUIRE(address.valid());
     REQUIRE(address.encoded_legacy() == address_compressed);
 }
 
@@ -165,7 +139,6 @@ TEST_CASE("payment_address construct uncompressed hash testnet valid expected", 
     auto const hash = decode_base16<short_hash_size>(uncompressed_hash);
     REQUIRE(hash);
     payment_address const address(*hash, 0x6f);
-    REQUIRE(address.valid());
     REQUIRE(address.encoded_legacy() == address_uncompressed_testnet);
 }
 
@@ -175,7 +148,6 @@ TEST_CASE("payment_address construct script valid expected", "[payment_address]"
     script ops;
     REQUIRE(ops.from_string(script_text));
     payment_address const address = payment_address::from_script(ops, payment_address::mainnet_p2sh);
-    REQUIRE(address.valid());
     REQUIRE(address.encoded_legacy() == address_script);
 }
 
@@ -183,7 +155,6 @@ TEST_CASE("payment_address construct script testnet valid expected", "[payment_a
     script ops;
     REQUIRE(ops.from_string(script_text));
     payment_address const address = payment_address::from_script(ops, 0xc4);
-    REQUIRE(address.valid());
     REQUIRE(address.encoded_legacy() == address_script_testnet);
 }
 
@@ -193,7 +164,6 @@ TEST_CASE("payment_address construct payment valid expected", "[payment_address]
     auto const pay = decode_base16<payment_size>(payment_hex);
     REQUIRE(pay);
     payment_address const address = payment_address::from_payment(*pay).value();
-    REQUIRE(address.valid());
     REQUIRE(address.encoded_legacy() == address_script);
 }
 
@@ -201,7 +171,6 @@ TEST_CASE("payment_address construct payment testnet valid expected", "[payment_
     auto const pay = decode_base16<payment_size>(payment_testnet);
     REQUIRE(pay);
     payment_address const address = payment_address::from_payment(*pay).value();
-    REQUIRE(address.valid());
     REQUIRE(address.encoded_legacy() == address_script_testnet);
 }
 
@@ -212,7 +181,6 @@ TEST_CASE("payment_address construct copy valid expected", "[payment_address]") 
     REQUIRE(pay);
     payment_address const address = payment_address::from_payment(*pay).value();
     payment_address const copy(address);
-    REQUIRE(copy.valid());
     REQUIRE(copy.encoded_legacy() == address_script);
 }
 
@@ -226,7 +194,6 @@ TEST_CASE("payment_address version default mainnet", "[payment_address]") {
 TEST_CASE("payment_address version testnet testnet", "[payment_address]") {
     uint8_t const testnet = 0x6f;
     payment_address const address = payment_address::from_ec_public(ec_public::parse_from(compressed_pubkey).value(), testnet).value();
-    REQUIRE(address.valid());
     REQUIRE(address.version() == testnet);
 }
 
@@ -234,7 +201,6 @@ TEST_CASE("payment_address version script valid mainnet p2sh", "[payment_address
     script ops;
     REQUIRE(ops.from_string(script_text));
     payment_address const address = payment_address::from_script(ops, payment_address::mainnet_p2sh);
-    REQUIRE(address.valid());
     REQUIRE(address.version() == payment_address::mainnet_p2sh);
 }
 
@@ -242,7 +208,6 @@ TEST_CASE("payment_address version script valid mainnet p2sh", "[payment_address
 
 TEST_CASE("payment_address hash compressed point expected", "[payment_address]") {
     payment_address const address = payment_address::from_ec_public(ec_public::parse_from(compressed_pubkey).value(), payment_address::mainnet_p2kh).value();
-    REQUIRE(address.valid());
     REQUIRE(encode_base16(address.hash20()) == compressed_hash);
 }
 
@@ -250,33 +215,28 @@ TEST_CASE("payment_address hash compressed point expected", "[payment_address]")
 //cashAddr payment_address
 TEST_CASE("payment_address cashAddr mainnet encode", "[payment_address]") {
     payment_address const address = payment_address::from_ec_public(ec_public::parse_from("04278f7bfee4ef625f85279c3a01d57c22e2877a902128b2df85071f9d6c95b290f094f5bd1bff5880d09cc231c774d71ac22d3ab9bdd9dda2e75017b52d893367").value(), kth::domain::wallet::payment_address::mainnet_p2kh).value();
-    REQUIRE(address.valid());
     REQUIRE(address.encoded_cashaddr(false) == "bitcoincash:qpzz8n7jp6847yyx8t33matrgcsdx6c0cvmtevrfgz");
 }
 
 TEST_CASE("payment_address cashAddr testnet encode", "[payment_address]") {
     payment_address const address = payment_address::from_ec_public(ec_public::parse_from("04278f7bfee4ef625f85279c3a01d57c22e2877a902128b2df85071f9d6c95b290f094f5bd1bff5880d09cc231c774d71ac22d3ab9bdd9dda2e75017b52d893367").value(), kth::domain::wallet::payment_address::testnet_p2kh).value();
-    REQUIRE(address.valid());
     REQUIRE(address.encoded_cashaddr(false) == "bchtest:qpzz8n7jp6847yyx8t33matrgcsdx6c0cvleatp707");
 }
 
 TEST_CASE("payment_address cashAddr mainnet from string", "[payment_address]") {
     auto const address = payment_address::parse_from("bitcoincash:qpzz8n7jp6847yyx8t33matrgcsdx6c0cvmtevrfgz").value();
-    REQUIRE(address.valid());
     REQUIRE(address.encoded_cashaddr(false) == "bitcoincash:qpzz8n7jp6847yyx8t33matrgcsdx6c0cvmtevrfgz");
     REQUIRE(address.encoded_legacy() == "17DHrHvtmMRs9ciersFCPNhvJtryd5NWbT");
 }
 
 TEST_CASE("payment_address cashAddr testnet from string", "[payment_address]") {
     auto const address = payment_address::parse_from("bchtest:qpzz8n7jp6847yyx8t33matrgcsdx6c0cvleatp707", domain::config::network::testnet).value();
-    REQUIRE(address.valid());
     REQUIRE(address.encoded_cashaddr(false) == "bchtest:qpzz8n7jp6847yyx8t33matrgcsdx6c0cvleatp707");
     REQUIRE(address.encoded_legacy() == "mmjF9M1saNs7vjCGaSDaDHvFAtTgUNtfrJ");
 }
 
 TEST_CASE("payment_address token address from string", "[payment_address]") {
     auto const address = payment_address::parse_from("bitcoincash:pvstqkm54dtvnpyqxt5m5n7sjsn4enrlxc526xyxlnjkaycdzfeu69reyzmqx").value();
-    REQUIRE(address.valid());
     REQUIRE(address.encoded_cashaddr(false) == "bitcoincash:pvstqkm54dtvnpyqxt5m5n7sjsn4enrlxc526xyxlnjkaycdzfeu69reyzmqx");
     REQUIRE(address.encoded_cashaddr(true) == "bitcoincash:rvstqkm54dtvnpyqxt5m5n7sjsn4enrlxc526xyxlnjkaycdzfeu6hs99m6ed");
     // 32-byte address (`pay_script_hash_32`) — no legacy
@@ -298,7 +258,6 @@ TEST_CASE("payment_address 32-byte hash20 returns null sentinel", "[payment_addr
     hash_digest h32;
     for (size_t i = 0; i < h32.size(); ++i) h32[i] = static_cast<uint8_t>(i + 1);
     payment_address const address(h32, payment_address::mainnet_p2sh);
-    REQUIRE(address.valid());
     REQUIRE(address.hash20() == null_short_hash);
     REQUIRE(address.hash32() == h32);
 }
@@ -307,7 +266,6 @@ TEST_CASE("payment_address 32-byte to_payment returns zero sentinel", "[payment_
     hash_digest h32;
     for (size_t i = 0; i < h32.size(); ++i) h32[i] = static_cast<uint8_t>(i + 1);
     payment_address const address(h32, payment_address::mainnet_p2sh);
-    REQUIRE(address.valid());
     // `payment` is `byte_array<25>`; zero-initialised compares
     // equal against any other zero-initialised `payment`.
     payment const zero_payment{};
@@ -320,7 +278,6 @@ TEST_CASE("payment_address 20-byte accessors stay untouched on 20-byte hashes", 
     auto const hash = decode_base16<short_hash_size>(compressed_hash);
     REQUIRE(hash);
     payment_address const address(*hash, payment_address::mainnet_p2kh);
-    REQUIRE(address.valid());
     REQUIRE(address.hash20() == *hash);
     REQUIRE_FALSE(address.encoded_legacy().empty());
     REQUIRE(address.encoded_legacy() == address_compressed);


### PR DESCRIPTION
## Summary

Drop `payment_address::payment_address()` (default ctor), `.valid()` and the `valid_` flag. Every reachable instance is now produced by a factory returning `expect<>` or by an infallible ctor over already-validated components, so accessors and serializers are always meaningful and the runtime `.valid()` check has nothing to gate.

## Cascade

The seven `cashtoken_minting` param structs that used to hold `payment_address destination` (or `creator_address`) by value relied on the default ctor to allow `T params{};` followed by later field assignment. The field is semantically required — the code was already rejecting the sentinel via `!params.destination.valid()` — so the honest fix is aggregate construction with the required field provided up front. Types affected:

- `prepare_genesis_params::destination`
- `token_genesis_params::destination`
- `token_transfer_params::destination`
- `token_burn_params::destination`
- `nft_mint_request::destination`
- `ft_params::destination`
- `nft_collection_params::creator_address`

`nft_collection_item::destination` stays `std::optional<payment_address>` — it was already truly optional (falls back to `creator_address`).

The two local `payment_address token_change_addr;` / `bch_change_addr;` sentinels inside `create_token_transfer` become `std::optional<payment_address>` and check `has_value()`; they are genuinely "may or may not be set depending on the flow".

`stealth_sender::address_` moves from `payment_address` to `std::optional<payment_address>` for the same reason — `initialize()` may leave it unset when construction fails, and `operator bool()` now reports that via `.has_value()`.

## Comparison

**`operator<=>` was routing through `to_string()`**: encoding the address to base58 (BTC/LTC) or cashaddr (BCH) and running `strcmp` on the result. Under BCH the "canonical" was cashaddr token-unaware, which meant the ordering was already currency-dependent even for identical byte-level state. Replaced with a **defaulted `<=>`** — the underlying state is `uint8_t version_` + `hash_digest` + `size_t`, and the two infallible ctors leave any hash bytes past `hash_size_` deterministically zero (short-hash ctor copies 20 bytes into a `{null_hash}`-initialised `hash_data_`), so byte-lex compare is consistent, canonical across currencies, and skips the encode step.

## Simplifications enabled

Since a constructed `payment_address` is always valid:

- Every `if (!params.destination.valid()) return error;` guard in `cashtoken_minting.cpp` (and the `if (!req.destination.has_value())` loop over `params.nfts`) becomes dead code — deleted. The type itself now enforces "you had to give me a real address to build this struct."
- Two `blockchain::block_chain.cpp` sites lose their `.valid()` short-circuit inside address-membership checks; entries returned by `payment_address::extract*` are validated at construction, so the check was dead post-refactor.
- Internal `token_genesis_params gp{}` / `nft_mint_request req{}` build sites switch to designated / positional aggregate init. `nft_mint_request` is now `emplace_back`-constructed in-place where a temporary was created before.

## Callers

- Test file `cashtoken_minting.cpp` — ~30 sites migrated from `T params{}; params.destination = X;` to `T params{.destination = X};`. The `prepare_genesis_utxo rejects a default-constructed destination` test is deleted (the failure mode it exercised is no longer representable at the type level).
- Test file `payment_address.cpp` — the `payment_address construct default invalid` test and all the post-`.value()` `REQUIRE(address.valid())` guards go away.
- Test file `bitcoin_uri.cpp` — one dead `REQUIRE(payment.valid())` after a `.value()` unwrap deleted.

C-API is intentionally left untouched — the bulk regen at the end of the split picks up the removed default ctor / `.valid()` / `kth_wallet_payment_address_valid` in one pass.

Part of the #422 split.

## Test plan

- [x] `kth_domain_test` passes locally (1_011_093 assertions in 3872 test cases)
- [ ] Bulk regen PR restores C-API build + tests