### PR TITLE
refactor(wallet): make hd_public constexpr-usable

### DIFF
--- a/src/domain/include/kth/domain/wallet/hd_public.hpp
+++ b/src/domain/include/kth/domain/wallet/hd_public.hpp
@@ -71,9 +71,10 @@ struct KD_API hd_public {
     /// by an internal derivation step) into an `hd_public`. Caller is
     /// responsible for the on-curve invariant of `point`; no checks
     /// are performed here.
-    [[nodiscard]]
-    static
-    hd_public from_verified_components(ec_compressed const& point, hd_chain_code const& chain_code, hd_lineage const& lineage);
+    [[nodiscard]] static constexpr
+    hd_public from_verified_components(ec_compressed const& point, hd_chain_code const& chain_code, hd_lineage const& lineage) noexcept {
+        return hd_public(point, chain_code, lineage);
+    }
 
     [[nodiscard]]
     friend auto operator<=>(hd_public const& a, hd_public const& b) = default;
@@ -82,13 +83,13 @@ struct KD_API hd_public {
     [[nodiscard]]
     std::string to_string() const;
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     hd_chain_code const& chain_code() const noexcept { return chain_; }
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     hd_lineage const& lineage() const noexcept { return lineage_; }
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     ec_compressed const& point() const noexcept { return point_; }
 
     [[nodiscard]]
@@ -109,7 +110,9 @@ struct KD_API hd_public {
     void wipe() noexcept;
 
 private:
-    hd_public(ec_compressed const& point, hd_chain_code const& chain_code, hd_lineage const& lineage);
+    constexpr
+    hd_public(ec_compressed const& point, hd_chain_code const& chain_code, hd_lineage const& lineage) noexcept
+        : chain_(chain_code), lineage_(lineage), point_(point) {}
 
     static
     expect<hd_public> from_key_impl(hd_key const& key);

--- a/src/domain/src/wallet/hd_public.cpp
+++ b/src/domain/src/wallet/hd_public.cpp
@@ -55,17 +55,8 @@ expect<hd_public> hd_public::from_hd_key_with_prefix(hd_key const& key, uint32_t
     return from_key_impl(key, prefix);
 }
 
-hd_public::hd_public(ec_compressed const& point, hd_chain_code const& chain_code, hd_lineage const& lineage)
-    : chain_(chain_code), lineage_(lineage), point_(point)
-{}
-
 // Factories.
 // ----------------------------------------------------------------------------
-
-// static
-hd_public hd_public::from_verified_components(ec_compressed const& point, hd_chain_code const& chain_code, hd_lineage const& lineage) {
-    return hd_public(point, chain_code, lineage);
-}
 
 // static
 expect<hd_public> hd_public::from_secret(ec_secret const& secret, hd_chain_code const& chain_code, hd_lineage const& lineage) {

--- a/src/domain/test/wallet/hd_public.cpp
+++ b/src/domain/test/wallet/hd_public.cpp
@@ -14,6 +14,47 @@ using namespace kth::domain::wallet;
 
 // TODO: test altchain
 
+// Compile-time verification that `from_verified_components`, the
+// private ctor it wraps, and the three accessors are usable in a
+// constant expression. A regression that made any of them
+// runtime-only would surface as a compile error here.
+namespace {
+
+constexpr ec_compressed kSamplePoint = {{
+    0x02, 0x50, 0x86, 0x3a, 0xd6, 0x4a, 0x87, 0xae,
+    0x8a, 0x2f, 0xe8, 0x3c, 0x1a, 0xf1, 0xa8, 0x40,
+    0x3c, 0xb5, 0x3f, 0x53, 0xe4, 0x86, 0xd8, 0x51,
+    0x1d, 0xad, 0x8a, 0x04, 0x88, 0x7e, 0x5b, 0x23,
+    0x52,
+}};
+
+constexpr hd_chain_code kSampleChain = {{
+    0x87, 0x3d, 0xff, 0x81, 0xc0, 0x2f, 0x52, 0x56,
+    0x23, 0xfd, 0x1f, 0xe5, 0x16, 0x7e, 0xac, 0x3a,
+    0x55, 0xa0, 0x49, 0xde, 0x3d, 0x31, 0x4b, 0xb4,
+    0x2e, 0xe2, 0x27, 0xff, 0xed, 0x37, 0xd5, 0x08,
+}};
+
+constexpr hd_lineage kSampleLineage{
+    .prefixes = hd_public::mainnet,
+    .depth = 0,
+    .parent_fingerprint = 0,
+    .child_number = 0,
+};
+
+constexpr auto kSample = hd_public::from_verified_components(
+    kSamplePoint, kSampleChain, kSampleLineage);
+
+static_assert(kSample.point() == kSamplePoint);
+static_assert(kSample.chain_code() == kSampleChain);
+static_assert(kSample.lineage() == kSampleLineage);
+static_assert(kSample == kSample);
+static_assert(hd_public::mainnet == 76067358);
+static_assert(hd_public::testnet == 70617039);
+static_assert(hd_public::to_prefix(0x1122334455667788ULL) == 0x55667788);
+
+} // namespace
+
 constexpr char short_seed[] = "000102030405060708090a0b0c0d0e0f";
 constexpr char long_seed[] = "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542";
 


### PR DESCRIPTION
## Summary
Same shape as the ec_* / payment_address batch. The two static constants (`mainnet`, `testnet`) and the `to_prefix` version-extractor were already inline `static constexpr`. This picks up the remaining pure-value pieces:

- `from_verified_components` moves to the header as `constexpr` + `noexcept` — one line, calls the private ctor.
- The private wrapping ctor is `constexpr` + `noexcept` so `from_verified_components` can invoke it in a constant expression.
- The three read-only accessors (`chain_code`, `lineage`, `point`) pick up `constexpr`. `operator<=>` defaulted was already implicitly constexpr in C++20.

Runtime path stays runtime — `parse_from` / `from_hd_key` / `from_hd_key_with_prefix` / `from_key_impl` all decode a byte payload + call the base58 checksum path; `from_secret` reaches into secp256k1; `to_string` / `to_hd_key` / `derive_public` / `fingerprint` / `wipe` all touch base58 / secp256k1 / mutation.

## Note on hd_lineage
The private ctor takes `hd_lineage const&`. That struct is already an aggregate of four scalars (`prefixes` / `depth` / `parent_fingerprint` / `child_number`) with a defaulted `<=>`, so it's constexpr-eligible out of the box — no changes needed there.

## Verification
`test/wallet/hd_public.cpp` gains a `static_assert` block that builds a sample key via `from_verified_components` at translation time and round-trips every accessor + the static conversions.

## Test plan
- [x] `kth_domain_test` — 1,011,094 assertions / 3,869 test cases green
- [x] Compile-time `static_asserts` in the hd_public test compile