### PR TITLE
ci: split Conan cache into sanitizer / clean families

### DIFF
--- a/.github/workflows/build-with-container.yml
+++ b/.github/workflows/build-with-container.yml
@@ -107,7 +107,15 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/.conan2
-          key: ${{ runner.os }}-conan2-${{ hashFiles('**/conan.lock') }}
+          # Two disjoint cache families: 'sanitizers' and 'clean'. The
+          # sanitizer flags leak into dep builds via `CXXFLAGS`/`LDFLAGS`
+          # env vars but are NOT reflected in Conan's package hash, so a
+          # sanitizer-instrumented dep (`libutxoz.a` with references to
+          # `__asan_report_*`) would end up under the same cache key as
+          # its clean counterpart and get restored into a later clean
+          # build — the link then fails on undefined sanitizer-runtime
+          # references. The split matches the sibling ccache key.
+          key: ${{ runner.os }}-conan2-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-${{ hashFiles('**/conan.lock') }}
       # - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
       #   with:
       #     path: ~/.cache/pip

--- a/.github/workflows/build-without-container.yml
+++ b/.github/workflows/build-without-container.yml
@@ -84,7 +84,14 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/.conan2
-          key: ${{ runner.os }}-conan2-${{ hashFiles('**/conan.lock') }}
+          # Split sanitizer / clean cache families. See the matching
+          # comment in `build-with-container.yml` — sanitizer flags
+          # leak into dep builds via env but don't factor into Conan's
+          # package hash, so a shared cache produces broken links
+          # (missing `__asan_report_*` / `__ubsan_handle_*` runtime
+          # symbols) when a sanitizer-built dep gets restored into a
+          # non-sanitizer build.
+          key: ${{ runner.os }}-conan2-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-${{ hashFiles('**/conan.lock') }}
       # - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
       #   with:
       #     path: ~/.cache/pip


### PR DESCRIPTION
## Summary
- Sanitizer builds pass `-fsanitize=…` through `CXXFLAGS`/`LDFLAGS` env vars into every dep Conan rebuilds with `--build=missing`. Those flags **leak into dep binaries but never reach Conan's package hash** — `-o march_id=…` is the only option the workflow varies, and it's identical for sanitizer and clean runs. Result: a sanitizer-instrumented `libutxoz.a` (full of `__asan_report_*` / `__ubsan_handle_*` calls) ends up cached under the same key as its clean counterpart. A later clean job restores it, tries to link, and fails on undefined sanitizer-runtime references.
- The sibling `ccache` restore already tags its key with the `sanitizers`|`clean` family for exactly this reason. This adds the same suffix to the Conan cache key — one line each in `build-with-container.yml` and `build-without-container.yml`. The container workflow's `Save Conan packages` step reads the restore step's primary key output, so it inherits the split automatically.
- Existing polluted binaries in the shared cache clear themselves on the first run under the new key — the miss triggers a fresh `--build=missing` on the affected packages.

## Diagnosis trail
The specific failing link that triggered this ([job](https://github.com/k-nuth/kth/actions/runs/29199065376/job/86667354212)):
```
libutxoz.a(database.cpp.o): undefined reference to `__asan_report_store8`
libutxoz.a(database.cpp.o): undefined reference to `__ubsan_handle_type_mismatch_v1`
```
was on `refactor/checkpoint-order-by-height` — a clean, non-sanitizer job. utxoz's source hasn't changed in weeks; the pollution came from a sanitizer job upstream in the cache lineage.

## Test plan
- [ ] After merge: watch the next non-sanitizer Build & Test run. First run under the new key rebuilds deps clean; subsequent runs hit the split cache and link succeeds.