### PR TITLE
refactor(wallet): modernize stealth_sender

### DIFF
--- a/src/domain/include/kth/domain/wallet/stealth_sender.hpp
+++ b/src/domain/include/kth/domain/wallet/stealth_sender.hpp
@@ -5,11 +5,12 @@
 #ifndef KTH_WALLET_STEALTH_SENDER_HPP
 #define KTH_WALLET_STEALTH_SENDER_HPP
 
+#include <cstddef>
 #include <cstdint>
-#include <optional>
 
 #include <kth/domain/chain/script.hpp>
 #include <kth/domain/define.hpp>
+#include <kth/domain/deserialization.hpp>
 #include <kth/domain/wallet/payment_address.hpp>
 #include <kth/domain/wallet/stealth_address.hpp>
 #include <kth/infrastructure/math/elliptic_curve.hpp>
@@ -18,39 +19,50 @@
 
 namespace kth::domain::wallet {
 
+/// Stealth-address sender. Valid-by-construction: every reachable
+/// instance came from `from_stealth_address`, which verifies the
+/// derived stealth script and payment address up front; accessors
+/// are always meaningful.
+///
 /// This class does not support multisignature stealth addresses.
 struct KD_API stealth_sender {
-    /// Constructors.
-    /// Generate a send address from the stealth address.
-    stealth_sender(stealth_address const& address, data_chunk const& seed, binary const& filter, uint8_t version = payment_address::mainnet_p2kh);
+    /// Generate the send address by drawing a fresh ephemeral private
+    /// key from `seed`. Fails when the seed cannot yield a valid
+    /// ephemeral key or when any downstream stealth-derivation step
+    /// (single spend key, on-curve derivation, script construction,
+    /// address wrap) rejects the input.
+    [[nodiscard]]
+    static
+    expect<stealth_sender> from_stealth_address(stealth_address const& address,
+                                                data_chunk const& seed,
+                                                binary const& filter,
+                                                uint8_t version);
 
-    /// Generate a send address from the stealth address.
-    stealth_sender(ec_secret const& ephemeral_private,
-                   stealth_address const& address,
-                   data_chunk const& seed,
-                   binary const& filter,
-                   uint8_t version = payment_address::mainnet_p2kh);
-
-    /// Caller must test after construct.
-    operator bool() const;
+    /// Same, using a caller-supplied ephemeral private key.
+    [[nodiscard]]
+    static
+    expect<stealth_sender> from_ephemeral(ec_secret const& ephemeral_private,
+                                          stealth_address const& address,
+                                          data_chunk const& seed,
+                                          binary const& filter,
+                                          uint8_t version);
 
     /// Attach this script to the output before the send output.
     [[nodiscard]]
-    chain::script const& stealth_script() const;
+    chain::script const& stealth_script() const noexcept;
 
     /// The bitcoin payment address to which the payment will be made.
     [[nodiscard]]
-    const wallet::payment_address& payment_address() const;
+    wallet::payment_address const& payment_address() const noexcept;
 
 private:
-    void initialize(ec_secret const& ephemeral_private,
-                    stealth_address const& address,
-                    data_chunk const& seed,
-                    binary const& filter);
+    stealth_sender(uint8_t version,
+                   chain::script script,
+                   wallet::payment_address address);
 
     uint8_t const version_;
-    chain::script script_;
-    std::optional<wallet::payment_address> address_;
+    chain::script const script_;
+    wallet::payment_address const address_;
 };
 
 } // namespace kth::domain::wallet

--- a/src/domain/src/wallet/stealth_sender.cpp
+++ b/src/domain/src/wallet/stealth_sender.cpp
@@ -5,76 +5,78 @@
 #include <kth/domain/wallet/stealth_sender.hpp>
 
 #include <cstdint>
+#include <utility>
 
 #include <kth/domain/chain/script.hpp>
 #include <kth/domain/math/stealth.hpp>
 #include <kth/domain/wallet/payment_address.hpp>
+#include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/utility/binary.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 
 namespace kth::domain::wallet {
 
-stealth_sender::stealth_sender(stealth_address const& address,
-                               data_chunk const& seed,
-                               binary const& filter,
-                               uint8_t version)
-    : version_(version) {
+stealth_sender::stealth_sender(uint8_t version,
+                               chain::script script,
+                               wallet::payment_address address)
+    : version_(version)
+    , script_(std::move(script))
+    , address_(std::move(address))
+{}
+
+// static
+expect<stealth_sender> stealth_sender::from_stealth_address(stealth_address const& address,
+                                                            data_chunk const& seed,
+                                                            binary const& filter,
+                                                            uint8_t version) {
     ec_secret ephemeral_private;
-    if (create_ephemeral_key(ephemeral_private, seed)) {
-        initialize(ephemeral_private, address, seed, filter);
+    if ( ! create_ephemeral_key(ephemeral_private, seed)) {
+        return std::unexpected(kth::error::illegal_value);
     }
+    return from_ephemeral(ephemeral_private, address, seed, filter, version);
 }
 
-stealth_sender::stealth_sender(ec_secret const& ephemeral_private,
-                               stealth_address const& address,
-                               data_chunk const& seed,
-                               binary const& filter,
-                               uint8_t version)
-    : version_(version) {
-    initialize(ephemeral_private, address, seed, filter);
-}
-
-stealth_sender::operator bool() const {
-    return address_.has_value();
-}
-
-// private
-// TODO(legacy): convert to factory and make script_ and address_ const.
-void stealth_sender::initialize(ec_secret const& ephemeral_private,
-                                stealth_address const& address,
-                                data_chunk const& seed,
-                                binary const& filter) {
+// static
+expect<stealth_sender> stealth_sender::from_ephemeral(ec_secret const& ephemeral_private,
+                                                     stealth_address const& address,
+                                                     data_chunk const& seed,
+                                                     binary const& filter,
+                                                     uint8_t version) {
     ec_compressed ephemeral_public;
     if ( ! secret_to_public(ephemeral_public, ephemeral_private)) {
-        return;
+        return std::unexpected(kth::error::illegal_value);
     }
 
     auto const& spend_keys = address.spend_keys();
     if (spend_keys.size() != 1) {
-        return;
+        return std::unexpected(kth::error::illegal_value);
     }
 
     ec_compressed sender_public;
     if ( ! uncover_stealth(sender_public, address.scan_key(), ephemeral_private, spend_keys.front())) {
-        return;
+        return std::unexpected(kth::error::illegal_value);
     }
 
-    if (create_stealth_script(script_, ephemeral_private, filter, seed)) {
-        auto address_result = wallet::payment_address::from_ec_public(ec_public::from_verified_point(sender_public, true), version_);
-        if (address_result) {
-            address_ = *address_result;
-        }
+    chain::script script;
+    if ( ! create_stealth_script(script, ephemeral_private, filter, seed)) {
+        return std::unexpected(kth::error::illegal_value);
     }
+
+    auto payment = wallet::payment_address::from_ec_public(
+        ec_public::from_verified_point(sender_public, true), version);
+    if ( ! payment) {
+        return std::unexpected(payment.error());
+    }
+
+    return stealth_sender(version, std::move(script), std::move(*payment));
 }
 
-// Will be invalid if construct fails.
-chain::script const& stealth_sender::stealth_script() const {
+chain::script const& stealth_sender::stealth_script() const noexcept {
     return script_;
 }
 
-// Precondition: `operator bool()` returned true.
-const wallet::payment_address& stealth_sender::payment_address() const {
-    return *address_;
+wallet::payment_address const& stealth_sender::payment_address() const noexcept {
+    return address_;
 }
 
 } // namespace kth::domain::wallet


### PR DESCRIPTION
## Summary

Same shape as the #436 pass on `stealth_receiver`: `stealth_sender` becomes a factory-only, `expect<>`-returning value type with no `operator bool`, no `optional` sentinel on the derived payment address, and no post-construction mutation via a private `initialize` routine.

## What changed

- **Both ctors become named static factories** returning `expect<stealth_sender>`:
  - `from_stealth_address(address, seed, filter, version)` — the previous default entry point; draws a fresh ephemeral private key from `seed` and delegates.
  - `from_ephemeral(ephemeral_private, address, seed, filter, version)` — the previous "sender knows their own ephemeral key" entry point.

  Both fail with `error::illegal_value` when any downstream stealth step (ephemeral-key creation, `secret_to_public`, single spend key, `uncover_stealth`, script build, address wrap) rejects the input. The old signatures let those failures leave the sender half-initialised and forced callers to consult `operator bool()` before touching the accessors.
- **`operator bool()` gone.** Existence == success.
- **Drop the private `initialize(...)` mutator.** Its body inlines into `from_ephemeral`, and the terminal `stealth_sender(version, script, address)` ctor takes fully-baked values — the previous `// TODO(legacy): convert to factory and make script_ and address_ const.` marker is now the shape of the class.
- **`script_` and `address_` are `const` after construction** (`address_` also drops the `std::optional` wrap). `stealth_script()` and `payment_address()` return `noexcept` references without a precondition.
- **Default `version = payment_address::mainnet_p2kh` argument dropped** from both factories.
- **Header hygiene**: adds `<cstddef>` and `deserialization.hpp` explicitly (same reason as #436 — `concepts.hpp` uses unqualified `size_t`).

## Cascade

- No non-C-API callers in-tree; the only reference to the old ctor is a fully commented-out block in `test/wallet/stealth_receiver.cpp` (predates the current sweep). Left as-is.
- C-API bindings for `stealth_sender_construct{,_from_ephemeral}`, `_valid`, `_stealth_script`, and `_payment_address` are intentionally left untouched; the bulk regen at the end of the split picks up the factories + removed `operator bool` in one pass.

## Test plan

- [x] `kth_domain_test` passes locally (1_011_093 assertions in 3872 test cases)