### PR TITLE
refactor(wallet): make ec_private constexpr-usable

### DIFF
--- a/src/domain/include/kth/domain/wallet/ec_private.hpp
+++ b/src/domain/include/kth/domain/wallet/ec_private.hpp
@@ -37,34 +37,45 @@ using wif_compressed = byte_array<wif_compressed_size>;
 /// that validated the underlying `ec_secret` lies in the curve's
 /// scalar range, so `to_public()` never fails.
 struct KD_API ec_private {
-    static uint8_t const compressed_sentinel;
+    static constexpr uint8_t compressed_sentinel = 0x01;
 
     // WIF carries a compression flag for payment address generation but
     // assumes a mapping to payment address version. This is insufficient
     // as a parameterized mapping is required, so we use the same technique
     // as with hd keys, merging the two necessary values into one version.
-    static uint8_t  const mainnet_wif;
-    static uint8_t  const mainnet_p2kh;
-    static uint16_t const mainnet;
-    static uint8_t  const testnet_wif;
-    static uint8_t  const testnet_p2kh;
-    static uint16_t const testnet;
+#if defined(KTH_CURRENCY_LTC)
+    static constexpr uint8_t  mainnet_wif  = 0xb0;
+    static constexpr uint8_t  mainnet_p2kh = 0x30;
+#else
+    static constexpr uint8_t  mainnet_wif  = 0x80;
+    static constexpr uint8_t  mainnet_p2kh = 0x00;
+#endif
+    static constexpr uint8_t  testnet_wif  = 0xef;
+    static constexpr uint8_t  testnet_p2kh = 0x6f;
 
-    static
-    uint8_t to_address_prefix(uint16_t version) {
+    [[nodiscard]] static constexpr
+    uint8_t to_address_prefix(uint16_t version) noexcept {
         return version & 0x00FF;
     }
 
-    static
-    uint8_t to_wif_prefix(uint16_t version) {
+    [[nodiscard]] static constexpr
+    uint8_t to_wif_prefix(uint16_t version) noexcept {
         return version >> 8;
     }
 
-    // Unfortunately can't use this below to define mainnet (MSVC).
-    static
-    uint16_t to_version(uint8_t address, uint8_t wif) {
+    [[nodiscard]] static constexpr
+    uint16_t to_version(uint8_t address, uint8_t wif) noexcept {
         return uint16_t(wif) << 8 | address;
     }
+
+    // Inline `to_version(p2kh, wif)` — the member function is declared
+    // above but not yet defined at this point of the class definition,
+    // so it can't be called in a constant expression here (the same
+    // reason the original .cpp had to compute `mainnet`/`testnet` at
+    // TU-scope). Kept in-line so the values still change atomically
+    // with the two `p2kh` / `wif` constants that feed them.
+    static constexpr uint16_t mainnet = uint16_t(mainnet_wif) << 8 | mainnet_p2kh;
+    static constexpr uint16_t testnet = uint16_t(testnet_wif) << 8 | testnet_p2kh;
 
     /// Parse a WIF-encoded private key. `error::illegal_value` on
     /// malformed input or a secret outside the curve's scalar range.
@@ -88,29 +99,30 @@ struct KD_API ec_private {
     /// Wrap a secret that the caller has already verified lies in the
     /// curve's scalar range (or produced by an internal derivation step
     /// that guarantees it). No range check is performed here.
-    [[nodiscard]]
-    static
-    ec_private from_verified_secret(ec_secret const& secret, uint16_t version, bool compress);
+    [[nodiscard]] static constexpr
+    ec_private from_verified_secret(ec_secret const& secret, uint16_t version, bool compress) noexcept {
+        return ec_private(secret, version, compress);
+    }
 
     [[nodiscard]]
     friend auto operator<=>(ec_private const&, ec_private const&) = default;
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     ec_secret const& value() const noexcept { return secret_; }
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     ec_secret const& secret() const noexcept { return secret_; }
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     uint16_t version() const noexcept { return version_; }
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     uint8_t payment_version() const noexcept { return to_address_prefix(version_); }
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     uint8_t wif_version() const noexcept { return to_wif_prefix(version_); }
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     bool compressed() const noexcept { return compress_; }
 
     /// WIF encoding used by `fmt::formatter<ec_private>`.
@@ -124,6 +136,7 @@ struct KD_API ec_private {
     expect<payment_address> to_payment_address() const;
 
 private:
+    constexpr
     ec_private(ec_secret const& secret, uint16_t version, bool compress) noexcept
         : compress_(compress), version_(version), secret_(secret) {}
 

--- a/src/domain/src/wallet/ec_private.cpp
+++ b/src/domain/src/wallet/ec_private.cpp
@@ -21,21 +21,6 @@
 
 namespace kth::domain::wallet {
 
-uint8_t const ec_private::compressed_sentinel = 0x01;
-#if defined(KTH_CURRENCY_LTC)
-uint8_t const ec_private::mainnet_wif  = 0xb0;
-uint8_t const ec_private::mainnet_p2kh = 0x30;
-#else
-uint8_t const ec_private::mainnet_wif  = 0x80;
-uint8_t const ec_private::mainnet_p2kh = 0x00;
-#endif
-
-uint16_t const ec_private::mainnet = to_version(mainnet_p2kh, mainnet_wif);
-
-uint8_t  const ec_private::testnet_wif  = 0xef;
-uint8_t  const ec_private::testnet_p2kh = 0x6f;
-uint16_t const ec_private::testnet      = to_version(testnet_p2kh, testnet_wif);
-
 // Validators.
 // ----------------------------------------------------------------------------
 
@@ -61,11 +46,6 @@ expect<ec_private> ec_private::from_secret(ec_secret const& secret, uint16_t ver
     if ( ! kth::verify(secret)) {
         return std::unexpected(kth::error::illegal_value);
     }
-    return ec_private(secret, version, compress);
-}
-
-// static
-ec_private ec_private::from_verified_secret(ec_secret const& secret, uint16_t version, bool compress) {
     return ec_private(secret, version, compress);
 }
 

--- a/src/domain/test/wallet/ec_private.cpp
+++ b/src/domain/test/wallet/ec_private.cpp
@@ -12,6 +12,37 @@ using namespace kth::domain::wallet;
 
 // TODO(legacy): add version tests
 
+// Compile-time verification that the constexpr surface is actually
+// usable as a constant expression. A `constexpr` variable definition
+// forces evaluation at translation time — a regression that made
+// `from_verified_secret`, the private ctor, or any accessor
+// runtime-only would surface as a compile error here, closer to the
+// type than a downstream call site.
+namespace {
+
+constexpr ec_secret kSecret = {{
+    0x80, 0x10, 0xb1, 0xbb, 0x11, 0x9a, 0xd3, 0x7d,
+    0x4b, 0x65, 0xa1, 0x02, 0x2a, 0x31, 0x48, 0x97,
+    0xb1, 0xb3, 0x61, 0x4b, 0x34, 0x59, 0x74, 0x33,
+    0x2c, 0xb1, 0xb9, 0x58, 0x2c, 0xf0, 0x35, 0x36,
+}};
+
+constexpr auto kSample = ec_private::from_verified_secret(
+    kSecret, ec_private::mainnet, /*compress=*/true);
+
+static_assert(kSample.compressed());
+static_assert(kSample.secret() == kSecret);
+static_assert(kSample.version() == ec_private::mainnet);
+static_assert(kSample.payment_version() == ec_private::mainnet_p2kh);
+static_assert(kSample.wif_version() == ec_private::mainnet_wif);
+static_assert(kSample == kSample);
+static_assert(ec_private::compressed_sentinel == 0x01);
+static_assert(ec_private::to_version(0x00, 0x80) == 0x8000);
+static_assert(ec_private::to_address_prefix(0x8042) == 0x42);
+static_assert(ec_private::to_wif_prefix(0x8042)     == 0x80);
+
+} // namespace
+
 constexpr auto secret = "8010b1bb119ad37d4b65a1022a314897b1b3614b345974332cb1b9582cf03536"_base16;
 constexpr auto wif_compressed_str = "L1WepftUBemj6H4XQovkiW1ARVjxMqaw4oj2kmkYqdG1xTnBcHfC";
 constexpr auto wif_uncompressed_str = "5JngqQmHagNTknnCshzVUysLMWAjT23FWs1TgNU5wyFH5SB3hrP";


### PR DESCRIPTION
## Summary
Same shape as #441 (ec_public):
- Static byte / uint16 constants (`compressed_sentinel`, the `mainnet_*` / `testnet_*` set, `mainnet` / `testnet`) become inline `static constexpr` in the header — no more separate `.cpp` definitions.
- The three helpers that decompose a `uint16_t` version into its `p2kh` / `wif` bytes (`to_address_prefix`, `to_wif_prefix`, `to_version`) pick up `constexpr` + `noexcept`.
- `from_verified_secret` + every accessor (`value`, `secret`, `version`, `payment_version`, `wif_version`, `compressed`) are constexpr; the private wrapping ctor is constexpr so those two can call it in a constant expression.
- Everything runtime-only stays runtime — `from_secret`, `from_compressed`, `from_uncompressed`, `parse_from`, `is_wif`, `to_public`, `to_payment_address`, `to_string` reach into secp256k1 / base58 / allocate.

## Nit
`mainnet` and `testnet` used to be initialised via `to_version(...)` at TU scope. Moving them into the class as `static constexpr` members means they can't call `to_version` at that point (its body is not yet complete). Inlining the `uint16_t(wif) << 8 | p2kh` shift keeps them where they belong.

## Verification
`test/wallet/ec_private.cpp` gains a `static_assert` block that forces `ec_private::from_verified_secret(...)` to evaluate at translation time and round-trips every accessor + the two static-helper conversions.

## Test plan
- [x] `kth_domain_test` — 1,011,094 assertions / 3,869 test cases green
- [x] Compile-time `static_asserts` in the ec_private test compile