### PR TITLE
refactor(wallet): modernize stealth_receiver

### DIFF
--- a/src/domain/include/kth/domain/wallet/stealth_receiver.hpp
+++ b/src/domain/include/kth/domain/wallet/stealth_receiver.hpp
@@ -5,10 +5,11 @@
 #ifndef KTH_WALLET_STEALTH_RECEIVER_HPP
 #define KTH_WALLET_STEALTH_RECEIVER_HPP
 
+#include <cstddef>
 #include <cstdint>
-#include <optional>
 
 #include <kth/domain/define.hpp>
+#include <kth/domain/deserialization.hpp>
 #include <kth/domain/wallet/payment_address.hpp>
 #include <kth/domain/wallet/stealth_address.hpp>
 #include <kth/infrastructure/math/elliptic_curve.hpp>
@@ -16,35 +17,49 @@
 
 namespace kth::domain::wallet {
 
+/// Stealth-address receiver. Valid-by-construction: every reachable
+/// instance came from `from_secrets`, which verifies both private
+/// keys lift to points and the resulting `stealth_address` is well-
+/// formed; accessors and derivations are always meaningful.
+///
 /// This class does not support multisignature stealth addresses.
 struct KD_API stealth_receiver {
-    /// Constructors.
-    stealth_receiver(ec_secret const& scan_private,
-                     ec_secret const& spend_private,
-                     binary const& filter,
-                     uint8_t version = payment_address::mainnet_p2kh);
-
-    /// Caller must test after construct.
-    operator bool() const;
-
-    /// Get the stealth address.
+    /// Build a receiver from a scan / spend private-key pair against
+    /// a caller-supplied bloom filter and payment-address version.
+    /// Fails if either private key is off-curve or if the derived
+    /// stealth address is malformed.
     [[nodiscard]]
-    const wallet::stealth_address& stealth_address() const;
+    static
+    expect<stealth_receiver> from_secrets(ec_secret const& scan_private,
+                                          ec_secret const& spend_private,
+                                          binary const& filter,
+                                          uint8_t version);
+
+    /// Peer stealth address for this receiver.
+    [[nodiscard]]
+    wallet::stealth_address const& stealth_address() const noexcept;
 
     /// Derive a payment address to compare against the blockchain.
-    bool derive_address(payment_address& out_address,
-                        ec_compressed const& ephemeral_public) const;
+    [[nodiscard]]
+    expect<payment_address> derive_address(ec_compressed const& ephemeral_public) const;
 
-    /// Once address is discovered, derive the private spend key.
-    bool derive_private(ec_secret& out_private,
-                        ec_compressed const& ephemeral_public) const;
+    /// Once the address is discovered, derive the private spend key
+    /// for the corresponding output.
+    [[nodiscard]]
+    expect<ec_secret> derive_private(ec_compressed const& ephemeral_public) const;
 
 private:
+    stealth_receiver(uint8_t version,
+                     ec_secret const& scan_private,
+                     ec_secret const& spend_private,
+                     ec_compressed const& spend_public,
+                     wallet::stealth_address address);
+
     uint8_t const version_;
     ec_secret const scan_private_;
     ec_secret const spend_private_;
-    ec_compressed spend_public_;
-    std::optional<wallet::stealth_address> address_;
+    ec_compressed const spend_public_;
+    wallet::stealth_address const address_;
 };
 
 } // namespace kth::domain::wallet

--- a/src/domain/src/wallet/stealth_receiver.cpp
+++ b/src/domain/src/wallet/stealth_receiver.cpp
@@ -5,61 +5,74 @@
 #include <kth/domain/wallet/stealth_receiver.hpp>
 
 #include <cstdint>
+#include <utility>
 
 #include <kth/domain/math/stealth.hpp>
 #include <kth/domain/wallet/payment_address.hpp>
 #include <kth/domain/wallet/stealth_address.hpp>
+#include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/math/elliptic_curve.hpp>
 #include <kth/infrastructure/utility/binary.hpp>
 
 namespace kth::domain::wallet {
 
-// TODO(legacy): use to factory and make address_ and spend_public_ const.
-stealth_receiver::stealth_receiver(ec_secret const& scan_private,
+stealth_receiver::stealth_receiver(uint8_t version,
+                                   ec_secret const& scan_private,
                                    ec_secret const& spend_private,
-                                   binary const& filter,
-                                   uint8_t version)
-    : version_(version), scan_private_(scan_private), spend_private_(spend_private) {
+                                   ec_compressed const& spend_public,
+                                   wallet::stealth_address address)
+    : version_(version)
+    , scan_private_(scan_private)
+    , spend_private_(spend_private)
+    , spend_public_(spend_public)
+    , address_(std::move(address))
+{}
+
+// static
+expect<stealth_receiver> stealth_receiver::from_secrets(ec_secret const& scan_private,
+                                                       ec_secret const& spend_private,
+                                                       binary const& filter,
+                                                       uint8_t version) {
     ec_compressed scan_public;
-    if (secret_to_public(scan_public, scan_private_) &&
-        secret_to_public(spend_public_, spend_private_)) {
-        auto built = stealth_address::from_components(
-            filter, scan_public, {spend_public_}, 0, stealth_address::mainnet_p2kh);
-        if (built) {
-            address_ = std::move(*built);
-        }
+    if ( ! secret_to_public(scan_public, scan_private)) {
+        return std::unexpected(kth::error::illegal_value);
     }
+
+    ec_compressed spend_public;
+    if ( ! secret_to_public(spend_public, spend_private)) {
+        return std::unexpected(kth::error::illegal_value);
+    }
+
+    auto address = stealth_address::from_components(
+        filter, scan_public, {spend_public}, 0, stealth_address::mainnet_p2kh);
+    if ( ! address) {
+        return std::unexpected(address.error());
+    }
+
+    return stealth_receiver(version, scan_private, spend_private,
+                            spend_public, std::move(*address));
 }
 
-stealth_receiver::operator bool() const {
-    return address_.has_value();
+wallet::stealth_address const& stealth_receiver::stealth_address() const noexcept {
+    return address_;
 }
 
-// Precondition: `operator bool()` returned true.
-const wallet::stealth_address& stealth_receiver::stealth_address() const {
-    return *address_;
-}
-
-bool stealth_receiver::derive_address(payment_address& out_address,
-                                      ec_compressed const& ephemeral_public) const {
+expect<payment_address> stealth_receiver::derive_address(ec_compressed const& ephemeral_public) const {
     ec_compressed receiver_public;
-    if ( ! uncover_stealth(receiver_public, ephemeral_public, scan_private_,
-                         spend_public_)) {
-        return false;
+    if ( ! uncover_stealth(receiver_public, ephemeral_public, scan_private_, spend_public_)) {
+        return std::unexpected(kth::error::illegal_value);
     }
 
-    auto result = payment_address::from_ec_public(ec_public::from_verified_point(receiver_public, true), version_);
-    if ( ! result) {
-        return false;
-    }
-    out_address = *result;
-    return true;
+    return payment_address::from_ec_public(
+        ec_public::from_verified_point(receiver_public, true), version_);
 }
 
-bool stealth_receiver::derive_private(ec_secret& out_private,
-                                      ec_compressed const& ephemeral_public) const {
-    return uncover_stealth(out_private, ephemeral_public, scan_private_,
-                           spend_private_);
+expect<ec_secret> stealth_receiver::derive_private(ec_compressed const& ephemeral_public) const {
+    ec_secret out;
+    if ( ! uncover_stealth(out, ephemeral_public, scan_private_, spend_private_)) {
+        return std::unexpected(kth::error::illegal_value);
+    }
+    return out;
 }
 
 } // namespace kth::domain::wallet


### PR DESCRIPTION
## Summary

Convert `stealth_receiver` to the project's current shape — a factory-only, `expect<>`-returning value type with no `operator bool`, no OUT-param derives, and no `optional` sentinel on the composed address.

## What changed

- **Ctor becomes `stealth_receiver::from_secrets(...)`** returning `expect<stealth_receiver>`. Runs `secret_to_public` on both scan and spend privates and builds the peer `stealth_address` via `from_components` up front; any of those steps failing surfaces the error to the caller instead of leaving a half-initialised receiver behind.
- **`operator bool()` gone.** The type's existence is now the success signal — every constructed instance is valid.
- **`address_` drops the `std::optional<stealth_address>` wrap.** The factory guarantees a real address; the field is a plain `wallet::stealth_address` again.
- **`stealth_address()` accessor** returns `stealth_address const&` unconditionally (`noexcept`). No precondition to remember.
- **`derive_address(out, ephemeral)` → `expect<payment_address> derive_address(ephemeral)`**. Same for `derive_private` (now returns `expect<ec_secret>`). The old signature forced callers to construct a `payment_address` up front just to have a slot to write into — post-#431 that isn't representable without an aggregate init with a real address, which defeats the point.
- **`spend_public_` becomes `const`** — everything about the type is now immutable after construction.
- **Default `version = payment_address::mainnet_p2kh` argument dropped** from the factory. Callers pass the version explicitly (project rule against default parameters).

## Cascade

- No non-test callers in-tree: the only external user is a stealth suite `test/wallet/stealth_receiver.cpp` that is fully commented out (predates the current sweep). Left as-is — the file compiles and links.
- C-API bindings for `stealth_receiver_construct`, `_valid`, `derive_address`, and `derive_private` are intentionally left untouched; the bulk regen at the end of the split picks up the removed default ctor / operator bool / OUT-param signatures and substitutes the factory + `expect<>` shape in one pass.

## Header hygiene

- Adds `<cstddef>` explicitly — the new `deserialization.hpp` include-chain lands on `concepts.hpp` which uses unqualified `size_t`; other consumers picked it up transitively from `chain/script.hpp`, but `stealth_receiver.hpp` doesn't include that.

## Test plan

- [x] `kth_domain_test` passes locally (1_011_093 assertions in 3872 test cases)