### PR TITLE
refactor(wallet): make payment_address constexpr-usable

### DIFF
--- a/src/domain/include/kth/domain/wallet/payment_address.hpp
+++ b/src/domain/include/kth/domain/wallet/payment_address.hpp
@@ -5,6 +5,8 @@
 #ifndef KTH_DOMAIN_WALLET_PAYMENT_ADDRESS_HPP
 #define KTH_DOMAIN_WALLET_PAYMENT_ADDRESS_HPP
 
+#include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -107,10 +109,21 @@ struct KD_API payment_address {
     expect<payment_address> from_pay_public_key_hash_script(chain::script const& script, uint8_t version);
 
     /// Wrap a 20-byte hash160 payload directly. Infallible.
-    payment_address(short_hash const& short_hash, uint8_t version);
+    constexpr
+    payment_address(short_hash const& short_hash, uint8_t version) noexcept
+        : version_(version)
+        , hash_size_(short_hash.size())
+    {
+        std::copy_n(short_hash.begin(), short_hash.size(), hash_data_.begin());
+    }
 
     /// Wrap a 32-byte hash payload directly. Infallible.
-    payment_address(hash_digest const& hash, uint8_t version);
+    constexpr
+    payment_address(hash_digest const& hash, uint8_t version) noexcept
+        : version_(version)
+        , hash_data_(hash)
+        , hash_size_(hash.size())
+    {}
 
     [[nodiscard]]
     friend auto operator<=>(payment_address const&, payment_address const&) = default;
@@ -137,21 +150,35 @@ struct KD_API payment_address {
     std::string encoded_token() const;
 #endif  //KTH_CURRENCY_BCH
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     uint8_t version() const noexcept { return version_; }
 
-    [[nodiscard]]
-    byte_span hash_span() const;
+    [[nodiscard]] constexpr
+    byte_span hash_span() const noexcept {
+        return {hash_data_.begin(), hash_size_};
+    }
 
     /// 20-byte hash accessor. Only valid for 20-byte addresses
     /// (P2KH, P2SH). Returns `null_short_hash` when the address
     /// carries a 32-byte hash — use `hash32()` for 32-byte payloads
     /// or `hash_span()` for the size-agnostic path.
-    [[nodiscard]]
-    short_hash hash20() const;
+    [[nodiscard]] constexpr
+    short_hash hash20() const noexcept {
+        // `pay_script_hash_32` (BCH 2025 Leibniz) addresses store a
+        // 32-byte hash that doesn't fit in a `short_hash`. Returning
+        // the first 20 bytes would be silent truncation. Surface that
+        // as the zero sentinel so callers can detect "no 20-byte
+        // hash available".
+        if (hash_size_ > short_hash_size) {
+            return null_short_hash;
+        }
+        short_hash hash{};
+        std::copy_n(hash_data_.begin(), hash.size(), hash.begin());
+        return hash;
+    }
 
-    [[nodiscard]]
-    hash_digest const& hash32() const;
+    [[nodiscard]] constexpr
+    hash_digest const& hash32() const noexcept { return hash_data_; }
 
     /// 25-byte `<version><20-byte hash><checksum>` payment layout.
     /// Only valid for 20-byte addresses. Returns a zero-initialised

--- a/src/domain/src/wallet/payment_address.cpp
+++ b/src/domain/src/wallet/payment_address.cpp
@@ -33,19 +33,6 @@ using namespace kth::domain::wallet;
 
 namespace kth::domain::wallet {
 
-payment_address::payment_address(short_hash const& short_hash, uint8_t version)
-    : version_(version)
-    , hash_size_(short_hash.size())
-{
-    std::copy_n(short_hash.begin(), short_hash.size(), hash_data_.begin());
-}
-
-payment_address::payment_address(hash_digest const& hash, uint8_t version)
-    : version_(version)
-    , hash_data_(hash)
-    , hash_size_(hash.size())
-{}
-
 // Validators.
 // ----------------------------------------------------------------------------
 
@@ -348,28 +335,6 @@ std::string payment_address::encoded_token() const {
 
 // Accessors.
 // ----------------------------------------------------------------------------
-
-kth::byte_span payment_address::hash_span() const {
-    return {hash_data_.begin(), hash_size_};
-}
-
-short_hash payment_address::hash20() const {
-    // `pay_script_hash_32` (BCH 2025 Leibniz) addresses store a
-    // 32-byte hash that doesn't fit in a `short_hash`. Returning
-    // the first 20 bytes would be silent truncation. Surface that
-    // as the zero sentinel so callers can detect "no 20-byte hash
-    // available".
-    if (hash_size_ > short_hash_size) {
-        return null_short_hash;
-    }
-    short_hash hash;
-    std::copy_n(hash_data_.begin(), hash.size(), hash.begin());
-    return hash;
-}
-
-hash_digest const& payment_address::hash32() const {
-    return hash_data_;
-}
 
 payment payment_address::to_payment() const {
     // `payment` is the fixed 25-byte (`version` + 20-byte hash +

--- a/src/domain/test/wallet/payment_address.cpp
+++ b/src/domain/test/wallet/payment_address.cpp
@@ -12,6 +12,39 @@ using namespace kth::domain::wallet;
 
 // Start Test Suite: payment_address tests
 
+// Compile-time verification that both wrapping ctors and the
+// hash / version accessors are usable in a constant expression. A
+// regression that made any of the newly-constexpr pieces runtime-
+// only would surface as a compile error here, closer to the type
+// than a downstream call site.
+namespace {
+
+constexpr short_hash kShort = {{
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+    0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+    0x11, 0x12, 0x13, 0x14,
+}};
+
+constexpr hash_digest kFull = {{
+    0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+    0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+    0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+}};
+
+constexpr payment_address kP2kh{kShort, payment_address::mainnet_p2kh};
+static_assert(kP2kh.version() == payment_address::mainnet_p2kh);
+static_assert(kP2kh.hash20() == kShort);
+static_assert(kP2kh == kP2kh);
+
+constexpr payment_address kFullHash{kFull, payment_address::mainnet_p2kh};
+static_assert(kFullHash.hash32() == kFull);
+// 32-byte hash carriers have no legal 20-byte representation — the
+// accessor surfaces `null_short_hash` sentinel rather than truncating.
+static_assert(kFullHash.hash20() == null_short_hash);
+
+} // namespace
+
 // $ bx base16-encode "Satoshi" | bx sha256
 constexpr char secret_hex[] = "002688cc350a5333a87fa622eacec626c3d1c0ebf9f3793de3885fa254d7e393";
 constexpr char script_text[] = "dup hash160 [18c0bd8d1818f1bf99cb1df2269c645318ef7b73] equalverify checksig";


### PR DESCRIPTION
## Summary
The static byte constants (`mainnet_p2kh`/`mainnet_p2sh`/`testnet_*` and the BCH cashaddr prefixes) were already inline `static constexpr`. This picks up the remaining pure-value pieces that were still runtime because they lived in the `.cpp`:

- Both wrapping ctors (`payment_address(short_hash, uint8_t)` and `payment_address(hash_digest, uint8_t)`) move to the header as `constexpr` + `noexcept`. Each is a two-member init plus a `std::copy_n` (constexpr in C++20).
- `version()`, `hash_span()`, `hash20()`, `hash32()` become `constexpr` + `noexcept` in the header. `hash20()` keeps its `null_short_hash` sentinel behaviour for 32-byte payloads (from #104).
- `operator<=>` defaulted was already implicitly constexpr in C++20.

Everything else stays runtime — the `parse_from` / `from_ec_*` / `from_script` / `from_payment` factories all reach into base58 / cashaddr / secp256k1 / hashing; `to_string` / `encoded_legacy` / `encoded_cashaddr` / `to_payment` all touch base58 or the double-sha256 checksum via `wrap()`.

## Verification
`test/wallet/payment_address.cpp` gains a `static_assert` block that forces both ctors + every constexpr accessor to evaluate at translation time, and pins the 32-byte-payload `null_short_hash` sentinel behaviour.

## Test plan
- [x] `kth_domain_test` — 1,011,094 assertions / 3,869 test cases green
- [x] Compile-time `static_asserts` in the payment_address test compile