### PR TITLE
refactor(wallet): make ec_public + ec_private valid-by-construction

### DIFF
--- a/src/domain/include/kth/domain/wallet/ec_private.hpp
+++ b/src/domain/include/kth/domain/wallet/ec_private.hpp
@@ -32,14 +32,10 @@ size_t wif_compressed_size = wif_uncompressed_size + 1U;
 
 using wif_compressed = byte_array<wif_compressed_size>;
 
-/**
- * EC secret with WIF version and compression metadata.
- *
- * Default-constructible (invalid state) so the C-API generator can
- * hand out an "empty" handle; fallible construction goes through
- * `parse_from` / `from_compressed` / `from_uncompressed`, each
- * returning `expect<ec_private>`.
- */
+/// EC secret with WIF version and compression metadata.
+/// Valid-by-construction: every reachable instance came from a factory
+/// that validated the underlying `ec_secret` lies in the curve's
+/// scalar range, so `to_public()` never fails.
 struct KD_API ec_private {
     static uint8_t const compressed_sentinel;
 
@@ -71,7 +67,7 @@ struct KD_API ec_private {
     }
 
     /// Parse a WIF-encoded private key. `error::illegal_value` on
-    /// malformed input.
+    /// malformed input or a secret outside the curve's scalar range.
     [[nodiscard]]
     static
     expect<ec_private> parse_from(std::string_view wif, uint8_t version);
@@ -84,24 +80,20 @@ struct KD_API ec_private {
     static
     expect<ec_private> from_uncompressed(wif_uncompressed const& wif, uint8_t address_version);
 
-    ec_private() = default;
+    /// Validate `secret` lies in the curve's scalar range and wrap it.
+    [[nodiscard]]
+    static
+    expect<ec_private> from_secret(ec_secret const& secret, uint16_t version, bool compress);
 
-    /// The version is 16 bits. The most significant byte is the WIF prefix
-    /// and the least significant byte is the address prefix.
-    explicit
-    ec_private(ec_secret const& secret, uint16_t version = mainnet, bool compress = true) noexcept
-        : valid_(true), compress_(compress), version_(version), secret_(secret) {}
+    /// Wrap a secret that the caller has already verified lies in the
+    /// curve's scalar range (or produced by an internal derivation step
+    /// that guarantees it). No range check is performed here.
+    [[nodiscard]]
+    static
+    ec_private from_verified_secret(ec_secret const& secret, uint16_t version, bool compress);
 
     [[nodiscard]]
-    bool valid() const noexcept { return valid_; }
-
-    [[nodiscard]]
-    friend bool operator==(ec_private const&, ec_private const&) = default;
-
-    [[nodiscard]]
-    friend auto operator<=>(ec_private const& a, ec_private const& b) {
-        return a.to_string() <=> b.to_string();
-    }
+    friend auto operator<=>(ec_private const&, ec_private const&) = default;
 
     [[nodiscard]]
     ec_secret const& value() const noexcept { return secret_; }
@@ -132,10 +124,12 @@ struct KD_API ec_private {
     expect<payment_address> to_payment_address() const;
 
 private:
+    ec_private(ec_secret const& secret, uint16_t version, bool compress) noexcept
+        : compress_(compress), version_(version), secret_(secret) {}
+
     static
     bool is_wif(byte_span decoded);
 
-    bool      valid_{false};
     bool      compress_{true};
     uint16_t  version_{0};
     ec_secret secret_{null_hash};

--- a/src/domain/include/kth/domain/wallet/ec_public.hpp
+++ b/src/domain/include/kth/domain/wallet/ec_public.hpp
@@ -6,10 +6,8 @@
 #define KTH_DOMAIN_WALLET_EC_PUBLIC_HPP
 
 #include <cstdint>
-#include <expected>
 #include <string>
 #include <string_view>
-#include <system_error>
 
 #include <kth/domain/define.hpp>
 #include <kth/domain/deserialization.hpp>
@@ -22,13 +20,10 @@ namespace kth::domain::wallet {
 class ec_private;
 class payment_address;
 
-/**
- * Elliptic-curve public key, either compressed or uncompressed.
- *
- * Default-constructible (invalid state) so the C-API generator can
- * hand out an "empty" handle; the fallible construction paths return
- * `expect<ec_public>`.
- */
+/// Elliptic-curve public key, either compressed or uncompressed on the
+/// wire. Valid-by-construction: every reachable instance came from a
+/// factory that validated its input, so accessors and serializers are
+/// always meaningful.
 struct KD_API ec_public {
     static uint8_t const compressed_even;
     static uint8_t const compressed_odd;
@@ -49,7 +44,7 @@ struct KD_API ec_public {
     /// Derive from a validated `ec_private`.
     [[nodiscard]]
     static
-    expect<ec_public> from_private(ec_private const& secret);
+    ec_public from_private(ec_private const& secret);
 
     /// Wrap an uncompressed EC point, keeping the compressed/uncompressed
     /// wire form as requested.
@@ -57,23 +52,15 @@ struct KD_API ec_public {
     static
     expect<ec_public> from_point(ec_uncompressed const& point, bool compress);
 
-    ec_public() = default;
-
-    /// Wrap an already-compressed EC point.
-    explicit
-    ec_public(ec_compressed const& compressed_point, bool compress = true) noexcept
-        : valid_(true), compress_(compress), point_(compressed_point) {}
+    /// Wrap an already-compressed EC point that the caller has verified
+    /// lies on the curve (or produced by an internal derivation step
+    /// that guarantees it). No on-curve check is performed here.
+    [[nodiscard]]
+    static
+    ec_public from_verified_point(ec_compressed const& point, bool compress);
 
     [[nodiscard]]
-    friend bool operator==(ec_public const&, ec_public const&) = default;
-
-    [[nodiscard]]
-    friend auto operator<=>(ec_public const& a, ec_public const& b) {
-        return a.to_string() <=> b.to_string();
-    }
-
-    [[nodiscard]]
-    bool valid() const noexcept { return valid_; }
+    friend auto operator<=>(ec_public const&, ec_public const&) = default;
 
     [[nodiscard]]
     ec_compressed const& value() const noexcept { return point_; }
@@ -92,19 +79,21 @@ struct KD_API ec_public {
     std::string encoded() const { return to_string(); }
 
     [[nodiscard]]
-    std::expected<data_chunk, std::error_code> to_data() const;
+    data_chunk to_data() const;
 
     [[nodiscard]]
-    std::expected<ec_uncompressed, std::error_code> to_uncompressed() const;
+    ec_uncompressed to_uncompressed() const;
 
     [[nodiscard]]
     expect<payment_address> to_payment_address(uint8_t version = mainnet_p2kh) const;
 
 private:
+    ec_public(ec_compressed const& point, bool compress) noexcept
+        : compress_(compress), point_(point) {}
+
     static
     bool is_point(byte_span decoded);
 
-    bool valid_{false};
     bool compress_{true};
     ec_compressed point_ = null_compressed_point;
 };

--- a/src/domain/src/chain/script.cpp
+++ b/src/domain/src/chain/script.cpp
@@ -809,14 +809,10 @@ operation::list script::to_pay_public_key_hash_pattern(short_hash const& hash) {
 }
 
 operation::list script::to_pay_public_key_hash_pattern_unlocking(endorsement const& end, wallet::ec_public const& pubkey) {
-    auto pubkey_data = pubkey.to_data();
-    if ( ! pubkey_data) {
-        return operation::list {};
-    }
     return operation::list {
         operation(opcode::push_size_0),
         operation(end),
-        operation(std::move(*pubkey_data))
+        operation(pubkey.to_data())
     };
 }
 

--- a/src/domain/src/wallet/ec_private.cpp
+++ b/src/domain/src/wallet/ec_private.cpp
@@ -57,6 +57,19 @@ bool ec_private::is_wif(byte_span decoded) {
 // ----------------------------------------------------------------------------
 
 // static
+expect<ec_private> ec_private::from_secret(ec_secret const& secret, uint16_t version, bool compress) {
+    if ( ! kth::verify(secret)) {
+        return std::unexpected(kth::error::illegal_value);
+    }
+    return ec_private(secret, version, compress);
+}
+
+// static
+ec_private ec_private::from_verified_secret(ec_secret const& secret, uint16_t version, bool compress) {
+    return ec_private(secret, version, compress);
+}
+
+// static
 expect<ec_private> ec_private::parse_from(std::string_view wif, uint8_t version) {
     data_chunk decoded;
     if ( ! decode_base58(decoded, std::string{wif}) || ! is_wif(decoded)) {
@@ -77,8 +90,7 @@ expect<ec_private> ec_private::from_compressed(wif_compressed const& wif, uint8_
 
     uint16_t const version = to_version(address_version, wif.front());
     auto const secret = slice<1, ec_secret_size + 1>(wif);
-    ec_private out{secret, version, true};
-    return out;
+    return from_secret(secret, version, true);
 }
 
 // static
@@ -89,8 +101,7 @@ expect<ec_private> ec_private::from_uncompressed(wif_uncompressed const& wif, ui
 
     uint16_t const version = to_version(address_version, wif.front());
     auto const secret = slice<1, ec_secret_size + 1>(wif);
-    ec_private out{secret, version, false};
-    return out;
+    return from_secret(secret, version, false);
 }
 
 // Serializer.
@@ -115,16 +126,15 @@ std::string ec_private::to_string() const {
 // Methods.
 // ----------------------------------------------------------------------------
 
-// A valid secret always produces a valid public point.
+// A valid secret always produces a valid public point; factories that
+// build an `ec_private` verify the scalar's range up front. Assert
+// catches the only invariant-breaking path: `from_verified_secret`
+// called with a secret outside `[1, n-1]`.
 ec_public ec_private::to_public() const {
-    if ( ! valid_) {
-        return ec_public{};
-    }
     ec_compressed point;
-    if ( ! secret_to_public(point, secret_)) {
-        return ec_public{};
-    }
-    return ec_public{point, compressed()};
+    DEBUG_ONLY(auto const ok =) secret_to_public(point, secret_);
+    KTH_ASSERT_MSG(ok, "secret_to_public failed — from_verified_secret called with an out-of-range scalar");
+    return ec_public::from_verified_point(point, compressed());
 }
 
 expect<payment_address> ec_private::to_payment_address() const {

--- a/src/domain/src/wallet/ec_public.cpp
+++ b/src/domain/src/wallet/ec_public.cpp
@@ -14,6 +14,7 @@
 #include <kth/infrastructure/formats/base_16.hpp>
 #include <kth/infrastructure/math/elliptic_curve.hpp>
 #include <kth/infrastructure/math/hash.hpp>
+#include <kth/infrastructure/utility/assert.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 
 namespace kth::domain::wallet {
@@ -38,28 +39,30 @@ bool ec_public::is_point(byte_span decoded) {
 // ----------------------------------------------------------------------------
 
 // static
+ec_public ec_public::from_verified_point(ec_compressed const& point, bool compress) {
+    return ec_public(point, compress);
+}
+
+// static
 expect<ec_public> ec_public::from_data(data_chunk const& decoded) {
     if ( ! is_point(decoded)) {
         return std::unexpected(kth::error::illegal_value);
     }
 
     if (decoded.size() == ec_compressed_size) {
-        return ec_public{to_array<ec_compressed_size>(decoded), true};
+        return ec_public(to_array<ec_compressed_size>(decoded), true);
     }
 
     ec_compressed compressed;
     if ( ! kth::compress(compressed, to_array<ec_uncompressed_size>(decoded))) {
         return std::unexpected(kth::error::illegal_value);
     }
-    return ec_public{compressed, false};
+    return ec_public(compressed, false);
 }
 
 // static
-expect<ec_public> ec_public::from_private(ec_private const& secret) {
-    if ( ! secret.valid()) {
-        return std::unexpected(kth::error::illegal_value);
-    }
-    return ec_public{secret.to_public()};
+ec_public ec_public::from_private(ec_private const& secret) {
+    return secret.to_public();
 }
 
 // static
@@ -72,7 +75,7 @@ expect<ec_public> ec_public::from_point(ec_uncompressed const& point, bool compr
     if ( ! kth::compress(compressed, point)) {
         return std::unexpected(kth::error::illegal_value);
     }
-    return ec_public{compressed, compress};
+    return ec_public(compressed, compress);
 }
 
 // static
@@ -91,38 +94,28 @@ std::string ec_public::to_string() const {
     if (compressed()) {
         return encode_base16(point_);
     }
-
-    // A well-formed point always decompresses.
-    auto const uncompressed = to_uncompressed();
-    return encode_base16(uncompressed ? *uncompressed : null_uncompressed_point);
+    return encode_base16(to_uncompressed());
 }
 
 // Methods.
 // ----------------------------------------------------------------------------
 
-std::expected<data_chunk, std::error_code> ec_public::to_data() const {
-    if ( ! valid_) {
-        return std::unexpected(error::pubkey_type);
-    }
+data_chunk ec_public::to_data() const {
     if (compressed()) {
         return data_chunk(point_.begin(), point_.begin() + ec_compressed_size);
     }
-
     auto const uncompressed = to_uncompressed();
-    if ( ! uncompressed) {
-        return std::unexpected(uncompressed.error());
-    }
-    return data_chunk(uncompressed->begin(), uncompressed->end());
+    return data_chunk(uncompressed.begin(), uncompressed.end());
 }
 
-std::expected<ec_uncompressed, std::error_code> ec_public::to_uncompressed() const {
-    if ( ! valid_) {
-        return std::unexpected(error::pubkey_type);
-    }
+ec_uncompressed ec_public::to_uncompressed() const {
+    // A valid compressed point always decompresses; the factories that
+    // produce `ec_public` all validate on-curve first. Assert catches
+    // the only invariant-breaking path: `from_verified_point` called
+    // with an off-curve point.
     ec_uncompressed out;
-    if ( ! kth::decompress(out, to_array<ec_compressed_size>(point_))) {
-        return std::unexpected(error::pubkey_type);
-    }
+    DEBUG_ONLY(auto const ok =) kth::decompress(out, to_array<ec_compressed_size>(point_));
+    KTH_ASSERT_MSG(ok, "decompress failed — from_verified_point called with an off-curve point");
     return out;
 }
 

--- a/src/domain/src/wallet/encrypted_keys.cpp
+++ b/src/domain/src/wallet/encrypted_keys.cpp
@@ -54,13 +54,13 @@ bool address_salt(ek_salt& salt, payment_address const& address) {
 
 static
 bool address_salt(ek_salt& salt, ec_compressed const& point, uint8_t version, bool compressed) {
-    auto address = payment_address::from_ec_public(ec_public{point, compressed}, version);
+    auto address = payment_address::from_ec_public(ec_public::from_verified_point(point, compressed), version);
     return address ? address_salt(salt, *address) : false;
 }
 
 static
 bool address_salt(ek_salt& salt, ec_secret const& secret, uint8_t version, bool compressed) {
-    auto address = payment_address::from_ec_private(ec_private{secret, version, compressed});
+    auto address = payment_address::from_ec_private(ec_private::from_verified_secret(secret, version, compressed));
     return address ? address_salt(salt, *address) : false;
 }
 
@@ -72,13 +72,13 @@ bool address_validate(ek_salt const& salt, payment_address const& address) {
 
 static
 bool address_validate(ek_salt const& salt, ec_compressed const& point, uint8_t version, bool compressed) {
-    auto address = payment_address::from_ec_public(ec_public{point, compressed}, version);
+    auto address = payment_address::from_ec_public(ec_public::from_verified_point(point, compressed), version);
     return address ? address_validate(salt, *address) : false;
 }
 
 static
 bool address_validate(ek_salt const& salt, ec_secret const& secret, uint8_t version, bool compressed) {
-    auto address = payment_address::from_ec_private(ec_private{secret, version, compressed});
+    auto address = payment_address::from_ec_private(ec_private::from_verified_secret(secret, version, compressed));
     return address ? address_validate(salt, *address) : false;
 }
 

--- a/src/domain/src/wallet/payment_address.cpp
+++ b/src/domain/src/wallet/payment_address.cpp
@@ -222,22 +222,12 @@ expect<payment_address> payment_address::from_payment(payment const& decoded) {
 
 // static
 expect<payment_address> payment_address::from_ec_private(ec_private const& secret) {
-    if ( ! secret.valid()) {
-        return std::unexpected(kth::error::illegal_value);
-    }
     return from_ec_public(secret.to_public(), secret.payment_version());
 }
 
 // static
 expect<payment_address> payment_address::from_ec_public(ec_public const& point, uint8_t version) {
-    if ( ! point.valid()) {
-        return std::unexpected(kth::error::illegal_value);
-    }
-    auto const data = point.to_data();
-    if ( ! data) {
-        return std::unexpected(kth::error::illegal_value);
-    }
-    return payment_address{bitcoin_short_hash(*data), version};
+    return payment_address{bitcoin_short_hash(point.to_data()), version};
 }
 
 // static

--- a/src/domain/src/wallet/stealth_receiver.cpp
+++ b/src/domain/src/wallet/stealth_receiver.cpp
@@ -44,7 +44,7 @@ bool stealth_receiver::derive_address(payment_address& out_address,
         return false;
     }
 
-    auto result = payment_address::from_ec_public(ec_public{receiver_public}, version_);
+    auto result = payment_address::from_ec_public(ec_public::from_verified_point(receiver_public, true), version_);
     if ( ! result) {
         return false;
     }

--- a/src/domain/src/wallet/stealth_sender.cpp
+++ b/src/domain/src/wallet/stealth_sender.cpp
@@ -60,7 +60,7 @@ void stealth_sender::initialize(ec_secret const& ephemeral_private,
     }
 
     if (create_stealth_script(script_, ephemeral_private, filter, seed)) {
-        auto address_result = wallet::payment_address::from_ec_public(ec_public{sender_public}, version_);
+        auto address_result = wallet::payment_address::from_ec_public(ec_public::from_verified_point(sender_public, true), version_);
         if (address_result) {
             address_ = *address_result;
         }

--- a/src/domain/test/math/stealth.cpp
+++ b/src/domain/test/math/stealth.cpp
@@ -75,7 +75,7 @@ TEST_CASE("stealth round trip", "[stealth]") {
     // Both parties therefore have the ability to generate the p2pkh address.
     // versioning: stealth_address::main corresponds to payment_address::main_p2pkh
     auto const address = wallet::payment_address::from_ec_public(
-        wallet::ec_public{stealth_pub}, wallet::payment_address::mainnet_p2kh).value();
+        wallet::ec_public::from_verified_point(stealth_pub, true), wallet::payment_address::mainnet_p2kh).value();
     REQUIRE(address.encoded_legacy() == p2pkh_address);
 }
 

--- a/src/domain/test/wallet/ec_private.cpp
+++ b/src/domain/test/wallet/ec_private.cpp
@@ -29,11 +29,11 @@ TEST_CASE("ec private uncompressed wif not compressed test", "[ec private]") {
 }
 
 TEST_CASE("ec private encode wif compressed test", "[ec private]") {
-    REQUIRE(ec_private(secret).to_string() == wif_compressed_str);
+    REQUIRE(ec_private::from_verified_secret(secret, ec_private::mainnet, true).to_string() == wif_compressed_str);
 }
 
 TEST_CASE("ec private encode wif uncompressed test", "[ec private]") {
-    REQUIRE(ec_private(secret, 0x8000, false).to_string() == wif_uncompressed_str);
+    REQUIRE(ec_private::from_verified_secret(secret, 0x8000, false).to_string() == wif_uncompressed_str);
 }
 
 TEST_CASE("ec private decode wif compressed test", "[ec private]") {

--- a/src/domain/test/wallet/message.cpp
+++ b/src/domain/test/wallet/message.cpp
@@ -109,7 +109,7 @@ TEST_CASE("message magic to recovery id invalid false", "[message recovery magic
 
 TEST_CASE("message sign message compressed expected", "[message sign message]") {
     auto const compressed = true;
-    auto const address = payment_address::from_ec_private(ec_private{secret, 0x00, compressed}).value();
+    auto const address = payment_address::from_ec_private(ec_private::from_verified_secret(secret, 0x00, compressed)).value();
     auto const message = to_chunk(std::string("Compressed"));
     message_signature out_signature;
     REQUIRE(sign_message(out_signature, message, secret, compressed));
@@ -118,7 +118,7 @@ TEST_CASE("message sign message compressed expected", "[message sign message]") 
 
 TEST_CASE("message sign message uncompressed expected", "[message sign message]") {
     auto const compressed = false;
-    auto const address = payment_address::from_ec_private(ec_private{secret, 0x00, compressed}).value();
+    auto const address = payment_address::from_ec_private(ec_private::from_verified_secret(secret, 0x00, compressed)).value();
     auto const message = to_chunk(std::string("Uncompressed"));
     message_signature out_signature;
     REQUIRE(sign_message(out_signature, message, secret, compressed));
@@ -157,13 +157,13 @@ TEST_CASE("message sign message wif uncompressed expected", "[message sign messa
 // Start Test Suite: message verify message
 
 TEST_CASE("message verify message compressed expected", "[message verify message]") {
-    auto const address = payment_address::from_ec_private(ec_private{secret}).value();
+    auto const address = payment_address::from_ec_private(ec_private::from_verified_secret(secret, ec_private::mainnet, true)).value();
     auto const message = to_chunk(std::string("Compressed"));
     REQUIRE(verify_message(message, address, signature_compressed));
 }
 
 TEST_CASE("message verify message uncompressed expected", "[message verify message]") {
-    auto const address = payment_address::from_ec_private(ec_private{secret, 0x00, false}).value();
+    auto const address = payment_address::from_ec_private(ec_private::from_verified_secret(secret, 0x00, false)).value();
     auto const message = to_chunk(std::string("Uncompressed"));
     REQUIRE(verify_message(message, address, signature_uncompressed));
 }

--- a/src/domain/test/wallet/payment_address.cpp
+++ b/src/domain/test/wallet/payment_address.cpp
@@ -57,7 +57,7 @@ TEST_CASE("payment_address construct string invalid invalid", "[payment_address]
 TEST_CASE("payment_address construct secret valid expected", "[payment_address]") {
     auto const secret = decode_base16<ec_secret_size>(secret_hex);
     REQUIRE(secret);
-    payment_address const address = payment_address::from_ec_private(ec_private{*secret}).value();
+    payment_address const address = payment_address::from_ec_private(ec_private::from_verified_secret(*secret, ec_private::mainnet, true)).value();
     REQUIRE(address.encoded_legacy() == address_compressed);
 }
 
@@ -67,14 +67,14 @@ TEST_CASE("payment_address construct secret testnet valid expected", "[payment_a
 
     // MSVC CTP loses the MSB (WIF prefix) byte of the literal version when
     // using this initializer, but the MSB isn't used by payment_address.
-    payment_address const address = payment_address::from_ec_private(ec_private{*secret, 0x806f}).value();
+    payment_address const address = payment_address::from_ec_private(ec_private::from_verified_secret(*secret, 0x806f, true)).value();
     REQUIRE(address.encoded_legacy() == address_compressed_testnet);
 }
 
 TEST_CASE("payment_address construct secret mainnet uncompressed valid expected", "[payment_address]") {
     auto const secret = decode_base16<ec_secret_size>(secret_hex);
     REQUIRE(secret);
-    payment_address const address = payment_address::from_ec_private(ec_private{*secret, payment_address::mainnet_p2kh, false}).value();
+    payment_address const address = payment_address::from_ec_private(ec_private::from_verified_secret(*secret, payment_address::mainnet_p2kh, false)).value();
     REQUIRE(address.encoded_legacy() == address_uncompressed);
 }
 
@@ -84,7 +84,7 @@ TEST_CASE("payment_address construct secret testnet uncompressed valid expected"
 
     // MSVC CTP loses the MSB (WIF prefix) byte of the literal version when
     // using this initializer, but the MSB isn't used by payment_address.
-    payment_address const address = payment_address::from_ec_private(ec_private{*secret, 0x806f, false}).value();
+    payment_address const address = payment_address::from_ec_private(ec_private::from_verified_secret(*secret, 0x806f, false)).value();
     REQUIRE(address.encoded_legacy() == address_uncompressed_testnet);
 }
 
@@ -122,7 +122,7 @@ TEST_CASE("payment_address construct public compressed from uncompressed testnet
 TEST_CASE("payment_address construct public uncompressed from compressed testnet valid expected", "[payment_address]") {
     auto const point = decode_base16<ec_compressed_size>(compressed_pubkey);
     REQUIRE(point);
-    payment_address const address = payment_address::from_ec_public(ec_public{*point, false}, 0x6f).value();
+    payment_address const address = payment_address::from_ec_public(ec_public::from_verified_point(*point, false), 0x6f).value();
     REQUIRE(address.encoded_legacy() == address_uncompressed_testnet);
 }
 


### PR DESCRIPTION
## Summary

Drop the default ctors, `.valid()`, `valid_` flag, and string-based `operator<=>` on both types. Every reachable instance now comes from a factory that validated its input (WIF checksum + secret range for `ec_private`; `is_public_key` on-curve check for `ec_public`), so accessors and derivations are always meaningful.

## `ec_public`

- **Drop `ec_public()` default ctor, `.valid()`, and `valid_`.**
- **Move `explicit ec_public(ec_compressed, bool)` to `private`**; the public "wrap a trusted point" entry point is now the named factory `from_verified_point(ec_compressed, bool)` (infallible, no on-curve check — caller vouches for the point).
- **Default `operator<=>`** — the underlying state is `bool compress_` + `ec_compressed point_` and byte-lex is a canonical order that skips the base16 encode + strcmp the previous impl did.
- **`to_data()` returns `data_chunk`** (was `expect<>`). **`to_uncompressed()` returns `ec_uncompressed`** (was `expect<>`). Both were only fallible via the removed `valid_` check plus a `kth::decompress` failure that can't happen for a validated compressed point.
- **`from_private(ec_private)` becomes infallible** — it just forwards to `secret.to_public()`, which under the new invariant never fails.

## `ec_private`

- **Drop `ec_private()` default ctor, `.valid()`, and `valid_`.**
- **Move `ec_private(ec_secret, uint16_t, bool)` ctor to `private` and strip its default arguments.** Two named public factories replace it: `from_secret(...)` (validates the secret lies in `[1, n-1]`, returns `expect<>`) and `from_verified_secret(...)` (infallible, caller vouches for the range).
- **WIF factories (`from_compressed`, `from_uncompressed`) now route through `from_secret`**, so a WIF whose checksum is valid but whose secret is out-of-range is rejected up front instead of silently producing an `ec_private` whose `to_public()` fails.
- **Default `operator<=>`** — state is `bool` + `uint16_t` + `ec_secret`, byte-lex is canonical and skips the WIF encode + strcmp.
- **`to_public()` becomes infallible** — the factory-enforced scalar range guarantees `secret_to_public` never fails, so the two sentinel-`ec_public{}` returns are gone.

## Invariant assertions

`ec_public::to_uncompressed()` and `ec_private::to_public()` still call the fallible primitives (`kth::decompress`, `secret_to_public`) and previously silently produced garbage when the class invariant was broken via a `from_verified_*` factory called with an off-curve point / out-of-range scalar. Both sites now capture the primitive's return value in a `DEBUG_ONLY` local and pass it through `KTH_ASSERT_MSG` — zero cost in release, catches contract violations in debug.

## Cascade

- `payment_address::from_ec_public` and `::from_ec_private` drop the `!secret.valid()` / `!point.valid()` guards and the `if (!data)` unwrap of `point.to_data()` — none can trip anymore.
- `chain::script::to_pay_public_key_hash_pattern_unlocking` drops its `if (!pubkey_data)` short-circuit — same reason. Empty-list returns collapse into the straight-line happy path.
- Every `ec_public{...}` / `ec_private{...}` wrap-ctor call outside the two files moves to the named factory (`from_verified_point` / `from_verified_secret`): `stealth_sender`, `stealth_receiver`, `encrypted_keys`, and the wallet / math tests.
- The two `ec_private(secret)` / `ec_private(secret, 0x8000, false)` test calls in `test/wallet/ec_private.cpp` migrate to `from_verified_secret(...)`.

C-API is intentionally left untouched — the bulk regen at the end of the split picks up the removed `.valid()` / default ctor / renamed factories in one pass. `kth_wallet_ec_{public,private}_valid`, `kth_wallet_ec_{public,private}_construct_default`, and the raw `(ec_compressed, bool)` / `(ec_secret, uint16_t, bool)` wrap ctors disappear from the generated surface at that point.

Part of the #422 split.

## Test plan

- [x] `kth_domain_test` passes locally (1_011_093 assertions in 3872 test cases)
- [ ] Bulk regen PR restores C-API build + tests