### PR TITLE
refactor(wallet): make bitcoin_uri a functional value type

### DIFF
--- a/src/domain/include/kth/domain/wallet/bitcoin_uri.hpp
+++ b/src/domain/include/kth/domain/wallet/bitcoin_uri.hpp
@@ -5,11 +5,13 @@
 #ifndef KTH_WALLET_BITCOIN_URI_HPP
 #define KTH_WALLET_BITCOIN_URI_HPP
 
+#include <cstddef>
 #include <cstdint>
-#include <map>
 #include <optional>
 #include <string>
 #include <string_view>
+
+#include <boost/unordered/unordered_flat_map.hpp>
 
 #include <kth/domain/define.hpp>
 #include <kth/domain/deserialization.hpp>
@@ -18,80 +20,70 @@
 
 namespace kth::domain::wallet {
 
-/**
- * BIP21 / BIP72 bitcoin URI (`bitcoin:address?params`).
- *
- * Builder-style API: default-construct then populate via setters, or
- * consume a serialized URI via `parse_from` which returns
- * `expect<bitcoin_uri>`. Use `valid()` to test whether any field has
- * been populated.
- */
+/// BIP21 / BIP72 bitcoin URI (`bitcoin:address?params`).
+///
+/// Immutable value type. Every reachable instance came from
+/// `parse_from(...)` or `from_parts(...)`, both returning `expect<>`;
+/// there's no default ctor and no post-construction mutation.
+///
+/// To build a URI programmatically, populate a `bitcoin_uri::parts`
+/// and hand it to `from_parts`:
+///
+///     auto uri = bitcoin_uri::from_parts({
+///         .address = payment.to_string(),
+///         .amount  = 10'000'000,
+///         .label   = "coffee",
+///     });
 struct KD_API bitcoin_uri {
+    /// Caller-populated parts used by `from_parts`. Field-order-only
+    /// aggregate init; all fields are optional except the address
+    /// (an empty address string produces a `bitcoin:` URI with no
+    /// path, which is a legal BIP21 form for "params only" URIs).
+    struct parts {
+        std::string address;
+        std::optional<uint64_t> amount;
+        std::optional<std::string> label;
+        std::optional<std::string> message;
+        std::optional<std::string> r;
+    };
+
     /// Parse a URI string. Returns `error::illegal_value` on malformed
     /// input.
     [[nodiscard]] static
-    expect<bitcoin_uri> parse_from(std::string_view uri, bool strict = true);
+    expect<bitcoin_uri> parse_from(std::string_view uri, bool strict);
 
-    /// Explicit so the C-API generator binds it as `construct_default`.
-    /// The builder-style setters expect this empty starting point.
-    bitcoin_uri() = default;
+    /// Build a URI value from caller-populated parts. Fails when the
+    /// address is non-empty but decodes neither as a `payment_address`
+    /// nor a `stealth_address`.
+    [[nodiscard]] static
+    expect<bitcoin_uri> from_parts(parts values);
 
+    // Equality only — no meaningful total order over URIs. `!=` is
+    // auto-synthesized by C++20 from `==`.
     [[nodiscard]]
     friend bool operator==(bitcoin_uri const&, bitcoin_uri const&) = default;
-
-    /// Provide the full comparison suite (`<`, `<=`, `>`, `>=`) via the
-    /// spaceship operator so callers don't have to remember which single
-    /// ordering operator we defined.
-    [[nodiscard]]
-    friend auto operator<=>(bitcoin_uri const& a, bitcoin_uri const& b) {
-        return a.to_string() <=> b.to_string();
-    }
-
-    /// True when at least one field has been populated.
-    [[nodiscard]]
-    bool valid() const;
 
     /// Serialized URI. Used by `fmt::formatter<bitcoin_uri>`.
     [[nodiscard]]
     std::string to_string() const;
 
-    [[nodiscard]]
-    std::string encoded() const { return to_string(); }
-
     /// Property getters.
-    [[nodiscard]] uint64_t        amount() const;
-    [[nodiscard]] std::string     label() const;
-    [[nodiscard]] std::string     message() const;
-    [[nodiscard]] std::string     r() const;
-    [[nodiscard]] std::string     address() const;
+    [[nodiscard]] uint64_t                amount() const;
+    [[nodiscard]] std::string             label() const;
+    [[nodiscard]] std::string             message() const;
+    [[nodiscard]] std::string             r() const;
+    [[nodiscard]] std::string const&      address() const noexcept { return address_; }
     [[nodiscard]] expect<payment_address> payment() const;
     [[nodiscard]] expect<stealth_address> stealth() const;
-    [[nodiscard]] std::string     parameter(std::string const& key) const;
-
-    /// Property setters.
-    void set_amount(uint64_t satoshis);
-    void set_label(std::string const& label);
-    void set_message(std::string const& message);
-    void set_r(std::string const& r);
-    bool set_address(std::string const& address);
-    void set_address(payment_address const& payment);
-    void set_address(stealth_address const& stealth);
-
-    /// uri_reader implementation.
-    void set_strict(bool strict);
-    bool set_scheme(std::string const& scheme);
-    bool set_authority(std::string const& authority);
-    bool set_path(std::string const& path);
-    bool set_fragment(std::string const& fragment);
-    bool set_parameter(std::string const& key, std::string const& value);
+    [[nodiscard]] std::string             parameter(std::string const& key) const;
 
 private:
-    bool set_amount(std::string const& satoshis);
+    using query_map = boost::unordered_flat_map<std::string, std::string>;
 
-    bool strict_{true};
-    std::string scheme_;
-    std::string address_;
-    std::map<std::string, std::string> query_;
+    bitcoin_uri(std::string address, query_map query);
+
+    std::string const address_;
+    query_map const query_;
 };
 
 } // namespace kth::domain::wallet

--- a/src/domain/src/wallet/bitcoin_uri.cpp
+++ b/src/domain/src/wallet/bitcoin_uri.cpp
@@ -4,11 +4,15 @@
 
 #include <kth/domain/wallet/bitcoin_uri.hpp>
 
+#include <algorithm>
+#include <array>
+#include <cctype>
 #include <cstddef>
 #include <cstdint>
-#include <map>
 #include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 #include <kth/domain/deserialization.hpp>
 #include <kth/domain/wallet/payment_address.hpp>
@@ -16,42 +20,202 @@
 #include <kth/domain/wallet/uri_reader.hpp>
 #include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/formats/base_10.hpp>
-#include <kth/infrastructure/wallet/uri.hpp>
 
 namespace kth::domain::wallet {
 
-static auto const bitcoin_scheme = "bitcoin";
-static auto const parameter_amount = "amount";
-static auto const parameter_label = "label";
-static auto const parameter_message = "message";
-static auto const parameter_r = "r";
-static auto const parameter_req_ = "req-";
-static constexpr size_t parameter_req_length = 4;
+namespace {
+
+constexpr auto bitcoin_scheme = "bitcoin";
+constexpr auto parameter_amount = "amount";
+constexpr auto parameter_label = "label";
+constexpr auto parameter_message = "message";
+constexpr auto parameter_r = "r";
+constexpr auto parameter_req_ = "req-";
+constexpr size_t parameter_req_length = 4;
+
+// RFC 3986 unreserved-in-query-value character check. Matches the
+// `is_query` \ {`&`, `=`} class the parser accepts, so escape+decode
+// round-trip is closed. Kept local because the shared helper in
+// infrastructure/wallet/uri.cpp is `static`.
+constexpr bool is_query_value_char(char c) noexcept {
+    if (('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z') || ('0' <= c && c <= '9')) return true;
+    switch (c) {
+        case '-': case '.': case '_': case '~':                                     // unreserved
+        case '!': case '$': case '\'': case '(': case ')': case '*': case '+':
+        case ',': case ';':                                                         // sub-delims (minus '&', '=')
+        case ':': case '@':                                                         // pchar extras
+        case '/': case '?':                                                         // query extras
+            return true;
+        default:
+            return false;
+    }
+}
+
+std::string percent_encode(std::string_view in) {
+    static constexpr std::array<char, 16> hex = {
+        '0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F'};
+    std::string out;
+    out.reserve(in.size());
+    for (auto const c : in) {
+        if (is_query_value_char(c)) {
+            out.push_back(c);
+        } else {
+            auto const byte = static_cast<uint8_t>(c);
+            out.push_back('%');
+            out.push_back(hex[byte >> 4]);
+            out.push_back(hex[byte & 0x0F]);
+        }
+    }
+    return out;
+}
+
+/// Internal `uri_reader` implementation. Holds the parser state
+/// mutably during URI decoding; `parse_from` extracts the address /
+/// query pair from a successful parse to build the immutable
+/// `bitcoin_uri`.
+struct bitcoin_uri_reader : public uri_reader {
+    bool parsed_ok = false;
+    bool strict = true;
+    std::string address;
+    boost::unordered_flat_map<std::string, std::string> query;
+
+    void set_strict(bool s) override {
+        strict = s;
+    }
+
+    bool set_scheme(std::string const& scheme) override {
+        if (scheme != bitcoin_scheme) {
+            return false;
+        }
+        parsed_ok = true;
+        return true;
+    }
+
+    bool set_authority(std::string const& authority) override {
+        // Using "bitcoin://" instead of "bitcoin:" is a common mistake, so we
+        // allow the authority in place of the path when not strict.
+        return ! strict && set_path(authority);
+    }
+
+    bool set_path(std::string const& path) override {
+        if ( ! address.empty()) {
+            return false;
+        }
+        // The path is either a payment_address or a stealth_address; we
+        // only care that it decodes as one of them.
+        if (payment_address::parse_from(path) || stealth_address::parse_from(path)) {
+            address = path;
+            return true;
+        }
+        return false;
+    }
+
+    bool set_fragment(std::string const& /*fragment*/) override {
+        return false;
+    }
+
+    bool set_parameter(std::string const& key, std::string const& value) override {
+        auto const required = [](std::string const& k) {
+            return k.substr(0, parameter_req_length) == parameter_req_;
+        };
+
+        if (key == parameter_amount) {
+            uint64_t decoded;
+            if ( ! decode_base10(decoded, value, btc_decimal_places, strict)) {
+                return false;
+            }
+            // Normalize the encoding so `parameter("amount")` reads
+            // back the same string regardless of leading zeros.
+            query[parameter_amount] = encode_base10(decoded, btc_decimal_places);
+            return true;
+        }
+
+        if (key == parameter_label || key == parameter_message || key == parameter_r) {
+            query[key] = value;
+            return true;
+        }
+
+        // Fail on any required parameter that we don't support.
+        return ! required(key);
+    }
+};
+
+}  // namespace
 
 // static
 expect<bitcoin_uri> bitcoin_uri::parse_from(std::string_view text, bool strict) {
-    auto parsed = uri_reader::parse<bitcoin_uri>(std::string{text}, strict);
-    if ( ! parsed.valid()) {
+    auto reader = uri_reader::parse<bitcoin_uri_reader>(std::string{text}, strict);
+    if ( ! reader.parsed_ok) {
         return std::unexpected(kth::error::illegal_value);
     }
-    return parsed;
+    return bitcoin_uri(std::move(reader.address), std::move(reader.query));
 }
 
-bool bitcoin_uri::valid() const {
-    // An uninitialized URI has every field empty.
-    return ! address_.empty() || ! query_.empty() || ! scheme_.empty();
+// static
+expect<bitcoin_uri> bitcoin_uri::from_parts(parts values) {
+    if ( ! values.address.empty()
+         && ! payment_address::parse_from(values.address)
+         && ! stealth_address::parse_from(values.address)) {
+        return std::unexpected(kth::error::illegal_value);
+    }
+
+    query_map query;
+    if (values.amount) {
+        query.emplace(parameter_amount, encode_base10(*values.amount, btc_decimal_places));
+    }
+    if (values.label) {
+        query.emplace(parameter_label, std::move(*values.label));
+    }
+    if (values.message) {
+        query.emplace(parameter_message, std::move(*values.message));
+    }
+    if (values.r) {
+        query.emplace(parameter_r, std::move(*values.r));
+    }
+
+    return bitcoin_uri(std::move(values.address), std::move(query));
 }
+
+bitcoin_uri::bitcoin_uri(std::string address, query_map query)
+    : address_(std::move(address))
+    , query_(std::move(query))
+{}
 
 // Serializer.
 // ----------------------------------------------------------------------------
 
 std::string bitcoin_uri::to_string() const {
-    // Bitcoin URIs don't use the authority or fragment components.
-    uri out;
-    out.set_scheme(bitcoin_scheme);
-    out.set_path(address_);
-    out.encode_query(query_);
-    return out.encoded();
+    // Emit directly: `bitcoin:<address>?k1=v1&k2=v2`. Keys are
+    // materialized in lexicographic order so the output is
+    // deterministic despite `query_` being an unordered map.
+    std::string out;
+    out.reserve(16 + address_.size() + query_.size() * 32);
+    out.append(bitcoin_scheme);
+    out.push_back(':');
+    out.append(address_);
+
+    if (query_.empty()) {
+        return out;
+    }
+
+    std::vector<query_map::const_iterator> sorted;
+    sorted.reserve(query_.size());
+    for (auto it = query_.begin(); it != query_.end(); ++it) {
+        sorted.push_back(it);
+    }
+    std::sort(sorted.begin(), sorted.end(), [](auto const& a, auto const& b) {
+        return a->first < b->first;
+    });
+
+    char sep = '?';
+    for (auto const& it : sorted) {
+        out.push_back(sep);
+        out.append(percent_encode(it->first));
+        out.push_back('=');
+        out.append(percent_encode(it->second));
+        sep = '&';
+    }
+    return out;
 }
 
 // Property getters.
@@ -87,119 +251,5 @@ std::string bitcoin_uri::parameter(std::string const& key) const {
     auto const value = query_.find(key);
     return value == query_.end() ? std::string() : value->second;
 }
-
-std::string bitcoin_uri::address() const {
-    return address_;
-}
-
-// Property setters.
-// ----------------------------------------------------------------------------
-
-void bitcoin_uri::set_amount(uint64_t satoshis) {
-    auto const amount = encode_base10(satoshis, btc_decimal_places);
-    query_[parameter_amount] = amount;
-}
-
-void bitcoin_uri::set_label(std::string const& label) {
-    query_[parameter_label] = label;
-}
-
-void bitcoin_uri::set_message(std::string const& message) {
-    query_[parameter_message] = message;
-}
-
-void bitcoin_uri::set_r(std::string const& r) {
-    query_[parameter_r] = r;
-}
-
-bool bitcoin_uri::set_address(std::string const& address) {
-    if (auto payment = payment_address::parse_from(address); payment) {
-        address_ = address;
-        return true;
-    }
-
-    if (auto stealth = stealth_address::parse_from(address); stealth) {
-        address_ = address;
-        return true;
-    }
-
-    return false;
-}
-
-void bitcoin_uri::set_address(payment_address const& payment) {
-    address_ = payment.encoded_legacy();
-}
-
-void bitcoin_uri::set_address(stealth_address const& stealth) {
-    address_ = stealth.to_string();
-}
-
-bool bitcoin_uri::set_amount(std::string const& satoshis) {
-    uint64_t decoded;
-    if ( ! decode_base10(decoded, satoshis, btc_decimal_places, strict_)) {
-        return false;
-    }
-
-    // Normalize the encoding for string-based getter (parameter).
-    set_amount(decoded);
-    return true;
-}
-
-// uri_reader implementation.
-// ----------------------------------------------------------------------------
-
-void bitcoin_uri::set_strict(bool strict) {
-    strict_ = strict;
-}
-
-bool bitcoin_uri::set_scheme(std::string const& scheme) {
-    if (scheme == bitcoin_scheme) {
-        scheme_ = scheme;
-        return true;
-    }
-
-    return false;
-}
-
-bool bitcoin_uri::set_authority(std::string const& authority) {
-    // Using "bitcoin://" instead of "bitcoin:" is a common mistake, so we
-    // allow the authority in place of the path when not strict.
-    return ! strict_ && set_path(authority);
-}
-
-bool bitcoin_uri::set_path(std::string const& path) {
-    // Guard against the path having been set via authority (or second set).
-    return address_.empty() && set_address(path);
-}
-
-bool bitcoin_uri::set_fragment(std::string const& /*fragment*/) {
-    return false;
-}
-
-bool bitcoin_uri::set_parameter(std::string const& key,
-                                std::string const& value) {
-    auto const required = [](std::string const& key) {
-        return key.substr(0, parameter_req_length) == parameter_req_;
-    };
-
-    if (key == parameter_amount) {
-        return set_amount(value);
-    }
-
-    if (key == parameter_label) {
-        set_label(value);
-    } else if (key == parameter_message) {
-        set_message(value);
-    } else if (key == parameter_r) {
-        set_r(value);
-    }
-
-    // Fail on any required parameter that we don't support.
-    return ! required(key);
-}
-
-// Operators.
-// ----------------------------------------------------------------------------
-
 
 } // namespace kth::domain::wallet

--- a/src/domain/test/wallet/bitcoin_uri.cpp
+++ b/src/domain/test/wallet/bitcoin_uri.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <concepts>
-#include <optional>
+#include <string>
 
 #include <test_helpers.hpp>
 
@@ -24,122 +24,84 @@ static_assert(
         { a == b } -> std::same_as<bool>;
     });
 
-// Constructors
+// parse_from
 // ----------------------------------------------------------------------------
 
-TEST_CASE("bitcoin uri default invalid", "[bitcoin uri]") {
-    REQUIRE( ! bitcoin_uri().valid());
-}
-
 TEST_CASE("bitcoin uri parse from bitcoin scheme valid", "[bitcoin uri]") {
-    REQUIRE(bitcoin_uri::parse_from("bitcoin:"));
+    REQUIRE(bitcoin_uri::parse_from("bitcoin:", true));
 }
 
 TEST_CASE("bitcoin uri parse from scheme mixed case normalized", "[bitcoin uri]") {
-    auto const uri = bitcoin_uri::parse_from("bitcOin:");
+    auto const uri = bitcoin_uri::parse_from("bitcOin:", true);
     REQUIRE(uri);
-    REQUIRE(uri->encoded() == "bitcoin:");
+    REQUIRE(uri->to_string() == "bitcoin:");
 }
 
 TEST_CASE("bitcoin uri parse from invalid scheme error", "[bitcoin uri]") {
-    REQUIRE( ! bitcoin_uri::parse_from("fedcoin:"));
+    REQUIRE( ! bitcoin_uri::parse_from("fedcoin:", true));
 }
 
 TEST_CASE("bitcoin uri parse from payment address only error", "[bitcoin uri]") {
-    REQUIRE( ! bitcoin_uri::parse_from("113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD"));
+    REQUIRE( ! bitcoin_uri::parse_from("113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD", true));
 }
 
 TEST_CASE("bitcoin uri parse from stealth address only error", "[bitcoin uri]") {
-    REQUIRE( ! bitcoin_uri::parse_from("hfFGUXFPKkQ5M6LC6aEUKMsURdhw93bUdYdacEtBA8XttLv7evZkira2i"));
+    REQUIRE( ! bitcoin_uri::parse_from("hfFGUXFPKkQ5M6LC6aEUKMsURdhw93bUdYdacEtBA8XttLv7evZkira2i", true));
 }
 
 TEST_CASE("bitcoin uri parse from fragment error", "[bitcoin uri]") {
-    REQUIRE( ! bitcoin_uri::parse_from("bitcoin:#satoshi"));
+    REQUIRE( ! bitcoin_uri::parse_from("bitcoin:#satoshi", true));
 }
 
 TEST_CASE("bitcoin uri parse from strict reject non ascii", "[bitcoin uri]") {
-    REQUIRE( ! bitcoin_uri::parse_from("bitcoin:?label=Some テスト"));
+    REQUIRE( ! bitcoin_uri::parse_from("bitcoin:?label=Some テスト", true));
 }
 
 TEST_CASE("bitcoin uri parse from non strict accept non ascii", "[bitcoin uri]") {
     REQUIRE(bitcoin_uri::parse_from("bitcoin:?label=Some テスト", false));
 }
 
-// Setters
+// from_parts
 // ----------------------------------------------------------------------------
 
-TEST_CASE("bitcoin uri set path payment address expected encoding", "[bitcoin uri]") {
-    auto const expected_payment = "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD";
-    auto const expected_uri = std::string("bitcoin:") + expected_payment;
-
-    bitcoin_uri uri;
-    REQUIRE(uri.set_path(expected_payment));
-    REQUIRE(uri.encoded() == expected_uri);
+TEST_CASE("bitcoin uri from parts empty is bitcoin scheme only", "[bitcoin uri]") {
+    auto const uri = bitcoin_uri::from_parts({});
+    REQUIRE(uri);
+    REQUIRE(uri->to_string() == "bitcoin:");
 }
 
-TEST_CASE("bitcoin uri set path stealth address expected encoding", "[bitcoin uri]") {
-    auto const expected_payment = "hfFGUXFPKkQ5M6LC6aEUKMsURdhw93bUdYdacEtBA8XttLv7evZkira2i";
-    auto const expected_uri = std::string("bitcoin:") + expected_payment;
-
-    bitcoin_uri uri;
-    REQUIRE(uri.set_path(expected_payment));
-    REQUIRE(uri.encoded() == expected_uri);
+TEST_CASE("bitcoin uri from parts payment address expected encoding", "[bitcoin uri]") {
+    auto const uri = bitcoin_uri::from_parts({.address = "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD"});
+    REQUIRE(uri);
+    REQUIRE(uri->to_string() == "bitcoin:113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
 }
 
-TEST_CASE("bitcoin uri set path reset stealth after payment expected encoding", "[bitcoin uri]") {
-    auto const expected_stealth = "hfFGUXFPKkQ5M6LC6aEUKMsURdhw93bUdYdacEtBA8XttLv7evZkira2i";
-    auto const expected_uri = std::string("bitcoin:") + expected_stealth;
-
-    bitcoin_uri uri;
-    auto const payment = payment_address::parse_from("113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD").value();
-    uri.set_address(payment);
-    auto const stealth = stealth_address::parse_from(expected_stealth);
-    REQUIRE(stealth);
-    uri.set_address(*stealth);
-    REQUIRE(uri.encoded() == expected_uri);
+TEST_CASE("bitcoin uri from parts stealth address expected encoding", "[bitcoin uri]") {
+    auto const uri = bitcoin_uri::from_parts({.address = "hfFGUXFPKkQ5M6LC6aEUKMsURdhw93bUdYdacEtBA8XttLv7evZkira2i"});
+    REQUIRE(uri);
+    REQUIRE(uri->to_string() == "bitcoin:hfFGUXFPKkQ5M6LC6aEUKMsURdhw93bUdYdacEtBA8XttLv7evZkira2i");
 }
 
-TEST_CASE("bitcoin uri set path reset payment after stealth expected encoding", "[bitcoin uri]") {
-    auto const expected_payment = "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD";
-    auto const expected_uri = std::string("bitcoin:") + expected_payment;
-
-    bitcoin_uri uri;
-    auto const stealth = stealth_address::parse_from("hfFGUXFPKkQ5M6LC6aEUKMsURdhw93bUdYdacEtBA8XttLv7evZkira2i");
-    REQUIRE(stealth);
-    uri.set_address(*stealth);
-    uri.set_address(payment_address::parse_from(expected_payment).value());
-    REQUIRE(uri.encoded() == expected_uri);
+TEST_CASE("bitcoin uri from parts invalid address error", "[bitcoin uri]") {
+    REQUIRE( ! bitcoin_uri::from_parts({.address = "not-a-real-address"}));
 }
 
-TEST_CASE("bitcoin uri set path reset path false", "[bitcoin uri]") {
-    auto const expected_payment = "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD";
-    auto const expected_uri = std::string("bitcoin:") + expected_payment;
-
-    bitcoin_uri uri;
-    auto const stealth = stealth_address::parse_from("hfFGUXFPKkQ5M6LC6aEUKMsURdhw93bUdYdacEtBA8XttLv7evZkira2i");
-    REQUIRE(stealth);
-    uri.set_address(*stealth);
-
-    // The set_path will not reset a path. This is necessary to catch failures in non-strict parsing.
-    REQUIRE( ! uri.set_path(expected_payment));
+TEST_CASE("bitcoin uri from parts amount encoded", "[bitcoin uri]") {
+    auto const uri = bitcoin_uri::from_parts({.amount = 120000});
+    REQUIRE(uri);
+    REQUIRE(uri->to_string() == "bitcoin:?amount=0.0012");
 }
 
-TEST_CASE("bitcoin uri set amount reset amount latter amount", "[bitcoin uri]") {
-    bitcoin_uri uri;
-    uri.set_amount(10000000000);
-    uri.set_amount(120000);
-    REQUIRE(uri.encoded() == "bitcoin:?amount=0.0012");
-}
-
-TEST_CASE("bitcoin uri all setters complex uri expected encoding", "[bitcoin uri]") {
-    bitcoin_uri uri;
-    uri.set_path("113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
-    uri.set_amount(120000);
-    uri.set_label("&=\n");
-    uri.set_message("hello bitcoin");
-    uri.set_r("http://example.com?purchase=shoes&user=bob");
-
-    REQUIRE(uri.encoded() ==
+TEST_CASE("bitcoin uri from parts all fields expected encoding", "[bitcoin uri]") {
+    auto const uri = bitcoin_uri::from_parts({
+        .address = "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD",
+        .amount = 120000,
+        .label = std::string("&=\n"),
+        .message = std::string("hello bitcoin"),
+        .r = std::string("http://example.com?purchase=shoes&user=bob"),
+    });
+    REQUIRE(uri);
+    REQUIRE(uri->to_string() ==
                 "bitcoin:113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD?"
                 "amount=0.0012&"
                 "label=%26%3D%0A&"
@@ -147,35 +109,29 @@ TEST_CASE("bitcoin uri all setters complex uri expected encoding", "[bitcoin uri
                 "r=http://example.com?purchase%3Dshoes%26user%3Dbob");
 }
 
-TEST_CASE("bitcoin uri set parameter amount denormalized normalized", "[bitcoin uri]") {
-    bitcoin_uri uri;
-    REQUIRE(uri.set_parameter("amount", ".0012"));
-    REQUIRE(uri.encoded() == "bitcoin:?amount=0.0012");
-}
-
 // Getters
 // ----------------------------------------------------------------------------
 
 TEST_CASE("bitcoin uri amount set expected", "[bitcoin uri]") {
-    auto const uri = bitcoin_uri::parse_from("bitcoin:?amount=0.0012");
+    auto const uri = bitcoin_uri::parse_from("bitcoin:?amount=0.0012", true);
     REQUIRE(uri);
     REQUIRE(uri->amount() == 120000u);
 }
 
 TEST_CASE("bitcoin uri label escaped expected", "[bitcoin uri]") {
-    auto const uri = bitcoin_uri::parse_from("bitcoin:?label=%26%3D%0A");
+    auto const uri = bitcoin_uri::parse_from("bitcoin:?label=%26%3D%0A", true);
     REQUIRE(uri);
     REQUIRE(uri->label() == "&=\n");
 }
 
 TEST_CASE("bitcoin uri message escaped expected", "[bitcoin uri]") {
-    auto const uri = bitcoin_uri::parse_from("bitcoin:?message=hello%20bitcoin");
+    auto const uri = bitcoin_uri::parse_from("bitcoin:?message=hello%20bitcoin", true);
     REQUIRE(uri);
     REQUIRE(uri->message() == "hello bitcoin");
 }
 
 TEST_CASE("bitcoin uri r escaped expected", "[bitcoin uri]") {
-    auto const uri = bitcoin_uri::parse_from("bitcoin:?r=http://example.com?purchase%3Dshoes%26user%3Dbob");
+    auto const uri = bitcoin_uri::parse_from("bitcoin:?r=http://example.com?purchase%3Dshoes%26user%3Dbob", true);
     REQUIRE(uri);
     REQUIRE(uri->r() == "http://example.com?purchase=shoes&user=bob");
 }
@@ -183,7 +139,7 @@ TEST_CASE("bitcoin uri r escaped expected", "[bitcoin uri]") {
 TEST_CASE("bitcoin uri payment valid expected", "[bitcoin uri]") {
     auto const expected_payment = "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD";
     auto const expected_uri = std::string("bitcoin:") + expected_payment;
-    auto const uri = bitcoin_uri::parse_from(expected_uri);
+    auto const uri = bitcoin_uri::parse_from(expected_uri, true);
     REQUIRE(uri);
     REQUIRE(uri->payment()->encoded_legacy() == expected_payment);
 }
@@ -191,7 +147,7 @@ TEST_CASE("bitcoin uri payment valid expected", "[bitcoin uri]") {
 TEST_CASE("bitcoin uri stealth valid expected", "[bitcoin uri]") {
     auto const expected_stealth = "hfFGUXFPKkQ5M6LC6aEUKMsURdhw93bUdYdacEtBA8XttLv7evZkira2i";
     auto const expected_uri = std::string("bitcoin:") + expected_stealth;
-    auto const uri = bitcoin_uri::parse_from(expected_uri);
+    auto const uri = bitcoin_uri::parse_from(expected_uri, true);
     REQUIRE(uri);
     REQUIRE(uri->stealth()->to_string() == expected_stealth);
 }
@@ -199,7 +155,7 @@ TEST_CASE("bitcoin uri stealth valid expected", "[bitcoin uri]") {
 TEST_CASE("bitcoin uri address payment expected", "[bitcoin uri]") {
     auto const expected_payment = "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD";
     auto const expected_uri = std::string("bitcoin:") + expected_payment;
-    auto const uri = bitcoin_uri::parse_from(expected_uri);
+    auto const uri = bitcoin_uri::parse_from(expected_uri, true);
     REQUIRE(uri);
     REQUIRE(uri->address() == expected_payment);
 }
@@ -207,13 +163,13 @@ TEST_CASE("bitcoin uri address payment expected", "[bitcoin uri]") {
 TEST_CASE("bitcoin uri address stealth expected", "[bitcoin uri]") {
     auto const expected_stealth = "hfFGUXFPKkQ5M6LC6aEUKMsURdhw93bUdYdacEtBA8XttLv7evZkira2i";
     auto const expected_uri = std::string("bitcoin:") + expected_stealth;
-    auto const uri = bitcoin_uri::parse_from(expected_uri);
+    auto const uri = bitcoin_uri::parse_from(expected_uri, true);
     REQUIRE(uri);
     REQUIRE(uri->address() == expected_stealth);
 }
 
 TEST_CASE("bitcoin uri parameter amount denormalized normalized", "[bitcoin uri]") {
-    auto const uri = bitcoin_uri::parse_from("bitcoin:?amount=.0012");
+    auto const uri = bitcoin_uri::parse_from("bitcoin:?amount=.0012", true);
     REQUIRE(uri);
     REQUIRE(uri->parameter("amount") == "0.0012");
 }
@@ -224,7 +180,7 @@ TEST_CASE("bitcoin uri parameters all complex uri expected", "[bitcoin uri]") {
         "amount=0.0012&"
         "label=%26%3D%0A&"
         "message=hello%20bitcoin&"
-        "r=http://example.com?purchase%3Dshoes%26user%3Dbob");
+        "r=http://example.com?purchase%3Dshoes%26user%3Dbob", true);
     REQUIRE(uri);
 
     REQUIRE(uri->address() == "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
@@ -238,8 +194,8 @@ TEST_CASE("bitcoin uri parameters all complex uri expected", "[bitcoin uri]") {
 // ----------------------------------------------------------------------------
 
 TEST_CASE("bitcoin uri equality same value equal", "[bitcoin uri]") {
-    auto const a = bitcoin_uri::parse_from("bitcoin:?amount=0.001");
-    auto const b = bitcoin_uri::parse_from("bitcoin:?amount=0.001");
+    auto const a = bitcoin_uri::parse_from("bitcoin:?amount=0.001", true);
+    auto const b = bitcoin_uri::parse_from("bitcoin:?amount=0.001", true);
     REQUIRE(a);
     REQUIRE(b);
     REQUIRE(*a == *b);
@@ -247,8 +203,8 @@ TEST_CASE("bitcoin uri equality same value equal", "[bitcoin uri]") {
 }
 
 TEST_CASE("bitcoin uri inequality different amount not equal", "[bitcoin uri]") {
-    auto const a = bitcoin_uri::parse_from("bitcoin:?amount=0.001");
-    auto const b = bitcoin_uri::parse_from("bitcoin:?amount=0.002");
+    auto const a = bitcoin_uri::parse_from("bitcoin:?amount=0.001", true);
+    auto const b = bitcoin_uri::parse_from("bitcoin:?amount=0.002", true);
     REQUIRE(a);
     REQUIRE(b);
     REQUIRE(*a != *b);

--- a/src/domain/test/wallet/uri_reader.cpp
+++ b/src/domain/test/wallet/uri_reader.cpp
@@ -14,16 +14,16 @@ using namespace kth::domain::wallet;
 
 // Test helper that relies on bitcoin_uri.
 static
-bitcoin_uri parse(std::string const& uri, bool strict = true) {
-    return uri_reader::parse<bitcoin_uri>(uri, strict);
+expect<bitcoin_uri> parse(std::string const& uri, bool strict = true) {
+    return bitcoin_uri::parse_from(uri, strict);
 }
 
 // Same, but returns just the success bit — spelled out so tests can
-// write `REQUIRE(parse_valid(x))` without inventing a `bool` cast on
-// the type.
+// write `REQUIRE(parse_valid(x))` without unwrapping the `expect<>`
+// at the callsite.
 static
 bool parse_valid(std::string const& uri, bool strict = true) {
-    return parse(uri, strict).valid();
+    return parse(uri, strict).has_value();
 }
 
 // Demonstrate custom uri_reader.
@@ -93,12 +93,12 @@ private:
 
 TEST_CASE("uri reader parse typical uri test", "[uri reader]") {
     auto const uri = parse("bitcoin:113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD?amount=0.1");
-    REQUIRE(uri.valid());
-    REQUIRE(uri.payment()->encoded_legacy() == "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
-    REQUIRE(uri.amount() == 10000000u);
-    REQUIRE(uri.label().empty());
-    REQUIRE(uri.message().empty());
-    REQUIRE(uri.r().empty());
+    REQUIRE(uri);
+    REQUIRE(uri->payment()->encoded_legacy() == "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
+    REQUIRE(uri->amount() == 10000000u);
+    REQUIRE(uri->label().empty());
+    REQUIRE(uri->message().empty());
+    REQUIRE(uri->r().empty());
 }
 
 TEST_CASE("uri reader parse positive scheme test", "[uri reader]") {
@@ -125,34 +125,34 @@ TEST_CASE("uri reader parse positive unknown optional parameter test", "[uri rea
     REQUIRE(parse_valid("bitcoin:?x"));
 
     auto const uri = parse("bitcoin:?ignore=true");
-    REQUIRE(uri.valid());
-    REQUIRE(uri.address().empty());
-    REQUIRE(uri.amount() == 0);
-    REQUIRE(uri.label().empty());
-    REQUIRE(uri.message().empty());
-    REQUIRE(uri.r().empty());
-    REQUIRE(uri.parameter("ignore").empty());
+    REQUIRE(uri);
+    REQUIRE(uri->address().empty());
+    REQUIRE(uri->amount() == 0);
+    REQUIRE(uri->label().empty());
+    REQUIRE(uri->message().empty());
+    REQUIRE(uri->r().empty());
+    REQUIRE(uri->parameter("ignore").empty());
 }
 
 TEST_CASE("uri reader parse negative unknown required parameter test", "[uri reader]") {
     auto const uri = parse("bitcoin:?req-ignore=false");
-    REQUIRE( ! uri.valid());
+    REQUIRE( ! uri);
 }
 
 TEST_CASE("uri reader parse address test", "[uri reader]") {
     auto const uri = parse("bitcoin:113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
-    REQUIRE(uri.valid());
-    REQUIRE(uri.payment()->encoded_legacy() == "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
-    REQUIRE(uri.amount() == 0);
-    REQUIRE(uri.label().empty());
-    REQUIRE(uri.message().empty());
-    REQUIRE(uri.r().empty());
+    REQUIRE(uri);
+    REQUIRE(uri->payment()->encoded_legacy() == "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
+    REQUIRE(uri->amount() == 0);
+    REQUIRE(uri->label().empty());
+    REQUIRE(uri->message().empty());
+    REQUIRE(uri->r().empty());
 }
 
 TEST_CASE("uri reader parse uri encoded address test", "[uri reader]") {
     auto const uri = parse("bitcoin:%3113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
-    REQUIRE(uri.valid());
-    REQUIRE(uri.payment()->encoded_legacy() == "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
+    REQUIRE(uri);
+    REQUIRE(uri->payment()->encoded_legacy() == "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
 }
 
 TEST_CASE("uri reader parse negative address test", "[uri reader]") {
@@ -163,18 +163,18 @@ TEST_CASE("uri reader parse negative address test", "[uri reader]") {
 
 TEST_CASE("uri reader parse amount only test", "[uri reader]") {
     auto const uri = parse("bitcoin:?amount=4.2");
-    REQUIRE(uri.valid());
-    REQUIRE( ! uri.payment());
-    REQUIRE(uri.amount() == 420000000u);
-    REQUIRE(uri.label().empty());
-    REQUIRE(uri.message().empty());
-    REQUIRE(uri.r().empty());
+    REQUIRE(uri);
+    REQUIRE( ! uri->payment());
+    REQUIRE(uri->amount() == 420000000u);
+    REQUIRE(uri->label().empty());
+    REQUIRE(uri->message().empty());
+    REQUIRE(uri->r().empty());
 }
 
 TEST_CASE("uri reader parse minimal amount test", "[uri reader]") {
     auto const uri = parse("bitcoin:?amount=.");
-    REQUIRE(uri.valid());
-    REQUIRE(uri.amount() == 0);
+    REQUIRE(uri);
+    REQUIRE(uri->amount() == 0);
 }
 
 TEST_CASE("uri reader parse invalid amount test", "[uri reader]") {
@@ -184,17 +184,18 @@ TEST_CASE("uri reader parse invalid amount test", "[uri reader]") {
 
 TEST_CASE("uri reader parse label only test", "[uri reader]") {
     auto const uri = parse("bitcoin:?label=test");
-    REQUIRE(uri.valid());
-    REQUIRE( ! uri.payment());
-    REQUIRE(uri.amount() == 0);
-    REQUIRE(uri.label() == "test");
-    REQUIRE(uri.message().empty());
-    REQUIRE(uri.r().empty());
+    REQUIRE(uri);
+    REQUIRE( ! uri->payment());
+    REQUIRE(uri->amount() == 0);
+    REQUIRE(uri->label() == "test");
+    REQUIRE(uri->message().empty());
+    REQUIRE(uri->r().empty());
 }
 
 TEST_CASE("uri reader parse reserved symbol with lowercase percent test", "[uri reader]") {
     auto const uri = parse("bitcoin:?label=%26%3d%6b");
-    REQUIRE(uri.label() == "&=k");
+    REQUIRE(uri);
+    REQUIRE(uri->label() == "&=k");
 }
 
 TEST_CASE("uri reader parse negative percent encoding test", "[uri reader]") {
@@ -204,12 +205,14 @@ TEST_CASE("uri reader parse negative percent encoding test", "[uri reader]") {
 
 TEST_CASE("uri reader parse encoded multibyte utf8 test", "[uri reader]") {
     auto const uri = parse("bitcoin:?label=%E3%83%95");
-    REQUIRE(uri.label() == "フ");
+    REQUIRE(uri);
+    REQUIRE(uri->label() == "フ");
 }
 
 TEST_CASE("uri reader parse non strict encoded multibyte utf8 with unencoded label space test", "[uri reader]") {
     auto const uri = parse("bitcoin:?label=Some テスト", false);
-    REQUIRE(uri.label() == "Some テスト");
+    REQUIRE(uri);
+    REQUIRE(uri->label() == "Some テスト");
 }
 
 TEST_CASE("uri reader parse negative strict encoded multibyte utf8 with unencoded label space test", "[uri reader]") {
@@ -218,20 +221,22 @@ TEST_CASE("uri reader parse negative strict encoded multibyte utf8 with unencode
 
 TEST_CASE("uri reader parse message only test", "[uri reader]") {
     auto const uri = parse("bitcoin:?message=Hi%20Alice");
-    REQUIRE( ! uri.payment());
-    REQUIRE(uri.amount() == 0);
-    REQUIRE(uri.label().empty());
-    REQUIRE(uri.message() == "Hi Alice");
-    REQUIRE(uri.r().empty());
+    REQUIRE(uri);
+    REQUIRE( ! uri->payment());
+    REQUIRE(uri->amount() == 0);
+    REQUIRE(uri->label().empty());
+    REQUIRE(uri->message() == "Hi Alice");
+    REQUIRE(uri->r().empty());
 }
 
 TEST_CASE("uri reader parse payment protocol only test", "[uri reader]") {
     auto const uri = parse("bitcoin:?r=http://www.example.com?purchase%3Dshoes");
-    REQUIRE( ! uri.payment());
-    REQUIRE(uri.amount() == 0);
-    REQUIRE(uri.label().empty());
-    REQUIRE(uri.message().empty());
-    REQUIRE(uri.r() == "http://www.example.com?purchase=shoes");
+    REQUIRE(uri);
+    REQUIRE( ! uri->payment());
+    REQUIRE(uri->amount() == 0);
+    REQUIRE(uri->label().empty());
+    REQUIRE(uri->message().empty());
+    REQUIRE(uri->r() == "http://www.example.com?purchase=shoes");
 }
 
 TEST_CASE("uri reader parse custom reader optional parameter type test", "[uri reader]") {


### PR DESCRIPTION
## Summary
- `bitcoin_uri` is now an immutable value type. `parse_from(text, strict)` returns `expect<bitcoin_uri>`; `from_parts(bitcoin_uri::parts)` builds one from an aggregate. No default ctor, no `.valid()`, no `set_*` chain.
- Query storage switches from `std::map` to `boost::unordered_flat_map`; `to_string()` emits inline (no intermediate `uri` builder), sorts keys lexicographically at emit time so the encoded form is deterministic.
- Equality is `= default`; `!=` auto-synthesizes. Ordering isn't defined — URIs don't have a meaningful total order.
- Test files rewritten against the new API. `custom_reader` demo in `uri_reader.cpp` untouched — the `uri_reader` template still exists for future consumers.

## Cascade
- No non-test in-tree callers of the removed setters or `.valid()`.
- Supersedes #422 (broader wallet-refactor spike that's been carved up into single-type PRs — #427 onward). Closing that one once this lands.
- `src/c-api/**` still references the old setter/`.valid()` surface; that layer has been broken since the earlier wallet PRs and gets fixed in one bulk pass right after this branch lands. Out of scope for this PR.

## Follow-ups (separate PRs)
- Sweep `infrastructure::wallet::uri` — same treatment (or replace with an external RFC 3986 library). The current builder-style bool-returning `decode()` and `set_*/remove_*` mutators are the last hold-out in the URI stack.
- Bulk c-api regen for all recently modernized wallet types.

## Test plan
- [x] `cmake --build . --target kth_domain_test` locally green
- [x] `kth_domain_test` — 1,011,094 assertions, 3,869 test cases pass
- [x] `[bitcoin uri],[uri reader]` filter — 138 assertions, 50 test cases pass