### PR TITLE
refactor(wallet): make ec_public constexpr-usable

### DIFF
--- a/src/domain/include/kth/domain/wallet/ec_public.hpp
+++ b/src/domain/include/kth/domain/wallet/ec_public.hpp
@@ -25,10 +25,14 @@ class payment_address;
 /// factory that validated its input, so accessors and serializers are
 /// always meaningful.
 struct KD_API ec_public {
-    static uint8_t const compressed_even;
-    static uint8_t const compressed_odd;
-    static uint8_t const uncompressed;
-    static uint8_t const mainnet_p2kh;
+    static constexpr uint8_t compressed_even = 0x02;
+    static constexpr uint8_t compressed_odd  = 0x03;
+    static constexpr uint8_t uncompressed    = 0x04;
+#if defined(KTH_CURRENCY_LTC)
+    static constexpr uint8_t mainnet_p2kh    = 0x30;
+#else
+    static constexpr uint8_t mainnet_p2kh    = 0x00;
+#endif
 
     /// Parse a base16-encoded key. `error::illegal_value` on malformed
     /// input or a value that fails EC curve verification.
@@ -55,20 +59,21 @@ struct KD_API ec_public {
     /// Wrap an already-compressed EC point that the caller has verified
     /// lies on the curve (or produced by an internal derivation step
     /// that guarantees it). No on-curve check is performed here.
-    [[nodiscard]]
-    static
-    ec_public from_verified_point(ec_compressed const& point, bool compress);
+    [[nodiscard]] static constexpr
+    ec_public from_verified_point(ec_compressed const& point, bool compress) noexcept {
+        return ec_public(point, compress);
+    }
 
     [[nodiscard]]
     friend auto operator<=>(ec_public const&, ec_public const&) = default;
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     ec_compressed const& value() const noexcept { return point_; }
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     ec_compressed const& point() const noexcept { return point_; }
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     bool compressed() const noexcept { return compress_; }
 
     /// Base16 encoding used by `fmt::formatter<ec_public>`.
@@ -88,6 +93,7 @@ struct KD_API ec_public {
     expect<payment_address> to_payment_address(uint8_t version = mainnet_p2kh) const;
 
 private:
+    constexpr
     ec_public(ec_compressed const& point, bool compress) noexcept
         : compress_(compress), point_(point) {}
 

--- a/src/domain/src/wallet/ec_public.cpp
+++ b/src/domain/src/wallet/ec_public.cpp
@@ -19,15 +19,6 @@
 
 namespace kth::domain::wallet {
 
-uint8_t const ec_public::compressed_even = 0x02;
-uint8_t const ec_public::compressed_odd  = 0x03;
-uint8_t const ec_public::uncompressed    = 0x04;
-#if defined(KTH_CURRENCY_LTC)
-uint8_t const ec_public::mainnet_p2kh = 0x30;
-#else
-uint8_t const ec_public::mainnet_p2kh = 0x00;
-#endif
-
 // Validators.
 // ----------------------------------------------------------------------------
 
@@ -37,11 +28,6 @@ bool ec_public::is_point(byte_span decoded) {
 
 // Factories.
 // ----------------------------------------------------------------------------
-
-// static
-ec_public ec_public::from_verified_point(ec_compressed const& point, bool compress) {
-    return ec_public(point, compress);
-}
 
 // static
 expect<ec_public> ec_public::from_data(data_chunk const& decoded) {

--- a/src/domain/test/wallet/ec_public.cpp
+++ b/src/domain/test/wallet/ec_public.cpp
@@ -10,7 +10,30 @@ using namespace kth::domain::wallet;
 
 // Start Test Suite: ec public tests
 
-// TEST_CASE("ec public todo", "[None]") {
-//}
+// Compile-time verification that the constexpr surface is actually
+// usable as a constant expression. A `constexpr` variable definition
+// forces evaluation at translation time — a regression that made
+// `from_verified_point`, the private ctor, or the accessors runtime-
+// only would surface as a compile error here, closer to the type than
+// a downstream call site.
+namespace {
+
+constexpr ec_compressed some_point = {{
+    0x02, 0x50, 0x86, 0x3a, 0xd6, 0x4a, 0x87, 0xae,
+    0x8a, 0x2f, 0xe8, 0x3c, 0x1a, 0xf1, 0xa8, 0x40,
+    0x3c, 0xb5, 0x3f, 0x53, 0xe4, 0x86, 0xd8, 0x51,
+    0x1d, 0xad, 0x8a, 0x04, 0x88, 0x7e, 0x5b, 0x23,
+    0x52,
+}};
+
+constexpr auto kSample = ec_public::from_verified_point(some_point, true);
+static_assert(kSample.compressed());
+static_assert(kSample.point() == some_point);
+static_assert(kSample == kSample);
+static_assert(ec_public::compressed_even == 0x02);
+static_assert(ec_public::compressed_odd  == 0x03);
+static_assert(ec_public::uncompressed    == 0x04);
+
+} // namespace
 
 // End Test Suite


### PR DESCRIPTION
## Summary
- Four static byte constants (`compressed_even`, `compressed_odd`, `uncompressed`, `mainnet_p2kh`) become inline `static constexpr uint8_t` in the header — no more separate `.cpp` definitions, no odr-use trip through the TU.
- `from_verified_point`, the private wrapping ctor, and the `value`/`point`/`compressed` accessors pick up `constexpr`. `operator<=>` was already implicitly constexpr since #432.
- Everything else stays runtime — `is_point`, `from_data`, `from_point`, `to_uncompressed` reach into libsecp256k1 (C library, not constexpr-eligible); `to_string`/`to_data`/`parse_from` allocate; `from_private`/`to_payment_address` cross into other wallet types.

## Verification
`test/wallet/ec_public.cpp` gains a `static_assert` block that forces `ec_public::from_verified_point(...)` to evaluate at translation time and round-trip the accessors. A regression that makes any of the newly-constexpr pieces runtime-only would surface as a compile error next to the type.

## Test plan
- [x] `kth_domain_test` — 1,011,094 assertions / 3,869 test cases green
- [x] Compile-time `static_asserts` in the ec_public test compile