### PR TITLE
refactor(infrastructure): modernize binary — factories, comparators, hash

### DIFF
--- a/src/domain/test/math/stealth.cpp
+++ b/src/domain/test/math/stealth.cpp
@@ -92,14 +92,14 @@ TEST_CASE("verify string constructor", "[stealth]") {
 // Binary as a value on the left, padded with zeros to the y.
 TEST_CASE("compare constructor results", "[stealth]") {
     std::string value = "01100111000";
-    binary prefix(value);
+    binary prefix = binary::parse_from(value).value();
     data_chunk blocks{{0x67, 0x00}};
     binary prefix2(value.size(), blocks);
     REQUIRE(prefix == prefix2);
 }
 
 TEST_CASE("bitfield test1", "[stealth]") {
-    binary prefix("01100111001");
+    binary prefix = binary::parse_from("01100111001").value();
     data_chunk raw_bitfield{{0x67, 0x20, 0x00, 0x0}};
     REQUIRE(raw_bitfield.size() * 8 >= prefix.size());
     binary compare(prefix.size(), raw_bitfield);

--- a/src/infrastructure/include/kth/infrastructure/utility/binary.hpp
+++ b/src/infrastructure/include/kth/infrastructure/utility/binary.hpp
@@ -7,11 +7,13 @@
 
 #include <bit>
 #include <cstdint>
+#include <expected>
 #include <string>
 #include <string_view>
 #include <utility>
 
 #include <kth/infrastructure/constants.hpp>
+#include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 
 namespace kth {
@@ -28,13 +30,12 @@ struct KI_API binary {
         return bit_size == 0 ? 0 : (bit_size - 1) / bits_per_block + 1;
     }
 
+    /// Parse a base2 string (each character `'0'` or `'1'` is one bit).
+    /// Returns `error::illegal_value` on any other character.
     [[nodiscard]] static
-    bool is_base2(std::string_view text) noexcept;
+    std::expected<binary, kth::code> parse_from(std::string_view bit_string);
 
     binary() = default;
-
-    explicit
-    binary(std::string_view bit_string);
 
     binary(size_type size, uint32_t number);
     binary(size_type size, byte_span blocks);
@@ -42,7 +43,9 @@ struct KI_API binary {
     void resize(size_type size);
     [[nodiscard]] bool operator[](size_type index) const;
     [[nodiscard]] data_chunk const& blocks() const noexcept;
-    [[nodiscard]] std::string encoded() const;
+
+    /// Base2 encoding used by `fmt::formatter<binary>`.
+    [[nodiscard]] std::string to_string() const;
 
     /// size in bits
     [[nodiscard]] size_type size() const noexcept;
@@ -50,18 +53,35 @@ struct KI_API binary {
     void prepend(binary const& prior);
     void shift_left(size_type distance);
     void shift_right(size_type distance);
-    [[nodiscard]] binary substring(size_type start, size_type length=max_size_t) const;
+    [[nodiscard]] binary substring(size_type start, size_type length) const;
 
     [[nodiscard]] bool is_prefix_of(byte_span field) const;
     [[nodiscard]] bool is_prefix_of(uint32_t field) const;
     [[nodiscard]] bool is_prefix_of(binary const& field) const;
 
-    binary& operator=(binary const& x);
-    [[nodiscard]] bool operator==(binary const& x) const;
-    [[nodiscard]] bool operator!=(binary const& x) const;
-    [[nodiscard]] bool operator<(binary const& x) const;
+    binary& operator=(binary const& x) = default;
+
+    /// Byte-lex over (`blocks_`, `final_block_excess_`). The class
+    /// invariant guarantees unused trailing bits are zero (every
+    /// mutator ends in `resize()`, which masks them), so member-wise
+    /// equality matches the bit-level equality the previous manual
+    /// `operator==` computed. The strong ordering `<=>` produces is
+    /// canonical and consistent with `==`, but it is NOT the same as
+    /// the previous string-lex order via `encoded()`: two values with
+    /// the same block bytes but different bit-length (e.g. `"1"` and
+    /// `"10000000"` both blocks `{0x80}` with `final_block_excess_`
+    /// 7 and 0) are ordered by their excess field, so the shorter
+    /// one is greater under the new order and less under the old.
+    /// No caller in-tree relies on the specific pre-refactor order —
+    /// map / set keys and sorted output only need a total order
+    /// consistent with equality, which this satisfies.
+    [[nodiscard]]
+    friend auto operator<=>(binary const&, binary const&) = default;
 
 private:
+    static
+    bool is_base2(std::string_view text) noexcept;
+
     static
     uint8_t shift_block_right(uint8_t next, uint8_t current, uint8_t prior, size_type original_offset, size_type intended_offset);
 
@@ -76,7 +96,14 @@ namespace std {
 template <>
 struct hash<kth::binary> {
     size_t operator()(kth::binary const& x) const {
-        return std::hash<std::string>()(x.encoded());
+        // Hash raw blocks + trailing-bit metadata directly — no
+        // base2 string allocation. Under the class invariant unused
+        // bits are zero, so equivalent values hash the same.
+        auto const& blocks = x.blocks();
+        auto h = std::hash<std::string_view>()(
+            std::string_view(reinterpret_cast<char const*>(blocks.data()), blocks.size()));
+        h ^= std::hash<size_t>()(x.size()) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+        return h;
     }
 };
 

--- a/src/infrastructure/src/config/base2.cpp
+++ b/src/infrastructure/src/config/base2.cpp
@@ -14,14 +14,15 @@ namespace kth::infrastructure::config {
 
 // static
 std::expected<base2, kth::code> base2::parse_from(std::string_view text) noexcept {
-    if ( ! binary::is_base2(text)) {
-        return std::unexpected(kth::error::illegal_value);
+    auto value = binary::parse_from(text);
+    if ( ! value) {
+        return std::unexpected(value.error());
     }
-    return base2{binary{text}};
+    return base2{*value};
 }
 
 std::string base2::to_string() const {
-    return value_.encoded();
+    return value_.to_string();
 }
 
 } // namespace kth::infrastructure::config

--- a/src/infrastructure/src/utility/binary.cpp
+++ b/src/infrastructure/src/utility/binary.cpp
@@ -22,18 +22,17 @@ bool binary::is_base2(std::string_view text) noexcept {
     return true;
 }
 
-binary::binary(std::string_view bit_string)
-    : binary()
-{
+// static
+std::expected<binary, kth::code> binary::parse_from(std::string_view bit_string) {
+    if ( ! is_base2(bit_string)) {
+        return std::unexpected(kth::error::illegal_value);
+    }
+
+    binary out;
     uint8_t block = 0;
     auto bit_iterator = binary::bits_per_block;
 
     for (char const representation : bit_string) {
-        if (representation != '0' && representation != '1') {
-            blocks_.clear();
-            return;
-        }
-
         if (representation == '1') {
             uint8_t const bitmask = 1 << (bit_iterator - 1);
             block |= bitmask;
@@ -42,17 +41,18 @@ binary::binary(std::string_view bit_string)
         --bit_iterator;
 
         if (bit_iterator == 0) {
-            blocks_.push_back(block);
+            out.blocks_.push_back(block);
             block = 0;
             bit_iterator = binary::bits_per_block;
         }
     }
 
     if (bit_iterator != binary::bits_per_block) {
-        blocks_.push_back(block);
+        out.blocks_.push_back(block);
     }
 
-    resize(bit_string.size());
+    out.resize(bit_string.size());
+    return out;
 }
 
 binary::binary(size_type size, uint32_t number)
@@ -109,7 +109,7 @@ data_chunk const& binary::blocks() const noexcept {
     return blocks_;
 }
 
-std::string binary::encoded() const {
+std::string binary::to_string() const {
     // Walk blocks (bytes), not bits: divisions by 8 in `operator[]`
     // dominate the naive per-bit form. Uninitialized-then-write is
     // faster than push_back — we know the exact size.
@@ -246,31 +246,5 @@ bool binary::is_prefix_of(byte_span field) const {
     binary const truncated_prefix(size(), field);
     return *this == truncated_prefix;
 }
-
-bool binary::operator<(binary const& x) const {
-    return encoded() < x.encoded();
-}
-
-bool binary::operator==(binary const& x) const {
-    if (size() != x.size()) {
-        return false;
-    }
-
-    auto const self = *this;
-
-    for (binary::size_type i = 0; i < size(); ++i) {
-        if (self[i] != x[i]) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-bool binary::operator!=(binary const& x) const {
-    return !(*this == x);
-}
-
-binary& binary::operator=(binary const& x) = default;
 
 } // namespace kth

--- a/src/infrastructure/test/utility/binary.cpp
+++ b/src/infrastructure/test/utility/binary.cpp
@@ -14,16 +14,16 @@ using namespace kth;
 TEST_CASE("infrastructure binary encoded 32 bits from data chunk", "[infrastructure][binary]") {
     data_chunk const blocks{ { 0xba, 0xad, 0xf0, 0x0d } };
     binary const prefix(32, blocks);
-    REQUIRE(prefix.encoded() == "10111010101011011111000000001101");
+    REQUIRE(prefix.to_string() == "10111010101011011111000000001101");
 }
 
 TEST_CASE("infrastructure binary encoded 32 bits from unsigned integer", "[infrastructure][binary]") {
     binary const prefix(32, uint32_t(0x0df0adba));
-    REQUIRE(prefix.encoded() == "10111010101011011111000000001101");
+    REQUIRE(prefix.to_string() == "10111010101011011111000000001101");
 }
 TEST_CASE("infrastructure binary encoded 8 bits from unsigned integer", "[infrastructure][binary]") {
     binary const prefix(8, uint32_t(0x0df0adba));
-    REQUIRE(prefix.encoded() == "10111010");
+    REQUIRE(prefix.to_string() == "10111010");
 }
 
 // End Test Suite
@@ -33,7 +33,7 @@ TEST_CASE("infrastructure binary encoded 8 bits from unsigned integer", "[infras
 TEST_CASE("infrastructure binary encoded string", "[infrastructure][binary]") {
     data_chunk const blocks{ { 0xba, 0xad, 0xf0, 0x0d } };
     binary const prefix(32, blocks);
-    REQUIRE(prefix.encoded() == "10111010101011011111000000001101");
+    REQUIRE(prefix.to_string() == "10111010101011011111000000001101");
 }
 
 // End Test Suite
@@ -316,11 +316,11 @@ TEST_CASE("substring request exceeds string", "[binary substring]") {
     REQUIRE(expected == result);
 }
 
-TEST_CASE("substring implicit length", "[binary substring]") {
+TEST_CASE("substring trailing tail", "[binary substring]") {
     binary instance(20, data_chunk{ 0xAA, 0xBB, 0xCC });
     binary::size_type start = 10;
     binary expected(10, data_chunk{ 0xEF, 0x00 });
-    binary result = instance.substring(start);
+    binary result = instance.substring(start, instance.size() - start);
     REQUIRE(expected == result);
 }
 
@@ -330,7 +330,7 @@ TEST_CASE("substring implicit length", "[binary substring]") {
 
 TEST_CASE("string to prefix 32 bits expected value", "[binary blocks]") {
     data_chunk const blocks{ { 0xba, 0xad, 0xf0, 0x0d } };
-    binary const prefix("10111010101011011111000000001101");
+    binary const prefix = binary::parse_from("10111010101011011111000000001101").value();
     REQUIRE(prefix.blocks() == blocks);
 }
 
@@ -345,7 +345,7 @@ TEST_CASE("bytes to prefix zero bits round trips", "[binary blocks]") {
     binary const prefix(0, bytes);
     REQUIRE(prefix.size() == 0u);
     REQUIRE(prefix.blocks().size() == 0u);
-    REQUIRE(prefix.encoded().empty());
+    REQUIRE(prefix.to_string().empty());
 }
 
 TEST_CASE("prefix to bytes zero bits round trips", "[binary blocks]") {
@@ -355,13 +355,13 @@ TEST_CASE("prefix to bytes zero bits round trips", "[binary blocks]") {
     REQUIRE(prefix.size() == 0u);
     REQUIRE(prefix.blocks().size() == 0u);
     REQUIRE(bytes.size() == 0u);
-    REQUIRE(prefix.encoded().empty());
+    REQUIRE(prefix.to_string().empty());
 }
 
 TEST_CASE("bytes to prefix one bit round trips", "[binary blocks]") {
     data_chunk bytes{ { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF } };
     auto prefix = binary(1, bytes);
-    auto const encoded = prefix.encoded();
+    auto const encoded = prefix.to_string();
     REQUIRE(prefix.size() == 1u);
     REQUIRE(prefix.blocks().size() == 1u);
     REQUIRE(encoded == "1");
@@ -371,7 +371,7 @@ TEST_CASE("prefix to bytes one bit round trips", "[binary blocks]") {
     data_chunk const blocks{ { 0xff, 0xff, 0xff, 0xff } };
     binary const prefix(1, blocks);
     auto const bytes = prefix.blocks();
-    auto const encoded = prefix.encoded();
+    auto const encoded = prefix.to_string();
     REQUIRE(prefix.size() == 1u);
     REQUIRE(prefix.blocks().size() == 1u);
     REQUIRE(bytes.size() == 1u);
@@ -381,7 +381,7 @@ TEST_CASE("prefix to bytes one bit round trips", "[binary blocks]") {
 TEST_CASE("bytes to prefix two bits leading zero round trips", "[binary blocks]") {
     data_chunk const bytes{ { 0x01, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42 } };
     auto const prefix = binary(2, bytes);
-    auto const encoded = prefix.encoded();
+    auto const encoded = prefix.to_string();
     REQUIRE(prefix.size() == 2u);
     REQUIRE(prefix.blocks().size() == 1u);
     REQUIRE(encoded == "00");
@@ -391,7 +391,7 @@ TEST_CASE("prefix to bytes two bits leading zero round trips", "[binary blocks]"
     data_chunk const blocks{ { 0x42, 0x42, 0x42, 0x01 } };
     binary const prefix(2, blocks);
     auto bytes = prefix.blocks();
-    auto const encoded = prefix.encoded();
+    auto const encoded = prefix.to_string();
     REQUIRE(prefix.size() == 2u);
     REQUIRE(prefix.blocks().size() == 1u);
     REQUIRE(bytes.size() == 1u);
@@ -401,7 +401,7 @@ TEST_CASE("prefix to bytes two bits leading zero round trips", "[binary blocks]"
 TEST_CASE("bytes to prefix two bytes leading null byte round trips", "[binary blocks]") {
     data_chunk const bytes{ { 0xFF, 0x00 } };
     auto const prefix = binary(16, bytes);
-    auto const encoded = prefix.encoded();
+    auto const encoded = prefix.to_string();
     REQUIRE(prefix.size() == 16u);
     REQUIRE(prefix.blocks().size() == 2u);
     REQUIRE(encoded == "1111111100000000");
@@ -411,7 +411,7 @@ TEST_CASE("prefix to bytes two bytes leading null byte round trips", "[binary bl
     data_chunk const blocks{ { 0x00, 0x00 } };
     binary const prefix(16, blocks);
     auto bytes = prefix.blocks();
-    auto const encoded = prefix.encoded();
+    auto const encoded = prefix.to_string();
     REQUIRE(prefix.size() == 16u);
     REQUIRE(prefix.blocks().size() == 2u);
     REQUIRE(bytes.size() == 2u);


### PR DESCRIPTION
## Summary

Full pass on `kth::binary`. Replaces the silent-fail string ctor and the hand-written comparators / hash, renames the base2 accessor to match the project's `to_string()` convention, and drops a stale default parameter.

## What changed

- **`binary(std::string_view)` public ctor → `parse_from(string_view)` factory** returning `std::expected<binary, kth::code>`. The old ctor cleared `blocks_` and returned on any non-`0/1` character, so a caller could not distinguish "you passed garbage" from "you built an empty binary on purpose". The factory returns `error::illegal_value` instead. Only one caller in-tree (a stealth test) used the string ctor; the rest went through `base2` config which now delegates to `binary::parse_from` too.
- **`is_base2` moves to `private`** — the only external user was `base2::parse_from`, which now goes through `binary::parse_from` directly. C-API surface for `is_base2` will be picked up in the bulk regen.
- **Defaulted `operator<=>`, `operator==`, `operator=`** replace the four hand-written comparators / assignment. The manual `operator==` walked bits via `operator[]`; the manual `operator<` routed through `encoded()` (allocate a base2 string per compare, then `std::string` lex). The defaulted forms compare `blocks_` (`data_chunk`, defaulted `<=>`) then `final_block_excess_` (`uint8_t`), skipping both allocations. The class invariant (unused trailing bits zero, enforced by `resize()`) makes member-wise equality equivalent to the previous bit-level walk. The new strong order is NOT the same as the old `encoded()`-based order — two values with the same block bytes but different bit-length now sort by excess (shorter is greater), not by string-lex — but no in-tree caller relies on the specific pre-refactor order. Doc comment on `<=>` calls this out.
- **`encoded()` → `to_string()`** — aligns with the convention on `hd_public`, `ec_public`, `payment_address`, etc.
- **Drop the `length = max_size_t` default on `substring`** — one test called it with only `start`; updated to pass `instance.size() - start` explicitly.
- **`std::hash<binary>` hashes `blocks_` + `size()` directly** instead of building the base2 string and hashing that. Equivalent values hash the same under the same invariant.

## Cascade

- `infrastructure::config::base2::parse_from` unwraps `binary::parse_from(text)` instead of the check-then-throw dance it used to do.
- `test/utility/binary.cpp` swaps `prefix.encoded()` for `prefix.to_string()`, the `binary("...")` construction for `binary::parse_from(...).value()`, and the implicit-length `substring(start)` for the explicit form.
- `test/math/stealth.cpp` swaps `binary prefix("...")` for `binary::parse_from(...).value()`.

## Test plan

- [x] `kth_infrastructure_test` passes locally (104_452 assertions in 440 test cases)
- [ ] `kth_domain_test` — build in flight; will confirm before merge