### PR TITLE
refactor(wallet): make stealth_address valid-by-construction

### DIFF
--- a/src/domain/include/kth/domain/wallet/stealth_address.hpp
+++ b/src/domain/include/kth/domain/wallet/stealth_address.hpp
@@ -20,14 +20,8 @@
 
 namespace kth::domain::wallet {
 
-/**
- * Stealth payment address.
- *
- * Default-constructible so callers that hold a `stealth_address` as a
- * struct member (e.g. `stealth_receiver::address_`) can fill it later
- * via assignment. Fallible construction goes through `parse_from`,
- * which returns `expect<stealth_address>`.
- */
+/// Stealth payment address. Valid-by-construction: every reachable
+/// instance was produced by a factory that validated its inputs.
 struct KD_API stealth_address {
     /// DEPRECATED: we intend to make p2kh same as payment address versions.
     static uint8_t const mainnet_p2kh;
@@ -45,30 +39,30 @@ struct KD_API stealth_address {
     static
     expect<stealth_address> parse_from(std::string_view encoded);
 
-    stealth_address();
+    /// Parse the wire encoding
+    /// (`[version][options][scan_pubkey][N][spend_pubkeys][sigs][filter_bits][filter][checksum]`).
+    [[nodiscard]]
+    static
+    expect<stealth_address> from_data(data_chunk const& decoded);
 
-    explicit
-    stealth_address(data_chunk const& decoded);
-
-    stealth_address(binary const& filter, ec_compressed const& scan_key, point_list const& spend_keys, uint8_t signatures = 0, uint8_t version = mainnet_p2kh);
+    /// Wrap a caller-supplied component tuple. Coerces `signatures` to
+    /// a valid range and folds `scan_key` into `spend_keys` if the
+    /// list is empty (matches the historical constructor's behaviour).
+    /// Fails on too-many spend keys (>255) or an over-long filter.
+    [[nodiscard]]
+    static
+    expect<stealth_address> from_components(binary const& filter,
+                                            ec_compressed const& scan_key,
+                                            point_list const& spend_keys,
+                                            uint8_t signatures,
+                                            uint8_t version);
 
     [[nodiscard]]
-    friend bool operator==(stealth_address const&, stealth_address const&) = default;
-
-    [[nodiscard]]
-    friend auto operator<=>(stealth_address const& a, stealth_address const& b) {
-        return a.encoded() <=> b.encoded();
-    }
-
-    [[nodiscard]]
-    bool valid() const noexcept { return valid_; }
+    friend auto operator<=>(stealth_address const&, stealth_address const&) = default;
 
     /// Base58 encoding used by `fmt::formatter<stealth_address>`.
     [[nodiscard]]
-    std::string encoded() const;
-
-    [[nodiscard]]
-    std::string to_string() const { return encoded(); }
+    std::string to_string() const;
 
     [[nodiscard]]
     uint8_t version() const noexcept { return version_; }
@@ -89,18 +83,17 @@ struct KD_API stealth_address {
     data_chunk to_chunk() const;
 
 private:
-    static
-    stealth_address from_stealth(data_chunk const& decoded);
-
-    static
-    stealth_address from_stealth(binary const& filter,
-                                 ec_compressed const& scan_key,
-                                 point_list const& spend_keys,
-                                 uint8_t signatures,
-                                 uint8_t version);
-
-    /// Parameter order is used to change the constructor signature.
-    stealth_address(uint8_t version, binary const& filter, ec_compressed const& scan_key, point_list const& spend_keys, uint8_t signatures);
+    stealth_address(uint8_t version,
+                    binary const& filter,
+                    ec_compressed const& scan_key,
+                    point_list const& spend_keys,
+                    uint8_t signatures)
+        : version_(version)
+        , scan_key_(scan_key)
+        , spend_keys_(spend_keys)
+        , signatures_(signatures)
+        , filter_(filter)
+    {}
 
     [[nodiscard]]
     bool reuse_key() const;
@@ -108,8 +101,6 @@ private:
     [[nodiscard]]
     uint8_t options() const;
 
-    // These should be const, apart from the need to implement assignment.
-    bool          valid_{false};
     uint8_t       version_{0};
     ec_compressed scan_key_;
     point_list    spend_keys_;

--- a/src/domain/include/kth/domain/wallet/stealth_receiver.hpp
+++ b/src/domain/include/kth/domain/wallet/stealth_receiver.hpp
@@ -6,6 +6,7 @@
 #define KTH_WALLET_STEALTH_RECEIVER_HPP
 
 #include <cstdint>
+#include <optional>
 
 #include <kth/domain/define.hpp>
 #include <kth/domain/wallet/payment_address.hpp>
@@ -43,7 +44,7 @@ private:
     ec_secret const scan_private_;
     ec_secret const spend_private_;
     ec_compressed spend_public_;
-    wallet::stealth_address address_;
+    std::optional<wallet::stealth_address> address_;
 };
 
 } // namespace kth::domain::wallet

--- a/src/domain/src/wallet/bitcoin_uri.cpp
+++ b/src/domain/src/wallet/bitcoin_uri.cpp
@@ -131,7 +131,7 @@ void bitcoin_uri::set_address(payment_address const& payment) {
 }
 
 void bitcoin_uri::set_address(stealth_address const& stealth) {
-    address_ = stealth.encoded();
+    address_ = stealth.to_string();
 }
 
 bool bitcoin_uri::set_amount(std::string const& satoshis) {

--- a/src/domain/src/wallet/stealth_address.cpp
+++ b/src/domain/src/wallet/stealth_address.cpp
@@ -48,26 +48,6 @@ uint8_t const stealth_address::reuse_key_flag = 1U << 0U;
 size_t const stealth_address::min_filter_bits = 1 * byte_bits;
 size_t const stealth_address::max_filter_bits = sizeof(uint32_t) * byte_bits;
 
-stealth_address::stealth_address()
-    : scan_key_(null_compressed_point)
-{}
-
-stealth_address::stealth_address(data_chunk const& decoded)
-    : stealth_address(from_stealth(decoded))
-{}
-
-stealth_address::stealth_address(binary const& filter,
-                                 ec_compressed const& scan_key,
-                                 point_list const& spend_keys,
-                                 uint8_t signatures,
-                                 uint8_t version)
-    : stealth_address(from_stealth(filter, scan_key, spend_keys, signatures, version))
-{}
-
-stealth_address::stealth_address(uint8_t version, binary const& filter, ec_compressed const& scan_key, point_list const& spend_keys, uint8_t signatures)
-    : valid_(true), version_(version), scan_key_(scan_key), spend_keys_(spend_keys), signatures_(signatures), filter_(filter)
-{}
-
 // Factories.
 // ----------------------------------------------------------------------------
 
@@ -77,19 +57,15 @@ expect<stealth_address> stealth_address::parse_from(std::string_view encoded) {
     if ( ! decode_base58(decoded, std::string{encoded})) {
         return std::unexpected(kth::error::illegal_value);
     }
-    stealth_address out = from_stealth(decoded);
-    if ( ! out.valid()) {
-        return std::unexpected(kth::error::illegal_value);
-    }
-    return out;
+    return from_data(decoded);
 }
 
-// This is the stealth address parser.
-stealth_address stealth_address::from_stealth(data_chunk const& decoded) {
+// static
+expect<stealth_address> stealth_address::from_data(data_chunk const& decoded) {
     // Size is guarded until we get to N.
     auto required_size = min_address_size;
     if (decoded.size() < required_size || !verify_checksum(decoded)) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     // [version:1 = 0x2a]
@@ -100,7 +76,7 @@ stealth_address stealth_address::from_stealth(data_chunk const& decoded) {
     ++iterator;
     auto const options = *iterator;
     if (options > reuse_key_flag) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     // [scan_pubkey:33]
@@ -117,7 +93,7 @@ stealth_address stealth_address::from_stealth(data_chunk const& decoded) {
     // Adjust and retest required size. for pubkey list.
     required_size += number_spend_pubkeys * ec_compressed_size;
     if (decoded.size() < required_size) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     // We don't explicitly save 'reuse', instead we add to spend_keys_.
@@ -142,7 +118,7 @@ stealth_address stealth_address::from_stealth(data_chunk const& decoded) {
     // [prefix_number_bits:1]
     auto const filter_bits = *iterator;
     if (filter_bits > max_filter_bits) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     // [prefix:prefix_number_bits / 8, round up]
@@ -152,21 +128,21 @@ stealth_address stealth_address::from_stealth(data_chunk const& decoded) {
     // Adjust and retest required size.
     required_size += filter_bytes;
     if (decoded.size() != required_size) {
-        return {};
+        return std::unexpected(kth::error::illegal_value);
     }
 
     // Deserialize the filter bytes/blocks.
     data_chunk const raw_filter(iterator, iterator + filter_bytes);
     binary const filter(filter_bits, raw_filter);
-    return {filter, scan_key, spend_keys, signatures, version};
+    return from_components(filter, scan_key, spend_keys, signatures, version);
 }
 
-// This corrects signature and spend_keys.
-stealth_address stealth_address::from_stealth(binary const& filter,
-                                              ec_compressed const& scan_key,
-                                              point_list const& spend_keys,
-                                              uint8_t signatures,
-                                              uint8_t version) {
+// static
+expect<stealth_address> stealth_address::from_components(binary const& filter,
+                                                        ec_compressed const& scan_key,
+                                                        point_list const& spend_keys,
+                                                        uint8_t signatures,
+                                                        uint8_t version) {
     // Ensure there is at least one spend key.
     auto spenders = spend_keys;
     if (spenders.empty()) {
@@ -176,27 +152,25 @@ stealth_address stealth_address::from_stealth(binary const& filter,
     // Guard against too many keys.
     auto const spend_keys_size = spenders.size();
     if (spend_keys_size > max_spend_key_count) {
-        return {};
-    };
+        return std::unexpected(kth::error::illegal_value);
+    }
 
     // Guard against prefix too long.
-    auto prefix_number_bits = filter.size();
-    if (prefix_number_bits > max_filter_bits) {
-        return {};
+    if (filter.size() > max_filter_bits) {
+        return std::unexpected(kth::error::illegal_value);
     }
 
     // Coerce signatures to a valid range.
     auto const maximum = signatures == 0 || signatures > spend_keys_size;
     auto const coerced = maximum ? uint8_t(spend_keys_size) : signatures;
 
-    // Parameter order is used to change the constructor signature.
-    return {version, filter, scan_key, spenders, coerced};
+    return stealth_address(version, filter, scan_key, spenders, coerced);
 }
 
 // Serializer.
 // ----------------------------------------------------------------------------
 
-std::string stealth_address::encoded() const {
+std::string stealth_address::to_string() const {
     return encode_base58(to_chunk());
 }
 

--- a/src/domain/src/wallet/stealth_receiver.cpp
+++ b/src/domain/src/wallet/stealth_receiver.cpp
@@ -23,17 +23,21 @@ stealth_receiver::stealth_receiver(ec_secret const& scan_private,
     ec_compressed scan_public;
     if (secret_to_public(scan_public, scan_private_) &&
         secret_to_public(spend_public_, spend_private_)) {
-        address_ = {filter, scan_public, {spend_public_}};
+        auto built = stealth_address::from_components(
+            filter, scan_public, {spend_public_}, 0, stealth_address::mainnet_p2kh);
+        if (built) {
+            address_ = std::move(*built);
+        }
     }
 }
 
 stealth_receiver::operator bool() const {
-    return address_.valid();
+    return address_.has_value();
 }
 
-// Will be invalid if construct fails.
+// Precondition: `operator bool()` returned true.
 const wallet::stealth_address& stealth_receiver::stealth_address() const {
-    return address_;
+    return *address_;
 }
 
 bool stealth_receiver::derive_address(payment_address& out_address,

--- a/src/domain/test/math/stealth.cpp
+++ b/src/domain/test/math/stealth.cpp
@@ -81,7 +81,7 @@ TEST_CASE("stealth round trip", "[stealth]") {
 
 TEST_CASE("verify string constructor", "[stealth]") {
     std::string const value = "01100110000";
-    binary prefix(value);
+    binary prefix = binary::parse_from(value).value();
     REQUIRE(value.size() == prefix.size());
     for (size_t i = 0; i < value.size(); ++i) {
         auto const comparison = value[i] == '1';

--- a/src/domain/test/wallet/bitcoin_uri.cpp
+++ b/src/domain/test/wallet/bitcoin_uri.cpp
@@ -193,7 +193,7 @@ TEST_CASE("bitcoin uri stealth valid expected", "[bitcoin uri]") {
     auto const expected_uri = std::string("bitcoin:") + expected_stealth;
     auto const uri = bitcoin_uri::parse_from(expected_uri);
     REQUIRE(uri);
-    REQUIRE(uri->stealth()->encoded() == expected_stealth);
+    REQUIRE(uri->stealth()->to_string() == expected_stealth);
 }
 
 TEST_CASE("bitcoin uri address payment expected", "[bitcoin uri]") {

--- a/src/domain/test/wallet/stealth_address.cpp
+++ b/src/domain/test/wallet/stealth_address.cpp
@@ -19,9 +19,9 @@ TEST_CASE("stealth address construct string expected encoding", "[stealth addres
     REQUIRE(scan);
     auto const spend1 = decode_base16<ec_compressed_size>(spend_key1);
     REQUIRE(spend1);
-    stealth_address address({}, *scan, {*spend1}, 0, 42);
-    REQUIRE(address.valid());
-    REQUIRE(address.encoded() == stealth_address_encoded);
+    auto const address = stealth_address::from_components({}, *scan, {*spend1}, 0, 42);
+    REQUIRE(address);
+    REQUIRE(address->to_string() == stealth_address_encoded);
 }
 
 TEST_CASE("stealth address construct decoded expected properties", "[stealth address]") {
@@ -33,14 +33,14 @@ TEST_CASE("stealth address construct decoded expected properties", "[stealth add
     REQUIRE(encode_base16(address->spend_keys()[0]) == spend_key1);
     REQUIRE((size_t)address->signatures() == 1u);
     REQUIRE(address->filter().size() == 0u);
-    REQUIRE(address->encoded() == stealth_address_encoded);
+    REQUIRE(address->to_string() == stealth_address_encoded);
 }
 
 TEST_CASE("stealth address encoding scan mainnet round trips", "[stealth address]") {
     auto const encoded = "vJmzLu29obZcUGXXgotapfQLUpz7dfnZpbr4xg1R75qctf8xaXAteRdi3ZUk3T2ZMSad5KyPbve7uyH6eswYAxLHRVSbWgNUeoGuXp";
     auto const address = stealth_address::parse_from(encoded);
     REQUIRE(address);
-    REQUIRE(address->encoded() == encoded);
+    REQUIRE(address->to_string() == encoded);
     REQUIRE(address->version() == 42u);
 }
 
@@ -48,7 +48,7 @@ TEST_CASE("stealth address encoding scan testnet round trips", "[stealth address
     std::string const encoded = "waPXhQwQE9tDugfgLkvpDs3dnkPx1RsfDjFt4zBq7EeWeATRHpyQpYrFZR8T4BQy91Vpvshm2TDER8b9ZryuZ8VSzz8ywzNzX8NqF4";
     auto const address = stealth_address::parse_from(encoded);
     REQUIRE(address);
-    REQUIRE(address->encoded() == encoded);
+    REQUIRE(address->to_string() == encoded);
     REQUIRE(address->version() == 43u);
 }
 
@@ -56,7 +56,7 @@ TEST_CASE("stealth address encoding scan pub mainnet round trips", "[stealth add
     auto const encoded = "hfFGUXFPKkQ5M6LC6aEUKMsURdhw93bUdYdacEtBA8XttLv7evZkira2i";
     auto const address = stealth_address::parse_from(encoded);
     REQUIRE(address);
-    REQUIRE(address->encoded() == encoded);
+    REQUIRE(address->to_string() == encoded);
     REQUIRE(address->version() == 42u);
 }
 
@@ -64,7 +64,7 @@ TEST_CASE("stealth address encoding scan pub testnet round trip", "[stealth addr
     auto const encoded = "idPayBqZUpZH7Y5GTaoEyGxDsEmU377JUmhtqG8yoHCkfGfhnAHmGUJbL";
     auto const address = stealth_address::parse_from(encoded);
     REQUIRE(address);
-    REQUIRE(address->encoded() == encoded);
+    REQUIRE(address->to_string() == encoded);
     REQUIRE(address->version() == 43u);
 }
 


### PR DESCRIPTION
## Summary

Drop the default ctor, `.valid()`, and `valid_` flag on `stealth_address`. Every reachable instance now comes from a factory returning `expect<>` (parse from base58, parse from raw bytes, or build from components), so accessors and serializers are always meaningful and the runtime `.valid()` check has nothing to gate.

## `stealth_address`

- **Drop `stealth_address()` default ctor, `.valid()`, and `valid_`.**
- **Delete the two public "delegating" ctors** (`stealth_address(data_chunk)` and `stealth_address(binary, ec_compressed, point_list, uint8_t=0, uint8_t=mainnet_p2kh)`) — both routed through `from_stealth` that returned a default-constructed sentinel on failure. Replaced by named static factories:
  - `from_data(data_chunk)` → `expect<stealth_address>` (parses the wire encoding).
  - `from_components(binary, ec_compressed, point_list, uint8_t signatures, uint8_t version)` → `expect<stealth_address>`.
- The private `stealth_address(uint8_t version, binary, ec_compressed, point_list, uint8_t signatures)` terminal ctor is kept as the "trust me" wrap (no `valid_(true)` init anymore); both public factories route through it.
- **Default `operator<=>`.** `binary` gained a defaulted `<=>` in #434, so the members (`uint8_t`, `ec_compressed`, `point_list`, `uint8_t`, `binary`) can be compared member-wise. Canonical strong ordering, no base58 encode + strcmp round-trip and no `to_chunk()` allocation.
- **Rename `encoded()` → `to_string()`.** Aligns with the convention on `hd_public`, `ec_public`, `payment_address`, etc. The alias `to_string()` that just called `encoded()` goes away.

## Cascade

- `stealth_receiver::address_` moves from `stealth_address` to `std::optional<stealth_address>` — `stealth_address` no longer has a default ctor to hold the "not yet initialised" state. The constructor's success path calls `stealth_address::from_components(filter, scan_public, {spend_public_}, 0, mainnet_p2kh)` and moves the value in; the failure path leaves the optional `nullopt`.
- `operator bool()` now returns `address_.has_value()`.
- The `stealth_address()` accessor returns `*address_` — precondition is that `operator bool()` returned true.
- `bitcoin_uri::set_address(stealth_address const&)` calls `stealth.to_string()` instead of `stealth.encoded()`.
- Tests updated:
  - `test/wallet/stealth_address.cpp` — one caller migrated from the removed public ctor to `stealth_address::from_components(...)`; four `->encoded()` calls swap to `->to_string()`.
  - `test/wallet/bitcoin_uri.cpp` — one dead `->encoded()` on the stealth result swaps to `->to_string()`.

C-API is intentionally left untouched — the bulk regen at the end of the split picks up the removed default ctor / `.valid()` / component-taking ctor / renamed encoder in one pass.

Part of the #422 split. Rebased on top of #434 (binary defaulted comparators).

## Test plan

- [x] `kth_domain_test` passes locally (1_011_093 assertions in 3872 test cases)
- [ ] Bulk regen PR restores C-API build + tests