### PR TITLE
refactor(wallet): make ek_private / ek_public / ek_token constexpr-usable

### DIFF
--- a/src/domain/include/kth/domain/wallet/ek_private.hpp
+++ b/src/domain/include/kth/domain/wallet/ek_private.hpp
@@ -25,14 +25,14 @@ struct KD_API ek_private {
     static
     expect<ek_private> parse_from(std::string_view encoded);
 
-    explicit
-    ek_private(encrypted_private const& value)
+    explicit constexpr
+    ek_private(encrypted_private const& value) noexcept
         : private_(value) {}
 
     [[nodiscard]]
     friend auto operator<=>(ek_private const& a, ek_private const& b) = default;
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     encrypted_private const& private_key() const noexcept { return private_; }
 
     /// Base58 encoding used by `fmt::formatter<ek_private>`.

--- a/src/domain/include/kth/domain/wallet/ek_public.hpp
+++ b/src/domain/include/kth/domain/wallet/ek_public.hpp
@@ -25,14 +25,14 @@ struct KD_API ek_public {
     static
     expect<ek_public> parse_from(std::string_view encoded);
 
-    explicit
-    ek_public(encrypted_public const& value)
+    explicit constexpr
+    ek_public(encrypted_public const& value) noexcept
         : public_(value) {}
 
     [[nodiscard]]
     friend auto operator<=>(ek_public const& a, ek_public const& b) = default;
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     encrypted_public const& public_key() const noexcept { return public_; }
 
     [[nodiscard]]

--- a/src/domain/include/kth/domain/wallet/ek_token.hpp
+++ b/src/domain/include/kth/domain/wallet/ek_token.hpp
@@ -25,14 +25,14 @@ struct KD_API ek_token {
     static
     expect<ek_token> parse_from(std::string_view encoded);
 
-    explicit
-    ek_token(encrypted_token const& value)
+    explicit constexpr
+    ek_token(encrypted_token const& value) noexcept
         : token_(value) {}
 
     [[nodiscard]]
     friend auto operator<=>(ek_token const& a, ek_token const& b) = default;
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     encrypted_token const& token() const noexcept { return token_; }
 
     [[nodiscard]]

--- a/src/domain/test/wallet/encrypted_keys.cpp
+++ b/src/domain/test/wallet/encrypted_keys.cpp
@@ -8,11 +8,37 @@
 
 #include <test_helpers.hpp>
 
+#include <kth/domain/wallet/ek_private.hpp>
+#include <kth/domain/wallet/ek_public.hpp>
+#include <kth/domain/wallet/ek_token.hpp>
 #include <kth/infrastructure/formats/base_58.hpp>
 
 using namespace kth;
 using namespace kd;
 using namespace kth::domain::wallet;
+
+// Compile-time verification that the ek_* wrappers can be built in a
+// constant expression from a caller-supplied `encrypted_*` payload —
+// a regression that made the wrapping ctor / accessor runtime-only
+// would surface as a compile error here.
+namespace {
+
+constexpr encrypted_private kSamplePriv{};
+constexpr ek_private kEkPriv{kSamplePriv};
+static_assert(kEkPriv.private_key() == kSamplePriv);
+static_assert(kEkPriv == kEkPriv);
+
+constexpr encrypted_public kSamplePub{};
+constexpr ek_public kEkPub{kSamplePub};
+static_assert(kEkPub.public_key() == kSamplePub);
+static_assert(kEkPub == kEkPub);
+
+constexpr encrypted_token kSampleTok{};
+constexpr ek_token kEkTok{kSampleTok};
+static_assert(kEkTok.token() == kSampleTok);
+static_assert(kEkTok == kEkTok);
+
+} // namespace
 
 // Start Test Suite: encrypted tests
 


### PR DESCRIPTION
## Summary
The three BIP38 wrapper types (`ek_private`, `ek_public`, `ek_token`) are structural clones — each holds a single `byte_array` (`encrypted_private`, `encrypted_public`, `encrypted_token`) and exposes one explicit wrapping ctor + one accessor. Combined into a single PR because the diff would be copy-paste across three otherwise.

- Wrapping ctor: `constexpr` + `noexcept`.
- Accessor (`private_key` / `public_key` / `token`): `constexpr`.
- `operator<=>` defaulted was already implicitly constexpr in C++20.
- The runtime factories (`parse_from`, decodes base58 + verifies checksum) and `to_string` base58 encoders stay runtime — they allocate.

## Verification
`test/wallet/encrypted_keys.cpp` gains a `static_assert` block that forces each `ek_*` wrapper to be built and inspected in a constant expression from a compile-time payload.

## Test plan
- [x] `kth_domain_test` — 1,011,094 assertions / 3,869 test cases green
- [x] Compile-time `static_asserts` in the encrypted_keys test compile