### PR TITLE
refactor(c-api): redesign cashtoken to single-call create_*

### DIFF
--- a/src/c-api/include/kth/capi/wallet/cashtoken_minting.h
+++ b/src/c-api/include/kth/capi/wallet/cashtoken_minting.h
@@ -16,54 +16,46 @@ extern "C" {
 #endif
 
 // ---------------------------------------------------------------------------
-// Opaque handles — one per C++ params/result struct.
+// Opaque handles
 // ---------------------------------------------------------------------------
 //
-// C mirrors the `kth::domain::wallet::cashtoken` C++ API. Each C++ struct
-// maps to an opaque handle (`kth_cashtoken_<type>_mut_t`) with
-// `construct_default` / `destruct` lifecycle functions plus per-field
-// setters/getters. Builders take a params handle and return either a
-// result handle via out-parameter or an error code.
+// This module deliberately does NOT expose the domain `*_params` structs
+// via handles. Those structs contain required `payment_address` members
+// which are not default-constructible under the current domain shape;
+// exposing them would either need sentinel state (dropped project-wide)
+// or a parallel C-API-side "holder" struct that would drift over time.
 //
-// Type aliases (all `void*` at the ABI level, see helpers.hpp):
-typedef void*       kth_cashtoken_prepare_genesis_params_mut_t;
-typedef void const* kth_cashtoken_prepare_genesis_params_const_t;
-typedef void*       kth_cashtoken_prepare_genesis_result_mut_t;
-typedef void const* kth_cashtoken_prepare_genesis_result_const_t;
+// Instead, each transaction-builder is a single `create_*` function that
+// takes every field as an argument. Optional fields use the same NULL /
+// has_value conventions used elsewhere in the C-API. Only the value
+// types that are useful to marshal individually (nft_spec, the list
+// element types, and the result types) keep a handle.
 
 typedef void*       kth_cashtoken_nft_spec_mut_t;
 typedef void const* kth_cashtoken_nft_spec_const_t;
+
 typedef void*       kth_cashtoken_nft_mint_request_mut_t;
 typedef void const* kth_cashtoken_nft_mint_request_const_t;
 typedef void*       kth_cashtoken_nft_mint_request_list_mut_t;
 typedef void const* kth_cashtoken_nft_mint_request_list_const_t;
+
 typedef void*       kth_cashtoken_nft_collection_item_mut_t;
 typedef void const* kth_cashtoken_nft_collection_item_const_t;
 typedef void*       kth_cashtoken_nft_collection_item_list_mut_t;
 typedef void const* kth_cashtoken_nft_collection_item_list_const_t;
 
-typedef void*       kth_cashtoken_token_genesis_params_mut_t;
-typedef void const* kth_cashtoken_token_genesis_params_const_t;
+typedef void*       kth_cashtoken_prepare_genesis_result_mut_t;
+typedef void const* kth_cashtoken_prepare_genesis_result_const_t;
+
 typedef void*       kth_cashtoken_token_genesis_result_mut_t;
 typedef void const* kth_cashtoken_token_genesis_result_const_t;
 
-typedef void*       kth_cashtoken_token_mint_params_mut_t;
-typedef void const* kth_cashtoken_token_mint_params_const_t;
 typedef void*       kth_cashtoken_token_mint_result_mut_t;
 typedef void const* kth_cashtoken_token_mint_result_const_t;
 
-typedef void*       kth_cashtoken_token_transfer_params_mut_t;
-typedef void const* kth_cashtoken_token_transfer_params_const_t;
-typedef void*       kth_cashtoken_token_burn_params_mut_t;
-typedef void const* kth_cashtoken_token_burn_params_const_t;
 typedef void*       kth_cashtoken_token_tx_result_mut_t;
 typedef void const* kth_cashtoken_token_tx_result_const_t;
 
-typedef void*       kth_cashtoken_ft_params_mut_t;
-typedef void const* kth_cashtoken_ft_params_const_t;
-
-typedef void*       kth_cashtoken_nft_collection_params_mut_t;
-typedef void const* kth_cashtoken_nft_collection_params_const_t;
 typedef void*       kth_cashtoken_nft_collection_result_mut_t;
 typedef void const* kth_cashtoken_nft_collection_result_const_t;
 
@@ -140,7 +132,7 @@ void kth_wallet_cashtoken_nft_spec_destruct(kth_cashtoken_nft_spec_mut_t self);
 
 
 // ---------------------------------------------------------------------------
-// nft_mint_request
+// nft_mint_request (single element + list)
 // ---------------------------------------------------------------------------
 
 KTH_EXPORT KTH_OWNED
@@ -155,10 +147,9 @@ KTH_EXPORT
 void kth_wallet_cashtoken_nft_mint_request_destruct(
     kth_cashtoken_nft_mint_request_mut_t self);
 
-// --- list ---
-
 KTH_EXPORT KTH_OWNED
-kth_cashtoken_nft_mint_request_list_mut_t kth_wallet_cashtoken_nft_mint_request_list_construct_default(void);
+kth_cashtoken_nft_mint_request_list_mut_t
+kth_wallet_cashtoken_nft_mint_request_list_construct_default(void);
 
 KTH_EXPORT
 void kth_wallet_cashtoken_nft_mint_request_list_push_back(
@@ -179,12 +170,12 @@ kth_cashtoken_nft_mint_request_const_t kth_wallet_cashtoken_nft_mint_request_lis
 
 
 // ---------------------------------------------------------------------------
-// nft_collection_item
+// nft_collection_item (single element + list)
 // ---------------------------------------------------------------------------
 
 /**
  * @param destination Optional — pass NULL to default to
- *                    `nft_collection_params::creator_address`.
+ *                    `create_nft_collection`'s `creator_address`.
  */
 KTH_EXPORT KTH_OWNED
 kth_cashtoken_nft_collection_item_mut_t kth_wallet_cashtoken_nft_collection_item_construct(
@@ -196,10 +187,9 @@ KTH_EXPORT
 void kth_wallet_cashtoken_nft_collection_item_destruct(
     kth_cashtoken_nft_collection_item_mut_t self);
 
-// --- list ---
-
 KTH_EXPORT KTH_OWNED
-kth_cashtoken_nft_collection_item_list_mut_t kth_wallet_cashtoken_nft_collection_item_list_construct_default(void);
+kth_cashtoken_nft_collection_item_list_mut_t
+kth_wallet_cashtoken_nft_collection_item_list_construct_default(void);
 
 KTH_EXPORT
 void kth_wallet_cashtoken_nft_collection_item_list_push_back(
@@ -214,56 +204,44 @@ KTH_EXPORT
 kth_size_t kth_wallet_cashtoken_nft_collection_item_list_count(
     kth_cashtoken_nft_collection_item_list_const_t list);
 
-/** @return Borrowed `kth_cashtoken_nft_collection_item_const_t` view into `list`. Do not destruct. */
+/** @return Borrowed `kth_cashtoken_nft_collection_item_const_t`. Do not destruct. */
 KTH_EXPORT
 kth_cashtoken_nft_collection_item_const_t kth_wallet_cashtoken_nft_collection_item_list_nth(
     kth_cashtoken_nft_collection_item_list_const_t list, kth_size_t index);
 
 
 // ---------------------------------------------------------------------------
-// prepare_genesis_params / prepare_genesis_result / prepare_genesis_utxo
+// prepare_genesis_utxo
 // ---------------------------------------------------------------------------
 
-KTH_EXPORT KTH_OWNED
-kth_cashtoken_prepare_genesis_params_mut_t kth_wallet_cashtoken_prepare_genesis_params_construct_default(void);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_prepare_genesis_params_destruct(
-    kth_cashtoken_prepare_genesis_params_mut_t self);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_prepare_genesis_params_set_utxo(
-    kth_cashtoken_prepare_genesis_params_mut_t self, kth_utxo_const_t utxo);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_prepare_genesis_params_set_destination(
-    kth_cashtoken_prepare_genesis_params_mut_t self, kth_payment_address_const_t destination);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_prepare_genesis_params_set_satoshis(
-    kth_cashtoken_prepare_genesis_params_mut_t self, uint64_t satoshis);
-
-/** @param change_address Optional — pass NULL for "no explicit change address". */
-KTH_EXPORT
-void kth_wallet_cashtoken_prepare_genesis_params_set_change_address(
-    kth_cashtoken_prepare_genesis_params_mut_t self, kth_payment_address_const_t change_address);
-
-/** @param[out] out Must point to a null `kth_cashtoken_prepare_genesis_result_mut_t` slot. */
+/**
+ * Build the "carrier" transaction that produces a UTXO at output 0
+ * suitable for a subsequent token genesis input.
+ *
+ * @param utxo             Required. A spendable UTXO to fund the carrier tx.
+ * @param destination      Required. Recipient of the new output 0.
+ * @param satoshis         Value carried by the new output 0.
+ * @param change_address   Optional — pass NULL for "no explicit change address".
+ * @param[out] out         Must point to a null slot. On success, populated
+ *                         with an owned handle. Untouched on error.
+ */
 KTH_EXPORT
 kth_error_code_t kth_wallet_cashtoken_prepare_genesis_utxo(
-    kth_cashtoken_prepare_genesis_params_const_t params,
+    kth_utxo_const_t utxo,
+    kth_payment_address_const_t destination,
+    uint64_t satoshis,
+    kth_payment_address_const_t change_address,
     KTH_OUT_OWNED kth_cashtoken_prepare_genesis_result_mut_t* out);
 
 KTH_EXPORT
 void kth_wallet_cashtoken_prepare_genesis_result_destruct(
     kth_cashtoken_prepare_genesis_result_mut_t self);
 
-/** @return Borrowed `kth_transaction_const_t` view; do not destruct. */
+/** @return Borrowed `kth_transaction_const_t` view. Do not destruct. */
 KTH_EXPORT
 kth_transaction_const_t kth_wallet_cashtoken_prepare_genesis_result_transaction(
     kth_cashtoken_prepare_genesis_result_const_t self);
 
-/** @return Number of signing indices. */
 KTH_EXPORT
 kth_size_t kth_wallet_cashtoken_prepare_genesis_result_signing_indices_count(
     kth_cashtoken_prepare_genesis_result_const_t self);
@@ -274,54 +252,32 @@ uint32_t kth_wallet_cashtoken_prepare_genesis_result_signing_index_nth(
 
 
 // ---------------------------------------------------------------------------
-// token_genesis_params / token_genesis_result / create_token_genesis
+// create_token_genesis
 // ---------------------------------------------------------------------------
 
-KTH_EXPORT KTH_OWNED
-kth_cashtoken_token_genesis_params_mut_t kth_wallet_cashtoken_token_genesis_params_construct_default(void);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_genesis_params_destruct(
-    kth_cashtoken_token_genesis_params_mut_t self);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_genesis_params_set_genesis_utxo(
-    kth_cashtoken_token_genesis_params_mut_t self, kth_utxo_const_t genesis_utxo);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_genesis_params_set_destination(
-    kth_cashtoken_token_genesis_params_mut_t self, kth_payment_address_const_t destination);
-
-/** Sets the optional FT supply. `has_value == 0` clears the optional. */
-KTH_EXPORT
-void kth_wallet_cashtoken_token_genesis_params_set_ft_amount(
-    kth_cashtoken_token_genesis_params_mut_t self, kth_bool_t has_value, uint64_t ft_amount);
-
-/** @param nft Optional — pass NULL to clear the NFT spec. */
-KTH_EXPORT
-void kth_wallet_cashtoken_token_genesis_params_set_nft(
-    kth_cashtoken_token_genesis_params_mut_t self, kth_cashtoken_nft_spec_const_t nft);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_genesis_params_set_satoshis(
-    kth_cashtoken_token_genesis_params_mut_t self, uint64_t satoshis);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_genesis_params_set_fee_utxos(
-    kth_cashtoken_token_genesis_params_mut_t self, kth_utxo_list_const_t fee_utxos);
-
-/** @param change_address Optional — pass NULL for no explicit change address. */
-KTH_EXPORT
-void kth_wallet_cashtoken_token_genesis_params_set_change_address(
-    kth_cashtoken_token_genesis_params_mut_t self, kth_payment_address_const_t change_address);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_genesis_params_set_script_flags(
-    kth_cashtoken_token_genesis_params_mut_t self, uint64_t script_flags);
-
+/**
+ * @param genesis_utxo     Required. Must have `outpoint.index() == 0`.
+ * @param destination      Required.
+ * @param has_ft_amount    Non-zero if `ft_amount` should be set.
+ * @param ft_amount        Read only when `has_ft_amount != 0`.
+ * @param nft              Optional — pass NULL for no NFT.
+ * @param satoshis         BCH satoshis carried by the token output.
+ * @param fee_utxos        Optional — pass NULL for "no fee UTXOs".
+ * @param change_address   Optional — pass NULL for no explicit change address.
+ * @param script_flags     Active script flags for commitment-size validation.
+ * @param[out] out         Must point to a null slot. Populated on success;
+ *                         untouched on error.
+ */
 KTH_EXPORT
 kth_error_code_t kth_wallet_cashtoken_create_token_genesis(
-    kth_cashtoken_token_genesis_params_const_t params,
+    kth_utxo_const_t genesis_utxo,
+    kth_payment_address_const_t destination,
+    kth_bool_t has_ft_amount, uint64_t ft_amount,
+    kth_cashtoken_nft_spec_const_t nft,
+    uint64_t satoshis,
+    kth_utxo_list_const_t fee_utxos,
+    kth_payment_address_const_t change_address,
+    uint64_t script_flags,
     KTH_OUT_OWNED kth_cashtoken_token_genesis_result_mut_t* out);
 
 KTH_EXPORT
@@ -347,56 +303,30 @@ uint32_t kth_wallet_cashtoken_token_genesis_result_signing_index_nth(
 
 
 // ---------------------------------------------------------------------------
-// token_mint_params / token_mint_result / create_token_mint
+// create_token_mint
 // ---------------------------------------------------------------------------
 
-KTH_EXPORT KTH_OWNED
-kth_cashtoken_token_mint_params_mut_t kth_wallet_cashtoken_token_mint_params_construct_default(void);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_mint_params_destruct(
-    kth_cashtoken_token_mint_params_mut_t self);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_mint_params_set_minting_utxo(
-    kth_cashtoken_token_mint_params_mut_t self, kth_utxo_const_t minting_utxo);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_mint_params_set_nfts(
-    kth_cashtoken_token_mint_params_mut_t self,
-    kth_cashtoken_nft_mint_request_list_const_t nfts);
-
 /**
- * Sets the optional preserved-minting commitment. `commitment == NULL`
- * clears the optional.
+ * @param minting_utxo             Required. Must hold an NFT with capability == minting.
+ * @param nfts                     Required. NFTs to mint.
+ * @param new_minting_commitment   Optional — pass NULL for no commitment replacement.
+ * @param new_minting_commitment_n Ignored when `new_minting_commitment == NULL`.
+ * @param minting_destination      Required by the domain builder. Passing NULL
+ *                                 surfaces as `error::illegal_value`.
+ * @param fee_utxos                Optional — pass NULL for no fee UTXOs.
+ * @param change_address           Optional — pass NULL for no explicit change address.
+ * @param script_flags             Active script flags for commitment-size validation.
  */
 KTH_EXPORT
-void kth_wallet_cashtoken_token_mint_params_set_new_minting_commitment(
-    kth_cashtoken_token_mint_params_mut_t self,
-    uint8_t const* commitment, kth_size_t commitment_n);
-
-/** Required — pass the address explicitly; no fallback to change_address. */
-KTH_EXPORT
-void kth_wallet_cashtoken_token_mint_params_set_minting_destination(
-    kth_cashtoken_token_mint_params_mut_t self,
-    kth_payment_address_const_t minting_destination);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_mint_params_set_fee_utxos(
-    kth_cashtoken_token_mint_params_mut_t self, kth_utxo_list_const_t fee_utxos);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_mint_params_set_change_address(
-    kth_cashtoken_token_mint_params_mut_t self,
-    kth_payment_address_const_t change_address);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_mint_params_set_script_flags(
-    kth_cashtoken_token_mint_params_mut_t self, uint64_t script_flags);
-
-KTH_EXPORT
 kth_error_code_t kth_wallet_cashtoken_create_token_mint(
-    kth_cashtoken_token_mint_params_const_t params,
+    kth_utxo_const_t minting_utxo,
+    kth_cashtoken_nft_mint_request_list_const_t nfts,
+    uint8_t const* new_minting_commitment,
+    kth_size_t new_minting_commitment_n,
+    kth_payment_address_const_t minting_destination,
+    kth_utxo_list_const_t fee_utxos,
+    kth_payment_address_const_t change_address,
+    uint64_t script_flags,
     KTH_OUT_OWNED kth_cashtoken_token_mint_result_mut_t* out);
 
 KTH_EXPORT
@@ -425,103 +355,53 @@ uint32_t kth_wallet_cashtoken_token_mint_result_minted_output_index_nth(
 
 
 // ---------------------------------------------------------------------------
-// token_transfer_params / create_token_transfer
+// create_token_transfer
 // ---------------------------------------------------------------------------
 
-KTH_EXPORT KTH_OWNED
-kth_cashtoken_token_transfer_params_mut_t kth_wallet_cashtoken_token_transfer_params_construct_default(void);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_transfer_params_destruct(
-    kth_cashtoken_token_transfer_params_mut_t self);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_transfer_params_set_token_utxos(
-    kth_cashtoken_token_transfer_params_mut_t self, kth_utxo_list_const_t token_utxos);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_transfer_params_set_destination(
-    kth_cashtoken_token_transfer_params_mut_t self, kth_payment_address_const_t destination);
-
-/** `has_value == 0` clears the optional. */
-KTH_EXPORT
-void kth_wallet_cashtoken_token_transfer_params_set_ft_amount(
-    kth_cashtoken_token_transfer_params_mut_t self, kth_bool_t has_value, uint64_t ft_amount);
-
-/** @param nft Optional — pass NULL to clear. */
-KTH_EXPORT
-void kth_wallet_cashtoken_token_transfer_params_set_nft(
-    kth_cashtoken_token_transfer_params_mut_t self, kth_cashtoken_nft_spec_const_t nft);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_transfer_params_set_fee_utxos(
-    kth_cashtoken_token_transfer_params_mut_t self, kth_utxo_list_const_t fee_utxos);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_transfer_params_set_token_change_address(
-    kth_cashtoken_token_transfer_params_mut_t self, kth_payment_address_const_t addr);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_transfer_params_set_bch_change_address(
-    kth_cashtoken_token_transfer_params_mut_t self, kth_payment_address_const_t addr);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_transfer_params_set_satoshis(
-    kth_cashtoken_token_transfer_params_mut_t self, uint64_t satoshis);
-
+/**
+ * @param token_utxos                Optional — pass NULL for no token UTXOs.
+ * @param destination                Required.
+ * @param has_ft_amount              Non-zero if `ft_amount` should be set.
+ * @param nft                        Optional — pass NULL for no NFT spec.
+ * @param fee_utxos                  Optional — pass NULL for no fee UTXOs.
+ * @param token_change_address       Optional — pass NULL.
+ * @param bch_change_address         Optional — pass NULL.
+ */
 KTH_EXPORT
 kth_error_code_t kth_wallet_cashtoken_create_token_transfer(
-    kth_cashtoken_token_transfer_params_const_t params,
+    kth_utxo_list_const_t token_utxos,
+    kth_payment_address_const_t destination,
+    kth_bool_t has_ft_amount, uint64_t ft_amount,
+    kth_cashtoken_nft_spec_const_t nft,
+    kth_utxo_list_const_t fee_utxos,
+    kth_payment_address_const_t token_change_address,
+    kth_payment_address_const_t bch_change_address,
+    uint64_t satoshis,
     KTH_OUT_OWNED kth_cashtoken_token_tx_result_mut_t* out);
 
 
 // ---------------------------------------------------------------------------
-// token_burn_params / create_token_burn
+// create_token_burn
 // ---------------------------------------------------------------------------
 
-KTH_EXPORT KTH_OWNED
-kth_cashtoken_token_burn_params_mut_t kth_wallet_cashtoken_token_burn_params_construct_default(void);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_burn_params_destruct(
-    kth_cashtoken_token_burn_params_mut_t self);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_burn_params_set_token_utxo(
-    kth_cashtoken_token_burn_params_mut_t self, kth_utxo_const_t token_utxo);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_burn_params_set_burn_ft_amount(
-    kth_cashtoken_token_burn_params_mut_t self, kth_bool_t has_value, uint64_t burn_ft_amount);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_burn_params_set_burn_nft(
-    kth_cashtoken_token_burn_params_mut_t self, kth_bool_t burn_nft);
-
-/** @param message Optional UTF-8 null-terminated string; NULL clears. */
-KTH_EXPORT
-void kth_wallet_cashtoken_token_burn_params_set_message(
-    kth_cashtoken_token_burn_params_mut_t self, char const* message);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_burn_params_set_destination(
-    kth_cashtoken_token_burn_params_mut_t self, kth_payment_address_const_t destination);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_burn_params_set_fee_utxos(
-    kth_cashtoken_token_burn_params_mut_t self, kth_utxo_list_const_t fee_utxos);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_burn_params_set_change_address(
-    kth_cashtoken_token_burn_params_mut_t self, kth_payment_address_const_t change_address);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_token_burn_params_set_satoshis(
-    kth_cashtoken_token_burn_params_mut_t self, uint64_t satoshis);
-
+/**
+ * @param token_utxo         Required.
+ * @param has_burn_ft_amount Non-zero if `burn_ft_amount` should be set.
+ * @param message            Optional UTF-8 null-terminated string; NULL clears.
+ * @param destination        Required.
+ * @param fee_utxos          Optional — pass NULL for no fee UTXOs.
+ * @param change_address     Optional — pass NULL.
+ */
 KTH_EXPORT
 kth_error_code_t kth_wallet_cashtoken_create_token_burn(
-    kth_cashtoken_token_burn_params_const_t params,
+    kth_utxo_const_t token_utxo,
+    kth_bool_t has_burn_ft_amount, uint64_t burn_ft_amount,
+    kth_bool_t burn_nft,
+    char const* message,
+    kth_payment_address_const_t destination,
+    kth_utxo_list_const_t fee_utxos,
+    kth_payment_address_const_t change_address,
+    uint64_t satoshis,
     KTH_OUT_OWNED kth_cashtoken_token_tx_result_mut_t* out);
 
 
@@ -547,101 +427,53 @@ uint32_t kth_wallet_cashtoken_token_tx_result_signing_index_nth(
 
 
 // ---------------------------------------------------------------------------
-// ft_params / create_ft — high-level fungible token genesis
+// create_ft — high-level fungible token genesis
 // ---------------------------------------------------------------------------
 
-KTH_EXPORT KTH_OWNED
-kth_cashtoken_ft_params_mut_t kth_wallet_cashtoken_ft_params_construct_default(void);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_ft_params_destruct(
-    kth_cashtoken_ft_params_mut_t self);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_ft_params_set_genesis_utxo(
-    kth_cashtoken_ft_params_mut_t self, kth_utxo_const_t genesis_utxo);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_ft_params_set_destination(
-    kth_cashtoken_ft_params_mut_t self, kth_payment_address_const_t destination);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_ft_params_set_total_supply(
-    kth_cashtoken_ft_params_mut_t self, uint64_t total_supply);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_ft_params_set_with_minting_nft(
-    kth_cashtoken_ft_params_mut_t self, kth_bool_t with_minting_nft);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_ft_params_set_fee_utxos(
-    kth_cashtoken_ft_params_mut_t self, kth_utxo_list_const_t fee_utxos);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_ft_params_set_change_address(
-    kth_cashtoken_ft_params_mut_t self, kth_payment_address_const_t change_address);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_ft_params_set_script_flags(
-    kth_cashtoken_ft_params_mut_t self, uint64_t script_flags);
-
+/**
+ * @param genesis_utxo     Required.
+ * @param destination      Required.
+ * @param fee_utxos        Optional — pass NULL for no fee UTXOs.
+ * @param change_address   Optional — pass NULL.
+ * @param script_flags     Only relevant when `with_minting_nft != 0`.
+ */
 KTH_EXPORT
 kth_error_code_t kth_wallet_cashtoken_create_ft(
-    kth_cashtoken_ft_params_const_t params,
+    kth_utxo_const_t genesis_utxo,
+    kth_payment_address_const_t destination,
+    uint64_t total_supply,
+    kth_bool_t with_minting_nft,
+    kth_utxo_list_const_t fee_utxos,
+    kth_payment_address_const_t change_address,
+    uint64_t script_flags,
     KTH_OUT_OWNED kth_cashtoken_token_genesis_result_mut_t* out);
 
 
 // ---------------------------------------------------------------------------
-// nft_collection_params / nft_collection_result / create_nft_collection
+// create_nft_collection
 // ---------------------------------------------------------------------------
 
-KTH_EXPORT KTH_OWNED
-kth_cashtoken_nft_collection_params_mut_t kth_wallet_cashtoken_nft_collection_params_construct_default(void);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_nft_collection_params_destruct(
-    kth_cashtoken_nft_collection_params_mut_t self);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_nft_collection_params_set_genesis_utxo(
-    kth_cashtoken_nft_collection_params_mut_t self, kth_utxo_const_t genesis_utxo);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_nft_collection_params_set_nfts(
-    kth_cashtoken_nft_collection_params_mut_t self,
-    kth_cashtoken_nft_collection_item_list_const_t nfts);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_nft_collection_params_set_creator_address(
-    kth_cashtoken_nft_collection_params_mut_t self, kth_payment_address_const_t creator_address);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_nft_collection_params_set_keep_minting_token(
-    kth_cashtoken_nft_collection_params_mut_t self, kth_bool_t keep_minting_token);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_nft_collection_params_set_ft_amount(
-    kth_cashtoken_nft_collection_params_mut_t self, kth_bool_t has_value, uint64_t ft_amount);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_nft_collection_params_set_fee_utxos(
-    kth_cashtoken_nft_collection_params_mut_t self, kth_utxo_list_const_t fee_utxos);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_nft_collection_params_set_change_address(
-    kth_cashtoken_nft_collection_params_mut_t self, kth_payment_address_const_t change_address);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_nft_collection_params_set_batch_size(
-    kth_cashtoken_nft_collection_params_mut_t self, kth_size_t batch_size);
-
-KTH_EXPORT
-void kth_wallet_cashtoken_nft_collection_params_set_script_flags(
-    kth_cashtoken_nft_collection_params_mut_t self, uint64_t script_flags);
-
+/**
+ * @param genesis_utxo         Required.
+ * @param nfts                 Required. Collection items.
+ * @param creator_address      Required. Default destination for items without one.
+ * @param has_ft_amount        Non-zero if `ft_amount` should be set.
+ * @param fee_utxos            Optional — pass NULL for no fee UTXOs.
+ * @param change_address       Optional — pass NULL.
+ * @param batch_size           NFTs per mint TX; must be > 0.
+ * @param script_flags         Active script flags for commitment-size validation.
+ */
 KTH_EXPORT
 kth_error_code_t kth_wallet_cashtoken_create_nft_collection(
-    kth_cashtoken_nft_collection_params_const_t params,
+    kth_utxo_const_t genesis_utxo,
+    kth_cashtoken_nft_collection_item_list_const_t nfts,
+    kth_payment_address_const_t creator_address,
+    kth_bool_t keep_minting_token,
+    kth_bool_t has_ft_amount, uint64_t ft_amount,
+    kth_utxo_list_const_t fee_utxos,
+    kth_payment_address_const_t change_address,
+    kth_size_t batch_size,
+    uint64_t script_flags,
     KTH_OUT_OWNED kth_cashtoken_nft_collection_result_mut_t* out);
 
 KTH_EXPORT
@@ -674,9 +506,8 @@ kth_size_t kth_wallet_cashtoken_nft_collection_result_batches_count(
     kth_cashtoken_nft_collection_result_const_t self);
 
 /**
- * Returns a borrowed view of a batch's mint-requests list. Caller must
- * NOT destruct this list — it's owned by the parent result handle and
- * invalidated when the result is destructed.
+ * @return Borrowed view of a batch's mint-requests list. Caller must NOT
+ *         destruct — owned by the parent result handle.
  */
 KTH_EXPORT
 kth_cashtoken_nft_mint_request_list_const_t kth_wallet_cashtoken_nft_collection_result_batch_mint_requests(

--- a/src/c-api/src/wallet/cashtoken_minting.cpp
+++ b/src/c-api/src/wallet/cashtoken_minting.cpp
@@ -5,7 +5,10 @@
 #include <kth/capi/wallet/cashtoken_minting.h>
 
 #include <cstring>
+#include <optional>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include <kth/capi/conversions.hpp>
 #include <kth/capi/helpers.hpp>
@@ -17,6 +20,46 @@
 #include <kth/infrastructure/error.hpp>
 
 namespace ct = kth::domain::wallet::cashtoken;
+
+namespace {
+
+// Shared helper to turn a (ptr, size) commitment pair into data_chunk.
+//
+// `(data == nullptr, n == 0)` is valid and means "empty commitment".
+// `(data == nullptr, n >  0)` is a caller bug — silently folding it to
+// an empty commitment would produce a valid-looking TX with the wrong
+// NFT commitment, so we trip the precondition instead of dropping the
+// bytes.
+kth::data_chunk commitment_from(uint8_t const* data, kth_size_t n) {
+    if (n == 0) return kth::data_chunk{};
+    KTH_PRECONDITION(data != nullptr);
+    return kth::data_chunk(data, data + kth::sz(n));
+}
+
+// Copies a `kth_utxo_list_const_t` handle into a fresh C++ vector.
+// NULL is interpreted as "empty list" — the only way the C caller
+// can express "no fee UTXOs" at this ABI.
+std::vector<kth::domain::chain::utxo>
+copy_utxo_list(kth_utxo_list_const_t list) {
+    if (list == nullptr) return {};
+    return kth::cpp_ref<std::vector<kth::domain::chain::utxo>>(list);
+}
+
+// Wraps a nullable address handle in `std::optional`. NULL → nullopt.
+std::optional<kth::domain::wallet::payment_address>
+optional_addr(kth_payment_address_const_t addr) {
+    if (addr == nullptr) return std::nullopt;
+    return kth::cpp_ref<kth::domain::wallet::payment_address>(addr);
+}
+
+// Wraps a nullable nft_spec handle in `std::optional`. NULL → nullopt.
+std::optional<ct::nft_spec>
+optional_nft_spec(kth_cashtoken_nft_spec_const_t spec) {
+    if (spec == nullptr) return std::nullopt;
+    return kth::cpp_ref<ct::nft_spec>(spec);
+}
+
+} // namespace
 
 extern "C" {
 
@@ -37,42 +80,10 @@ kth_error_code_t kth_wallet_cashtoken_encode_nft_number(
     return kth_ec_success;
 }
 
+
 // ---------------------------------------------------------------------------
 // Output factories
 // ---------------------------------------------------------------------------
-
-namespace {
-
-// Shared helper to turn a (ptr, size) commitment pair into data_chunk.
-//
-// `(data == nullptr, n == 0)` is valid and means "empty commitment".
-// `(data == nullptr, n >  0)` is a caller bug — silently folding it to
-// an empty commitment would produce a valid-looking TX with the wrong
-// NFT commitment, so we trip the precondition instead of dropping the
-// bytes.
-kth::data_chunk commitment_from(uint8_t const* data, kth_size_t n) {
-    if (n == 0) return kth::data_chunk{};
-    KTH_PRECONDITION(data != nullptr);
-    return kth::data_chunk(data, data + kth::sz(n));
-}
-
-// Copies a kth_utxo_list_const_t handle into a fresh C++ vector. NULL
-// list is interpreted as "empty vector" — the only way the C caller
-// can express "no fee UTXOs" at this ABI.
-std::vector<kth::domain::chain::utxo>
-copy_utxo_list(kth_utxo_list_const_t list) {
-    if (list == nullptr) return {};
-    return kth::cpp_ref<std::vector<kth::domain::chain::utxo>>(list);
-}
-
-// Wraps a nullable address handle in std::optional. NULL → nullopt.
-std::optional<kth::domain::wallet::payment_address>
-optional_addr(kth_payment_address_const_t addr) {
-    if (addr == nullptr) return std::nullopt;
-    return kth::cpp_ref<kth::domain::wallet::payment_address>(addr);
-}
-
-} // namespace
 
 kth_output_mut_t kth_wallet_cashtoken_create_ft_output(
     kth_payment_address_const_t destination,
@@ -126,6 +137,7 @@ kth_output_mut_t kth_wallet_cashtoken_create_combined_token_output(
         satoshis));
 }
 
+
 // ---------------------------------------------------------------------------
 // nft_spec
 // ---------------------------------------------------------------------------
@@ -135,18 +147,19 @@ kth_cashtoken_nft_spec_mut_t kth_wallet_cashtoken_nft_spec_construct(
     uint8_t const* commitment,
     kth_size_t commitment_n
 ) {
-    ct::nft_spec s;
-    s.capability = static_cast<kth::domain::chain::capability_t>(capability);
-    s.commitment = commitment_from(commitment, commitment_n);
-    return kth::leak(std::move(s));
+    return kth::leak(ct::nft_spec{
+        .capability = static_cast<kth::domain::chain::capability_t>(capability),
+        .commitment = commitment_from(commitment, commitment_n),
+    });
 }
 
 void kth_wallet_cashtoken_nft_spec_destruct(kth_cashtoken_nft_spec_mut_t self) {
     kth::del<ct::nft_spec>(self);
 }
 
+
 // ---------------------------------------------------------------------------
-// nft_mint_request
+// nft_mint_request (single element + list)
 // ---------------------------------------------------------------------------
 
 kth_cashtoken_nft_mint_request_mut_t kth_wallet_cashtoken_nft_mint_request_construct(
@@ -157,12 +170,12 @@ kth_cashtoken_nft_mint_request_mut_t kth_wallet_cashtoken_nft_mint_request_const
     uint64_t satoshis
 ) {
     KTH_PRECONDITION(destination != nullptr);
-    ct::nft_mint_request r;
-    r.destination = kth::cpp_ref<kth::domain::wallet::payment_address>(destination);
-    r.commitment = commitment_from(commitment, commitment_n);
-    r.capability = static_cast<kth::domain::chain::capability_t>(capability);
-    r.satoshis = satoshis;
-    return kth::leak(std::move(r));
+    return kth::leak(ct::nft_mint_request{
+        .destination = kth::cpp_ref<kth::domain::wallet::payment_address>(destination),
+        .commitment = commitment_from(commitment, commitment_n),
+        .capability = static_cast<kth::domain::chain::capability_t>(capability),
+        .satoshis = satoshis,
+    });
 }
 
 void kth_wallet_cashtoken_nft_mint_request_destruct(
@@ -170,8 +183,6 @@ void kth_wallet_cashtoken_nft_mint_request_destruct(
 ) {
     kth::del<ct::nft_mint_request>(self);
 }
-
-// --- list ---
 
 kth_cashtoken_nft_mint_request_list_mut_t
 kth_wallet_cashtoken_nft_mint_request_list_construct_default(void) {
@@ -210,8 +221,9 @@ kth_cashtoken_nft_mint_request_const_t kth_wallet_cashtoken_nft_mint_request_lis
     return &l[kth::sz(index)];
 }
 
+
 // ---------------------------------------------------------------------------
-// nft_collection_item
+// nft_collection_item (single element + list)
 // ---------------------------------------------------------------------------
 
 kth_cashtoken_nft_collection_item_mut_t kth_wallet_cashtoken_nft_collection_item_construct(
@@ -219,12 +231,10 @@ kth_cashtoken_nft_collection_item_mut_t kth_wallet_cashtoken_nft_collection_item
     kth_size_t commitment_n,
     kth_payment_address_const_t destination
 ) {
-    ct::nft_collection_item item;
-    item.commitment = commitment_from(commitment, commitment_n);
-    if (destination != nullptr) {
-        item.destination = kth::cpp_ref<kth::domain::wallet::payment_address>(destination);
-    }
-    return kth::leak(std::move(item));
+    return kth::leak(ct::nft_collection_item{
+        .commitment = commitment_from(commitment, commitment_n),
+        .destination = optional_addr(destination),
+    });
 }
 
 void kth_wallet_cashtoken_nft_collection_item_destruct(
@@ -232,8 +242,6 @@ void kth_wallet_cashtoken_nft_collection_item_destruct(
 ) {
     kth::del<ct::nft_collection_item>(self);
 }
-
-// --- list ---
 
 kth_cashtoken_nft_collection_item_list_mut_t
 kth_wallet_cashtoken_nft_collection_item_list_construct_default(void) {
@@ -272,61 +280,29 @@ kth_cashtoken_nft_collection_item_const_t kth_wallet_cashtoken_nft_collection_it
     return &l[kth::sz(index)];
 }
 
+
 // ---------------------------------------------------------------------------
-// prepare_genesis_params / prepare_genesis_result
+// prepare_genesis_utxo
 // ---------------------------------------------------------------------------
-
-kth_cashtoken_prepare_genesis_params_mut_t
-kth_wallet_cashtoken_prepare_genesis_params_construct_default(void) {
-    return kth::leak<ct::prepare_genesis_params>();
-}
-
-void kth_wallet_cashtoken_prepare_genesis_params_destruct(
-    kth_cashtoken_prepare_genesis_params_mut_t self
-) {
-    kth::del<ct::prepare_genesis_params>(self);
-}
-
-void kth_wallet_cashtoken_prepare_genesis_params_set_utxo(
-    kth_cashtoken_prepare_genesis_params_mut_t self, kth_utxo_const_t utxo
-) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(utxo != nullptr);
-    kth::cpp_ref<ct::prepare_genesis_params>(self).utxo =
-        kth::cpp_ref<kth::domain::chain::utxo>(utxo);
-}
-
-void kth_wallet_cashtoken_prepare_genesis_params_set_destination(
-    kth_cashtoken_prepare_genesis_params_mut_t self, kth_payment_address_const_t destination
-) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(destination != nullptr);
-    kth::cpp_ref<ct::prepare_genesis_params>(self).destination =
-        kth::cpp_ref<kth::domain::wallet::payment_address>(destination);
-}
-
-void kth_wallet_cashtoken_prepare_genesis_params_set_satoshis(
-    kth_cashtoken_prepare_genesis_params_mut_t self, uint64_t satoshis
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::prepare_genesis_params>(self).satoshis = satoshis;
-}
-
-void kth_wallet_cashtoken_prepare_genesis_params_set_change_address(
-    kth_cashtoken_prepare_genesis_params_mut_t self, kth_payment_address_const_t change_address
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::prepare_genesis_params>(self).change_address = optional_addr(change_address);
-}
 
 kth_error_code_t kth_wallet_cashtoken_prepare_genesis_utxo(
-    kth_cashtoken_prepare_genesis_params_const_t params,
+    kth_utxo_const_t utxo,
+    kth_payment_address_const_t destination,
+    uint64_t satoshis,
+    kth_payment_address_const_t change_address,
     KTH_OUT_OWNED kth_cashtoken_prepare_genesis_result_mut_t* out
 ) {
-    KTH_PRECONDITION(params != nullptr);
+    KTH_PRECONDITION(utxo != nullptr);
+    KTH_PRECONDITION(destination != nullptr);
     KTH_PRECONDITION(out != nullptr);
     KTH_PRECONDITION(*out == nullptr);
-    auto r = ct::prepare_genesis_utxo(kth::cpp_ref<ct::prepare_genesis_params>(params));
+
+    auto r = ct::prepare_genesis_utxo(ct::prepare_genesis_params{
+        .utxo = kth::cpp_ref<kth::domain::chain::utxo>(utxo),
+        .destination = kth::cpp_ref<kth::domain::wallet::payment_address>(destination),
+        .satoshis = satoshis,
+        .change_address = optional_addr(change_address),
+    });
     if ( ! r.has_value()) return kth::to_c_err(r.error());
     *out = kth::leak(std::move(*r));
     return kth_ec_success;
@@ -361,93 +337,37 @@ uint32_t kth_wallet_cashtoken_prepare_genesis_result_signing_index_nth(
     return v[kth::sz(index)];
 }
 
+
 // ---------------------------------------------------------------------------
-// token_genesis_params / token_genesis_result / create_token_genesis
+// create_token_genesis
 // ---------------------------------------------------------------------------
-
-kth_cashtoken_token_genesis_params_mut_t
-kth_wallet_cashtoken_token_genesis_params_construct_default(void) {
-    return kth::leak<ct::token_genesis_params>();
-}
-
-void kth_wallet_cashtoken_token_genesis_params_destruct(
-    kth_cashtoken_token_genesis_params_mut_t self
-) {
-    kth::del<ct::token_genesis_params>(self);
-}
-
-void kth_wallet_cashtoken_token_genesis_params_set_genesis_utxo(
-    kth_cashtoken_token_genesis_params_mut_t self, kth_utxo_const_t genesis_utxo
-) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(genesis_utxo != nullptr);
-    kth::cpp_ref<ct::token_genesis_params>(self).genesis_utxo =
-        kth::cpp_ref<kth::domain::chain::utxo>(genesis_utxo);
-}
-
-void kth_wallet_cashtoken_token_genesis_params_set_destination(
-    kth_cashtoken_token_genesis_params_mut_t self, kth_payment_address_const_t destination
-) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(destination != nullptr);
-    kth::cpp_ref<ct::token_genesis_params>(self).destination =
-        kth::cpp_ref<kth::domain::wallet::payment_address>(destination);
-}
-
-void kth_wallet_cashtoken_token_genesis_params_set_ft_amount(
-    kth_cashtoken_token_genesis_params_mut_t self, kth_bool_t has_value, uint64_t ft_amount
-) {
-    KTH_PRECONDITION(self != nullptr);
-    auto& p = kth::cpp_ref<ct::token_genesis_params>(self);
-    p.ft_amount = kth::int_to_bool(has_value) ? std::optional<uint64_t>(ft_amount) : std::nullopt;
-}
-
-void kth_wallet_cashtoken_token_genesis_params_set_nft(
-    kth_cashtoken_token_genesis_params_mut_t self, kth_cashtoken_nft_spec_const_t nft
-) {
-    KTH_PRECONDITION(self != nullptr);
-    auto& p = kth::cpp_ref<ct::token_genesis_params>(self);
-    p.nft = nft == nullptr
-        ? std::nullopt
-        : std::optional<ct::nft_spec>(kth::cpp_ref<ct::nft_spec>(nft));
-}
-
-void kth_wallet_cashtoken_token_genesis_params_set_satoshis(
-    kth_cashtoken_token_genesis_params_mut_t self, uint64_t satoshis
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::token_genesis_params>(self).satoshis = satoshis;
-}
-
-void kth_wallet_cashtoken_token_genesis_params_set_fee_utxos(
-    kth_cashtoken_token_genesis_params_mut_t self, kth_utxo_list_const_t fee_utxos
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::token_genesis_params>(self).fee_utxos = copy_utxo_list(fee_utxos);
-}
-
-void kth_wallet_cashtoken_token_genesis_params_set_change_address(
-    kth_cashtoken_token_genesis_params_mut_t self, kth_payment_address_const_t change_address
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::token_genesis_params>(self).change_address = optional_addr(change_address);
-}
-
-void kth_wallet_cashtoken_token_genesis_params_set_script_flags(
-    kth_cashtoken_token_genesis_params_mut_t self, uint64_t script_flags
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::token_genesis_params>(self).script_flags = script_flags;
-}
 
 kth_error_code_t kth_wallet_cashtoken_create_token_genesis(
-    kth_cashtoken_token_genesis_params_const_t params,
+    kth_utxo_const_t genesis_utxo,
+    kth_payment_address_const_t destination,
+    kth_bool_t has_ft_amount, uint64_t ft_amount,
+    kth_cashtoken_nft_spec_const_t nft,
+    uint64_t satoshis,
+    kth_utxo_list_const_t fee_utxos,
+    kth_payment_address_const_t change_address,
+    uint64_t script_flags,
     KTH_OUT_OWNED kth_cashtoken_token_genesis_result_mut_t* out
 ) {
-    KTH_PRECONDITION(params != nullptr);
+    KTH_PRECONDITION(genesis_utxo != nullptr);
+    KTH_PRECONDITION(destination != nullptr);
     KTH_PRECONDITION(out != nullptr);
     KTH_PRECONDITION(*out == nullptr);
-    auto r = ct::create_token_genesis(kth::cpp_ref<ct::token_genesis_params>(params));
+
+    auto r = ct::create_token_genesis(ct::token_genesis_params{
+        .genesis_utxo = kth::cpp_ref<kth::domain::chain::utxo>(genesis_utxo),
+        .destination = kth::cpp_ref<kth::domain::wallet::payment_address>(destination),
+        .ft_amount = kth::int_to_bool(has_ft_amount) ? std::optional<uint64_t>(ft_amount) : std::nullopt,
+        .nft = optional_nft_spec(nft),
+        .satoshis = satoshis,
+        .fee_utxos = copy_utxo_list(fee_utxos),
+        .change_address = optional_addr(change_address),
+        .script_flags = script_flags,
+    });
     if ( ! r.has_value()) return kth::to_c_err(r.error());
     *out = kth::leak(std::move(*r));
     return kth_ec_success;
@@ -491,92 +411,40 @@ uint32_t kth_wallet_cashtoken_token_genesis_result_signing_index_nth(
     return v[kth::sz(index)];
 }
 
+
 // ---------------------------------------------------------------------------
-// token_mint_params / token_mint_result / create_token_mint
+// create_token_mint
 // ---------------------------------------------------------------------------
-
-kth_cashtoken_token_mint_params_mut_t
-kth_wallet_cashtoken_token_mint_params_construct_default(void) {
-    return kth::leak<ct::token_mint_params>();
-}
-
-void kth_wallet_cashtoken_token_mint_params_destruct(
-    kth_cashtoken_token_mint_params_mut_t self
-) {
-    kth::del<ct::token_mint_params>(self);
-}
-
-void kth_wallet_cashtoken_token_mint_params_set_minting_utxo(
-    kth_cashtoken_token_mint_params_mut_t self, kth_utxo_const_t minting_utxo
-) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(minting_utxo != nullptr);
-    kth::cpp_ref<ct::token_mint_params>(self).minting_utxo =
-        kth::cpp_ref<kth::domain::chain::utxo>(minting_utxo);
-}
-
-void kth_wallet_cashtoken_token_mint_params_set_nfts(
-    kth_cashtoken_token_mint_params_mut_t self,
-    kth_cashtoken_nft_mint_request_list_const_t nfts
-) {
-    KTH_PRECONDITION(self != nullptr);
-    auto& p = kth::cpp_ref<ct::token_mint_params>(self);
-    p.nfts = nfts == nullptr
-        ? std::vector<ct::nft_mint_request>{}
-        : kth::cpp_ref<std::vector<ct::nft_mint_request>>(nfts);
-}
-
-void kth_wallet_cashtoken_token_mint_params_set_new_minting_commitment(
-    kth_cashtoken_token_mint_params_mut_t self,
-    uint8_t const* commitment, kth_size_t commitment_n
-) {
-    KTH_PRECONDITION(self != nullptr);
-    auto& p = kth::cpp_ref<ct::token_mint_params>(self);
-    p.new_minting_commitment = commitment == nullptr
-        ? std::nullopt
-        : std::optional<kth::data_chunk>(commitment_from(commitment, commitment_n));
-}
-
-void kth_wallet_cashtoken_token_mint_params_set_minting_destination(
-    kth_cashtoken_token_mint_params_mut_t self,
-    kth_payment_address_const_t minting_destination
-) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(minting_destination != nullptr);
-    kth::cpp_ref<ct::token_mint_params>(self).minting_destination =
-        kth::cpp_ref<kth::domain::wallet::payment_address>(minting_destination);
-}
-
-void kth_wallet_cashtoken_token_mint_params_set_fee_utxos(
-    kth_cashtoken_token_mint_params_mut_t self, kth_utxo_list_const_t fee_utxos
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::token_mint_params>(self).fee_utxos = copy_utxo_list(fee_utxos);
-}
-
-void kth_wallet_cashtoken_token_mint_params_set_change_address(
-    kth_cashtoken_token_mint_params_mut_t self,
-    kth_payment_address_const_t change_address
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::token_mint_params>(self).change_address = optional_addr(change_address);
-}
-
-void kth_wallet_cashtoken_token_mint_params_set_script_flags(
-    kth_cashtoken_token_mint_params_mut_t self, uint64_t script_flags
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::token_mint_params>(self).script_flags = script_flags;
-}
 
 kth_error_code_t kth_wallet_cashtoken_create_token_mint(
-    kth_cashtoken_token_mint_params_const_t params,
+    kth_utxo_const_t minting_utxo,
+    kth_cashtoken_nft_mint_request_list_const_t nfts,
+    uint8_t const* new_minting_commitment,
+    kth_size_t new_minting_commitment_n,
+    kth_payment_address_const_t minting_destination,
+    kth_utxo_list_const_t fee_utxos,
+    kth_payment_address_const_t change_address,
+    uint64_t script_flags,
     KTH_OUT_OWNED kth_cashtoken_token_mint_result_mut_t* out
 ) {
-    KTH_PRECONDITION(params != nullptr);
+    KTH_PRECONDITION(minting_utxo != nullptr);
+    KTH_PRECONDITION(nfts != nullptr);
     KTH_PRECONDITION(out != nullptr);
     KTH_PRECONDITION(*out == nullptr);
-    auto r = ct::create_token_mint(kth::cpp_ref<ct::token_mint_params>(params));
+
+    auto const new_commit_opt = new_minting_commitment == nullptr
+        ? std::optional<kth::data_chunk>(std::nullopt)
+        : std::optional<kth::data_chunk>(commitment_from(new_minting_commitment, new_minting_commitment_n));
+
+    auto r = ct::create_token_mint(ct::token_mint_params{
+        .minting_utxo = kth::cpp_ref<kth::domain::chain::utxo>(minting_utxo),
+        .nfts = kth::cpp_ref<std::vector<ct::nft_mint_request>>(nfts),
+        .new_minting_commitment = new_commit_opt,
+        .minting_destination = optional_addr(minting_destination),
+        .fee_utxos = copy_utxo_list(fee_utxos),
+        .change_address = optional_addr(change_address),
+        .script_flags = script_flags,
+    });
     if ( ! r.has_value()) return kth::to_c_err(r.error());
     *out = kth::leak(std::move(*r));
     return kth_ec_success;
@@ -627,190 +495,80 @@ uint32_t kth_wallet_cashtoken_token_mint_result_minted_output_index_nth(
     return v[kth::sz(index)];
 }
 
+
 // ---------------------------------------------------------------------------
-// token_transfer_params / create_token_transfer
+// create_token_transfer
 // ---------------------------------------------------------------------------
-
-kth_cashtoken_token_transfer_params_mut_t
-kth_wallet_cashtoken_token_transfer_params_construct_default(void) {
-    return kth::leak<ct::token_transfer_params>();
-}
-
-void kth_wallet_cashtoken_token_transfer_params_destruct(
-    kth_cashtoken_token_transfer_params_mut_t self
-) {
-    kth::del<ct::token_transfer_params>(self);
-}
-
-void kth_wallet_cashtoken_token_transfer_params_set_token_utxos(
-    kth_cashtoken_token_transfer_params_mut_t self, kth_utxo_list_const_t token_utxos
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::token_transfer_params>(self).token_utxos = copy_utxo_list(token_utxos);
-}
-
-void kth_wallet_cashtoken_token_transfer_params_set_destination(
-    kth_cashtoken_token_transfer_params_mut_t self, kth_payment_address_const_t destination
-) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(destination != nullptr);
-    kth::cpp_ref<ct::token_transfer_params>(self).destination =
-        kth::cpp_ref<kth::domain::wallet::payment_address>(destination);
-}
-
-void kth_wallet_cashtoken_token_transfer_params_set_ft_amount(
-    kth_cashtoken_token_transfer_params_mut_t self, kth_bool_t has_value, uint64_t ft_amount
-) {
-    KTH_PRECONDITION(self != nullptr);
-    auto& p = kth::cpp_ref<ct::token_transfer_params>(self);
-    p.ft_amount = kth::int_to_bool(has_value) ? std::optional<uint64_t>(ft_amount) : std::nullopt;
-}
-
-void kth_wallet_cashtoken_token_transfer_params_set_nft(
-    kth_cashtoken_token_transfer_params_mut_t self, kth_cashtoken_nft_spec_const_t nft
-) {
-    KTH_PRECONDITION(self != nullptr);
-    auto& p = kth::cpp_ref<ct::token_transfer_params>(self);
-    p.nft = nft == nullptr
-        ? std::nullopt
-        : std::optional<ct::nft_spec>(kth::cpp_ref<ct::nft_spec>(nft));
-}
-
-void kth_wallet_cashtoken_token_transfer_params_set_fee_utxos(
-    kth_cashtoken_token_transfer_params_mut_t self, kth_utxo_list_const_t fee_utxos
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::token_transfer_params>(self).fee_utxos = copy_utxo_list(fee_utxos);
-}
-
-void kth_wallet_cashtoken_token_transfer_params_set_token_change_address(
-    kth_cashtoken_token_transfer_params_mut_t self, kth_payment_address_const_t addr
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::token_transfer_params>(self).token_change_address = optional_addr(addr);
-}
-
-void kth_wallet_cashtoken_token_transfer_params_set_bch_change_address(
-    kth_cashtoken_token_transfer_params_mut_t self, kth_payment_address_const_t addr
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::token_transfer_params>(self).bch_change_address = optional_addr(addr);
-}
-
-void kth_wallet_cashtoken_token_transfer_params_set_satoshis(
-    kth_cashtoken_token_transfer_params_mut_t self, uint64_t satoshis
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::token_transfer_params>(self).satoshis = satoshis;
-}
 
 kth_error_code_t kth_wallet_cashtoken_create_token_transfer(
-    kth_cashtoken_token_transfer_params_const_t params,
+    kth_utxo_list_const_t token_utxos,
+    kth_payment_address_const_t destination,
+    kth_bool_t has_ft_amount, uint64_t ft_amount,
+    kth_cashtoken_nft_spec_const_t nft,
+    kth_utxo_list_const_t fee_utxos,
+    kth_payment_address_const_t token_change_address,
+    kth_payment_address_const_t bch_change_address,
+    uint64_t satoshis,
     KTH_OUT_OWNED kth_cashtoken_token_tx_result_mut_t* out
 ) {
-    KTH_PRECONDITION(params != nullptr);
+    KTH_PRECONDITION(destination != nullptr);
     KTH_PRECONDITION(out != nullptr);
     KTH_PRECONDITION(*out == nullptr);
-    auto r = ct::create_token_transfer(kth::cpp_ref<ct::token_transfer_params>(params));
+
+    auto r = ct::create_token_transfer(ct::token_transfer_params{
+        .token_utxos = copy_utxo_list(token_utxos),
+        .destination = kth::cpp_ref<kth::domain::wallet::payment_address>(destination),
+        .ft_amount = kth::int_to_bool(has_ft_amount) ? std::optional<uint64_t>(ft_amount) : std::nullopt,
+        .nft = optional_nft_spec(nft),
+        .fee_utxos = copy_utxo_list(fee_utxos),
+        .token_change_address = optional_addr(token_change_address),
+        .bch_change_address = optional_addr(bch_change_address),
+        .satoshis = satoshis,
+    });
     if ( ! r.has_value()) return kth::to_c_err(r.error());
     *out = kth::leak(std::move(*r));
     return kth_ec_success;
 }
 
+
 // ---------------------------------------------------------------------------
-// token_burn_params / create_token_burn
+// create_token_burn
 // ---------------------------------------------------------------------------
-
-kth_cashtoken_token_burn_params_mut_t
-kth_wallet_cashtoken_token_burn_params_construct_default(void) {
-    return kth::leak<ct::token_burn_params>();
-}
-
-void kth_wallet_cashtoken_token_burn_params_destruct(
-    kth_cashtoken_token_burn_params_mut_t self
-) {
-    kth::del<ct::token_burn_params>(self);
-}
-
-void kth_wallet_cashtoken_token_burn_params_set_token_utxo(
-    kth_cashtoken_token_burn_params_mut_t self, kth_utxo_const_t token_utxo
-) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(token_utxo != nullptr);
-    kth::cpp_ref<ct::token_burn_params>(self).token_utxo =
-        kth::cpp_ref<kth::domain::chain::utxo>(token_utxo);
-}
-
-void kth_wallet_cashtoken_token_burn_params_set_burn_ft_amount(
-    kth_cashtoken_token_burn_params_mut_t self, kth_bool_t has_value, uint64_t burn_ft_amount
-) {
-    KTH_PRECONDITION(self != nullptr);
-    auto& p = kth::cpp_ref<ct::token_burn_params>(self);
-    p.burn_ft_amount = kth::int_to_bool(has_value)
-        ? std::optional<uint64_t>(burn_ft_amount)
-        : std::nullopt;
-}
-
-void kth_wallet_cashtoken_token_burn_params_set_burn_nft(
-    kth_cashtoken_token_burn_params_mut_t self, kth_bool_t burn_nft
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::token_burn_params>(self).burn_nft = kth::int_to_bool(burn_nft);
-}
-
-void kth_wallet_cashtoken_token_burn_params_set_message(
-    kth_cashtoken_token_burn_params_mut_t self, char const* message
-) {
-    KTH_PRECONDITION(self != nullptr);
-    auto& p = kth::cpp_ref<ct::token_burn_params>(self);
-    p.message = message == nullptr ? std::nullopt : std::optional<std::string>(message);
-}
-
-void kth_wallet_cashtoken_token_burn_params_set_destination(
-    kth_cashtoken_token_burn_params_mut_t self, kth_payment_address_const_t destination
-) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(destination != nullptr);
-    kth::cpp_ref<ct::token_burn_params>(self).destination =
-        kth::cpp_ref<kth::domain::wallet::payment_address>(destination);
-}
-
-void kth_wallet_cashtoken_token_burn_params_set_fee_utxos(
-    kth_cashtoken_token_burn_params_mut_t self, kth_utxo_list_const_t fee_utxos
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::token_burn_params>(self).fee_utxos = copy_utxo_list(fee_utxos);
-}
-
-void kth_wallet_cashtoken_token_burn_params_set_change_address(
-    kth_cashtoken_token_burn_params_mut_t self, kth_payment_address_const_t change_address
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::token_burn_params>(self).change_address = optional_addr(change_address);
-}
-
-void kth_wallet_cashtoken_token_burn_params_set_satoshis(
-    kth_cashtoken_token_burn_params_mut_t self, uint64_t satoshis
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::token_burn_params>(self).satoshis = satoshis;
-}
 
 kth_error_code_t kth_wallet_cashtoken_create_token_burn(
-    kth_cashtoken_token_burn_params_const_t params,
+    kth_utxo_const_t token_utxo,
+    kth_bool_t has_burn_ft_amount, uint64_t burn_ft_amount,
+    kth_bool_t burn_nft,
+    char const* message,
+    kth_payment_address_const_t destination,
+    kth_utxo_list_const_t fee_utxos,
+    kth_payment_address_const_t change_address,
+    uint64_t satoshis,
     KTH_OUT_OWNED kth_cashtoken_token_tx_result_mut_t* out
 ) {
-    KTH_PRECONDITION(params != nullptr);
+    KTH_PRECONDITION(token_utxo != nullptr);
+    KTH_PRECONDITION(destination != nullptr);
     KTH_PRECONDITION(out != nullptr);
     KTH_PRECONDITION(*out == nullptr);
-    auto r = ct::create_token_burn(kth::cpp_ref<ct::token_burn_params>(params));
+
+    auto r = ct::create_token_burn(ct::token_burn_params{
+        .token_utxo = kth::cpp_ref<kth::domain::chain::utxo>(token_utxo),
+        .burn_ft_amount = kth::int_to_bool(has_burn_ft_amount) ? std::optional<uint64_t>(burn_ft_amount) : std::nullopt,
+        .burn_nft = kth::int_to_bool(burn_nft),
+        .message = message == nullptr ? std::optional<std::string>(std::nullopt) : std::optional<std::string>(message),
+        .destination = kth::cpp_ref<kth::domain::wallet::payment_address>(destination),
+        .fee_utxos = copy_utxo_list(fee_utxos),
+        .change_address = optional_addr(change_address),
+        .satoshis = satoshis,
+    });
     if ( ! r.has_value()) return kth::to_c_err(r.error());
     *out = kth::leak(std::move(*r));
     return kth_ec_success;
 }
 
+
 // ---------------------------------------------------------------------------
-// token_tx_result (shared by transfer / burn)
+// token_tx_result — shared by transfer / burn
 // ---------------------------------------------------------------------------
 
 void kth_wallet_cashtoken_token_tx_result_destruct(
@@ -842,180 +600,74 @@ uint32_t kth_wallet_cashtoken_token_tx_result_signing_index_nth(
     return v[kth::sz(index)];
 }
 
+
 // ---------------------------------------------------------------------------
-// ft_params / create_ft
+// create_ft
 // ---------------------------------------------------------------------------
-
-kth_cashtoken_ft_params_mut_t kth_wallet_cashtoken_ft_params_construct_default(void) {
-    return kth::leak<ct::ft_params>();
-}
-
-void kth_wallet_cashtoken_ft_params_destruct(kth_cashtoken_ft_params_mut_t self) {
-    kth::del<ct::ft_params>(self);
-}
-
-void kth_wallet_cashtoken_ft_params_set_genesis_utxo(
-    kth_cashtoken_ft_params_mut_t self, kth_utxo_const_t genesis_utxo
-) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(genesis_utxo != nullptr);
-    kth::cpp_ref<ct::ft_params>(self).genesis_utxo =
-        kth::cpp_ref<kth::domain::chain::utxo>(genesis_utxo);
-}
-
-void kth_wallet_cashtoken_ft_params_set_destination(
-    kth_cashtoken_ft_params_mut_t self, kth_payment_address_const_t destination
-) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(destination != nullptr);
-    kth::cpp_ref<ct::ft_params>(self).destination =
-        kth::cpp_ref<kth::domain::wallet::payment_address>(destination);
-}
-
-void kth_wallet_cashtoken_ft_params_set_total_supply(
-    kth_cashtoken_ft_params_mut_t self, uint64_t total_supply
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::ft_params>(self).total_supply = total_supply;
-}
-
-void kth_wallet_cashtoken_ft_params_set_with_minting_nft(
-    kth_cashtoken_ft_params_mut_t self, kth_bool_t with_minting_nft
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::ft_params>(self).with_minting_nft = kth::int_to_bool(with_minting_nft);
-}
-
-void kth_wallet_cashtoken_ft_params_set_fee_utxos(
-    kth_cashtoken_ft_params_mut_t self, kth_utxo_list_const_t fee_utxos
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::ft_params>(self).fee_utxos = copy_utxo_list(fee_utxos);
-}
-
-void kth_wallet_cashtoken_ft_params_set_change_address(
-    kth_cashtoken_ft_params_mut_t self, kth_payment_address_const_t change_address
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::ft_params>(self).change_address = optional_addr(change_address);
-}
-
-void kth_wallet_cashtoken_ft_params_set_script_flags(
-    kth_cashtoken_ft_params_mut_t self, uint64_t script_flags
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::ft_params>(self).script_flags = script_flags;
-}
 
 kth_error_code_t kth_wallet_cashtoken_create_ft(
-    kth_cashtoken_ft_params_const_t params,
+    kth_utxo_const_t genesis_utxo,
+    kth_payment_address_const_t destination,
+    uint64_t total_supply,
+    kth_bool_t with_minting_nft,
+    kth_utxo_list_const_t fee_utxos,
+    kth_payment_address_const_t change_address,
+    uint64_t script_flags,
     KTH_OUT_OWNED kth_cashtoken_token_genesis_result_mut_t* out
 ) {
-    KTH_PRECONDITION(params != nullptr);
+    KTH_PRECONDITION(genesis_utxo != nullptr);
+    KTH_PRECONDITION(destination != nullptr);
     KTH_PRECONDITION(out != nullptr);
     KTH_PRECONDITION(*out == nullptr);
-    auto r = ct::create_ft(kth::cpp_ref<ct::ft_params>(params));
+
+    auto r = ct::create_ft(ct::ft_params{
+        .genesis_utxo = kth::cpp_ref<kth::domain::chain::utxo>(genesis_utxo),
+        .destination = kth::cpp_ref<kth::domain::wallet::payment_address>(destination),
+        .total_supply = total_supply,
+        .with_minting_nft = kth::int_to_bool(with_minting_nft),
+        .fee_utxos = copy_utxo_list(fee_utxos),
+        .change_address = optional_addr(change_address),
+        .script_flags = script_flags,
+    });
     if ( ! r.has_value()) return kth::to_c_err(r.error());
     *out = kth::leak(std::move(*r));
     return kth_ec_success;
 }
 
+
 // ---------------------------------------------------------------------------
-// nft_collection_params / nft_collection_result / create_nft_collection
+// create_nft_collection
 // ---------------------------------------------------------------------------
-
-kth_cashtoken_nft_collection_params_mut_t
-kth_wallet_cashtoken_nft_collection_params_construct_default(void) {
-    return kth::leak<ct::nft_collection_params>();
-}
-
-void kth_wallet_cashtoken_nft_collection_params_destruct(
-    kth_cashtoken_nft_collection_params_mut_t self
-) {
-    kth::del<ct::nft_collection_params>(self);
-}
-
-void kth_wallet_cashtoken_nft_collection_params_set_genesis_utxo(
-    kth_cashtoken_nft_collection_params_mut_t self, kth_utxo_const_t genesis_utxo
-) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(genesis_utxo != nullptr);
-    kth::cpp_ref<ct::nft_collection_params>(self).genesis_utxo =
-        kth::cpp_ref<kth::domain::chain::utxo>(genesis_utxo);
-}
-
-void kth_wallet_cashtoken_nft_collection_params_set_nfts(
-    kth_cashtoken_nft_collection_params_mut_t self,
-    kth_cashtoken_nft_collection_item_list_const_t nfts
-) {
-    KTH_PRECONDITION(self != nullptr);
-    auto& p = kth::cpp_ref<ct::nft_collection_params>(self);
-    p.nfts = nfts == nullptr
-        ? std::vector<ct::nft_collection_item>{}
-        : kth::cpp_ref<std::vector<ct::nft_collection_item>>(nfts);
-}
-
-void kth_wallet_cashtoken_nft_collection_params_set_creator_address(
-    kth_cashtoken_nft_collection_params_mut_t self, kth_payment_address_const_t creator_address
-) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(creator_address != nullptr);
-    kth::cpp_ref<ct::nft_collection_params>(self).creator_address =
-        kth::cpp_ref<kth::domain::wallet::payment_address>(creator_address);
-}
-
-void kth_wallet_cashtoken_nft_collection_params_set_keep_minting_token(
-    kth_cashtoken_nft_collection_params_mut_t self, kth_bool_t keep_minting_token
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::nft_collection_params>(self).keep_minting_token =
-        kth::int_to_bool(keep_minting_token);
-}
-
-void kth_wallet_cashtoken_nft_collection_params_set_ft_amount(
-    kth_cashtoken_nft_collection_params_mut_t self, kth_bool_t has_value, uint64_t ft_amount
-) {
-    KTH_PRECONDITION(self != nullptr);
-    auto& p = kth::cpp_ref<ct::nft_collection_params>(self);
-    p.ft_amount = kth::int_to_bool(has_value) ? std::optional<uint64_t>(ft_amount) : std::nullopt;
-}
-
-void kth_wallet_cashtoken_nft_collection_params_set_fee_utxos(
-    kth_cashtoken_nft_collection_params_mut_t self, kth_utxo_list_const_t fee_utxos
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::nft_collection_params>(self).fee_utxos = copy_utxo_list(fee_utxos);
-}
-
-void kth_wallet_cashtoken_nft_collection_params_set_change_address(
-    kth_cashtoken_nft_collection_params_mut_t self, kth_payment_address_const_t change_address
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::nft_collection_params>(self).change_address = optional_addr(change_address);
-}
-
-void kth_wallet_cashtoken_nft_collection_params_set_batch_size(
-    kth_cashtoken_nft_collection_params_mut_t self, kth_size_t batch_size
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::nft_collection_params>(self).batch_size = kth::sz(batch_size);
-}
-
-void kth_wallet_cashtoken_nft_collection_params_set_script_flags(
-    kth_cashtoken_nft_collection_params_mut_t self, uint64_t script_flags
-) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<ct::nft_collection_params>(self).script_flags = script_flags;
-}
 
 kth_error_code_t kth_wallet_cashtoken_create_nft_collection(
-    kth_cashtoken_nft_collection_params_const_t params,
+    kth_utxo_const_t genesis_utxo,
+    kth_cashtoken_nft_collection_item_list_const_t nfts,
+    kth_payment_address_const_t creator_address,
+    kth_bool_t keep_minting_token,
+    kth_bool_t has_ft_amount, uint64_t ft_amount,
+    kth_utxo_list_const_t fee_utxos,
+    kth_payment_address_const_t change_address,
+    kth_size_t batch_size,
+    uint64_t script_flags,
     KTH_OUT_OWNED kth_cashtoken_nft_collection_result_mut_t* out
 ) {
-    KTH_PRECONDITION(params != nullptr);
+    KTH_PRECONDITION(genesis_utxo != nullptr);
+    KTH_PRECONDITION(nfts != nullptr);
+    KTH_PRECONDITION(creator_address != nullptr);
     KTH_PRECONDITION(out != nullptr);
     KTH_PRECONDITION(*out == nullptr);
-    auto r = ct::create_nft_collection(kth::cpp_ref<ct::nft_collection_params>(params));
+
+    auto r = ct::create_nft_collection(ct::nft_collection_params{
+        .genesis_utxo = kth::cpp_ref<kth::domain::chain::utxo>(genesis_utxo),
+        .nfts = kth::cpp_ref<std::vector<ct::nft_collection_item>>(nfts),
+        .creator_address = kth::cpp_ref<kth::domain::wallet::payment_address>(creator_address),
+        .keep_minting_token = kth::int_to_bool(keep_minting_token),
+        .ft_amount = kth::int_to_bool(has_ft_amount) ? std::optional<uint64_t>(ft_amount) : std::nullopt,
+        .fee_utxos = copy_utxo_list(fee_utxos),
+        .change_address = optional_addr(change_address),
+        .batch_size = kth::sz(batch_size),
+        .script_flags = script_flags,
+    });
     if ( ! r.has_value()) return kth::to_c_err(r.error());
     *out = kth::leak(std::move(*r));
     return kth_ec_success;

--- a/src/c-api/test/wallet/cashtoken_minting.cpp
+++ b/src/c-api/test/wallet/cashtoken_minting.cpp
@@ -162,14 +162,9 @@ TEST_CASE("C-API prepare_genesis_utxo - happy path produces a result",
     kth_payment_address_mut_t dest = make_addr();
     kth_utxo_mut_t u = make_bch_utxo(kParentTxA, 3u, 50000u);
 
-    kth_cashtoken_prepare_genesis_params_mut_t p =
-        kth_wallet_cashtoken_prepare_genesis_params_construct_default();
-    kth_wallet_cashtoken_prepare_genesis_params_set_utxo(p, u);
-    kth_wallet_cashtoken_prepare_genesis_params_set_destination(p, dest);
-    kth_wallet_cashtoken_prepare_genesis_params_set_satoshis(p, 10000u);
-
     kth_cashtoken_prepare_genesis_result_mut_t res = NULL;
-    kth_error_code_t ec = kth_wallet_cashtoken_prepare_genesis_utxo(p, &res);
+    kth_error_code_t ec = kth_wallet_cashtoken_prepare_genesis_utxo(
+        u, dest, 10000u, /*change_address=*/NULL, &res);
     REQUIRE(ec == kth_ec_success);
     REQUIRE(res != NULL);
 
@@ -177,7 +172,6 @@ TEST_CASE("C-API prepare_genesis_utxo - happy path produces a result",
     REQUIRE(kth_wallet_cashtoken_prepare_genesis_result_signing_index_nth(res, 0) == 0u);
 
     kth_wallet_cashtoken_prepare_genesis_result_destruct(res);
-    kth_wallet_cashtoken_prepare_genesis_params_destruct(p);
     kth_chain_utxo_destruct(u);
     kth_wallet_payment_address_destruct(dest);
 }
@@ -187,18 +181,12 @@ TEST_CASE("C-API prepare_genesis_utxo - rejects dust-level satoshis",
     kth_payment_address_mut_t dest = make_addr();
     kth_utxo_mut_t u = make_bch_utxo(kParentTxA, 0u, 50000u);
 
-    kth_cashtoken_prepare_genesis_params_mut_t p =
-        kth_wallet_cashtoken_prepare_genesis_params_construct_default();
-    kth_wallet_cashtoken_prepare_genesis_params_set_utxo(p, u);
-    kth_wallet_cashtoken_prepare_genesis_params_set_destination(p, dest);
-    kth_wallet_cashtoken_prepare_genesis_params_set_satoshis(p, 100u); // below dust
-
     kth_cashtoken_prepare_genesis_result_mut_t res = NULL;
-    kth_error_code_t ec = kth_wallet_cashtoken_prepare_genesis_utxo(p, &res);
+    kth_error_code_t ec = kth_wallet_cashtoken_prepare_genesis_utxo(
+        u, dest, /*satoshis=*/100u /* below dust */, NULL, &res);
     REQUIRE(ec != kth_ec_success);
     REQUIRE(res == NULL);
 
-    kth_wallet_cashtoken_prepare_genesis_params_destruct(p);
     kth_chain_utxo_destruct(u);
     kth_wallet_payment_address_destruct(dest);
 }
@@ -212,15 +200,16 @@ TEST_CASE("C-API create_token_genesis - FT-only returns category_id = parent txi
     kth_payment_address_mut_t dest = make_addr();
     kth_utxo_mut_t u = make_bch_utxo(kParentTxA, 0u, 50000u);
 
-    kth_cashtoken_token_genesis_params_mut_t p =
-        kth_wallet_cashtoken_token_genesis_params_construct_default();
-    kth_wallet_cashtoken_token_genesis_params_set_genesis_utxo(p, u);
-    kth_wallet_cashtoken_token_genesis_params_set_destination(p, dest);
-    kth_wallet_cashtoken_token_genesis_params_set_ft_amount(p, 1, 1000000u);
-    kth_wallet_cashtoken_token_genesis_params_set_script_flags(p, 0u);
-
     kth_cashtoken_token_genesis_result_mut_t res = NULL;
-    kth_error_code_t ec = kth_wallet_cashtoken_create_token_genesis(p, &res);
+    kth_error_code_t ec = kth_wallet_cashtoken_create_token_genesis(
+        u, dest,
+        /*has_ft_amount=*/1, /*ft_amount=*/1000000u,
+        /*nft=*/NULL,
+        /*satoshis=*/1000u,
+        /*fee_utxos=*/NULL,
+        /*change_address=*/NULL,
+        /*script_flags=*/0u,
+        &res);
     REQUIRE(ec == kth_ec_success);
     REQUIRE(res != NULL);
 
@@ -229,7 +218,6 @@ TEST_CASE("C-API create_token_genesis - FT-only returns category_id = parent txi
     REQUIRE(memcmp(cat, kParentTxA, 32) == 0);
 
     kth_wallet_cashtoken_token_genesis_result_destruct(res);
-    kth_wallet_cashtoken_token_genesis_params_destruct(p);
     kth_chain_utxo_destruct(u);
     kth_wallet_payment_address_destruct(dest);
 }
@@ -239,19 +227,19 @@ TEST_CASE("C-API create_token_genesis - rejects outpoint.index != 0",
     kth_payment_address_mut_t dest = make_addr();
     kth_utxo_mut_t u = make_bch_utxo(kParentTxA, 3u, 50000u); // index != 0
 
-    kth_cashtoken_token_genesis_params_mut_t p =
-        kth_wallet_cashtoken_token_genesis_params_construct_default();
-    kth_wallet_cashtoken_token_genesis_params_set_genesis_utxo(p, u);
-    kth_wallet_cashtoken_token_genesis_params_set_destination(p, dest);
-    kth_wallet_cashtoken_token_genesis_params_set_ft_amount(p, 1, 1000u);
-    kth_wallet_cashtoken_token_genesis_params_set_script_flags(p, 0u);
-
     kth_cashtoken_token_genesis_result_mut_t res = NULL;
-    kth_error_code_t ec = kth_wallet_cashtoken_create_token_genesis(p, &res);
+    kth_error_code_t ec = kth_wallet_cashtoken_create_token_genesis(
+        u, dest,
+        /*has_ft_amount=*/1, /*ft_amount=*/1000u,
+        /*nft=*/NULL,
+        /*satoshis=*/1000u,
+        /*fee_utxos=*/NULL,
+        /*change_address=*/NULL,
+        /*script_flags=*/0u,
+        &res);
     REQUIRE(ec != kth_ec_success);
     REQUIRE(res == NULL);
 
-    kth_wallet_cashtoken_token_genesis_params_destruct(p);
     kth_chain_utxo_destruct(u);
     kth_wallet_payment_address_destruct(dest);
 }
@@ -276,23 +264,23 @@ TEST_CASE("C-API create_nft_collection - partitions into batches",
         kth_wallet_cashtoken_nft_collection_item_destruct(item);
     }
 
-    kth_cashtoken_nft_collection_params_mut_t p =
-        kth_wallet_cashtoken_nft_collection_params_construct_default();
-    kth_wallet_cashtoken_nft_collection_params_set_genesis_utxo(p, u);
-    kth_wallet_cashtoken_nft_collection_params_set_nfts(p, items);
-    kth_wallet_cashtoken_nft_collection_params_set_creator_address(p, creator);
-    kth_wallet_cashtoken_nft_collection_params_set_batch_size(p, 5u);
-    kth_wallet_cashtoken_nft_collection_params_set_script_flags(p, 0u);
-
     kth_cashtoken_nft_collection_result_mut_t res = NULL;
-    kth_error_code_t ec = kth_wallet_cashtoken_create_nft_collection(p, &res);
+    kth_error_code_t ec = kth_wallet_cashtoken_create_nft_collection(
+        u, items, creator,
+        /*keep_minting_token=*/0,
+        /*has_ft_amount=*/0, /*ft_amount=*/0u,
+        /*fee_utxos=*/NULL,
+        /*change_address=*/NULL,
+        /*batch_size=*/5u,
+        /*script_flags=*/0u,
+        &res);
     REQUIRE(ec == kth_ec_success);
     REQUIRE(res != NULL);
 
     // 12 / batch_size=5 -> 3 batches (5 + 5 + 2)
     REQUIRE(kth_wallet_cashtoken_nft_collection_result_batches_count(res) == 3u);
 
-    // `final_burn` defaults to true (keep_minting_token == false).
+    // `final_burn` defaults to true (keep_minting_token == 0).
     REQUIRE(kth_wallet_cashtoken_nft_collection_result_final_burn(res) != 0);
 
     // The category id equals `kParentTxA`.
@@ -310,7 +298,6 @@ TEST_CASE("C-API create_nft_collection - partitions into batches",
     REQUIRE(kth_wallet_cashtoken_nft_mint_request_list_count(b2) == 2u);
 
     kth_wallet_cashtoken_nft_collection_result_destruct(res);
-    kth_wallet_cashtoken_nft_collection_params_destruct(p);
     kth_wallet_cashtoken_nft_collection_item_list_destruct(items);
     kth_chain_utxo_destruct(u);
     kth_wallet_payment_address_destruct(creator);


### PR DESCRIPTION
## Summary
- Each of `prepare_genesis_params`, `token_genesis_params`, `token_mint_params`, `token_transfer_params`, `token_burn_params`, `ft_params`, `nft_collection_params` on the domain side carries a required `payment_address`. Once `payment_address` lost its default ctor (valid-by-construction sweep), those structs stopped being default-constructible — the C-API's `_construct_default + set_* + create_*` builder for these no longer fit.
- Rather than reintroduce sentinels on the domain side or maintain a parallel C-API holder mirror, the params handles for those seven are dropped. Each `create_*` now takes every field as an argument: required fields must be non-NULL, optional fields follow the same `NULL` / `has_value` conventions used elsewhere in the C-API.

## Surface changes

### Removed
- `kth_cashtoken_prepare_genesis_params_*`, `token_genesis_params_*`, `token_mint_params_*`, `token_transfer_params_*`, `token_burn_params_*`, `ft_params_*`, `nft_collection_params_*` — all `_construct_default`, `_destruct`, and every `_set_*`.
- The matching opaque-handle typedefs from the header.

### Kept unchanged
- `nft_spec`, `nft_mint_request` (+ list), `nft_collection_item` (+ list): independent value-payload helpers with all-at-once `_construct(...)` — callers may want to build a list once and reuse.
- Result types (`prepare_genesis_result`, `token_genesis_result`, `token_mint_result`, `token_tx_result`, `nft_collection_result`) keep their handle + accessors surface.
- Free functions (`encode_nft_number`, `create_*_output`).

## Call-site shape

```c
kth_error_code_t kth_wallet_cashtoken_create_token_genesis(
    kth_utxo_const_t genesis_utxo,
    kth_payment_address_const_t destination,
    kth_bool_t has_ft_amount, uint64_t ft_amount,
    kth_cashtoken_nft_spec_const_t nft,           // NULL = nullopt
    uint64_t satoshis,
    kth_utxo_list_const_t fee_utxos,              // NULL = empty
    kth_payment_address_const_t change_address,   // NULL = nullopt
    uint64_t script_flags,
    KTH_OUT_OWNED kth_cashtoken_token_genesis_result_mut_t* out);
```

Inside, each `create_*` runs designated-initializer aggregate init over the domain params struct in one place — no reintroduced defaults, no holder mirror to keep in sync, no leftover setter state to worry about.

## Ordering
Merges before #439 (c-api wallet regen). After this lands, #439 re-includes `cashtoken_minting.cpp / .h / test` in the c-api build (currently excluded there as a temporary parche) and the whole c-api is green again.

## Test plan
- [x] `cmake --build . --target c-api` locally green (tested with #439's wallet regen files staged in the working tree, then reverted before commit — this PR's diff is cashtoken_minting.{h,cpp} + its test only)
- [x] `test/wallet/cashtoken_minting.cpp` recompiles standalone against the new call shape