### PR TITLE
refactor(wallet): make hd_private constexpr-usable

### DIFF
--- a/src/domain/include/kth/domain/wallet/hd_private.hpp
+++ b/src/domain/include/kth/domain/wallet/hd_private.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include <kth/domain/define.hpp>
 #include <kth/domain/deserialization.hpp>
@@ -83,26 +84,36 @@ struct KD_API hd_private {
     static
     expect<hd_private> from_hd_key_with_prefixes(hd_key const& private_key, uint64_t prefixes);
 
+    /// Package a matching `hd_public` / `ec_secret` pair into an
+    /// `hd_private`. Caller is responsible for the "matches" invariant
+    /// (i.e. `public_.point()` derives from `secret`); no on-curve or
+    /// consistency check is performed here. Mirrors
+    /// `hd_public::from_verified_components`.
+    [[nodiscard]] static constexpr
+    hd_private from_verified_parts(hd_public base, ec_secret const& secret) noexcept {
+        return hd_private(std::move(base), secret);
+    }
+
     [[nodiscard]]
     friend auto operator<=>(hd_private const&, hd_private const&) = default;
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     ec_secret const& secret() const noexcept { return secret_; }
 
     /// Read-only view of the composed public-side key. Note that its
     /// `lineage().prefixes` still carries the private+public pair
     /// packed together; use `to_public()` to obtain a peer with the
     /// prefix rewritten to the public-only view.
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     hd_public const& public_key() const noexcept { return public_; }
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     hd_chain_code const& chain_code() const noexcept { return public_.chain_code(); }
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     hd_lineage const& lineage() const noexcept { return public_.lineage(); }
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     ec_compressed const& point() const noexcept { return public_.point(); }
 
     /// Base58 encoding used by `fmt::formatter<hd_private>`.
@@ -136,7 +147,9 @@ private:
 
     static expect<hd_private> from_verified_secret(ec_secret const& secret, hd_chain_code const& chain_code, hd_lineage const& lineage);
 
-    hd_private(hd_public base, ec_secret const& secret);
+    constexpr
+    hd_private(hd_public base, ec_secret const& secret) noexcept
+        : public_(std::move(base)), secret_(secret) {}
 
     hd_public public_;
     ec_secret secret_ {null_hash};

--- a/src/domain/src/wallet/hd_private.cpp
+++ b/src/domain/src/wallet/hd_private.cpp
@@ -24,11 +24,6 @@
 
 namespace kth::domain::wallet {
 
-hd_private::hd_private(hd_public base, ec_secret const& secret)
-    : public_(std::move(base))
-    , secret_(secret)
-{}
-
 // Factories.
 // ----------------------------------------------------------------------------
 

--- a/src/domain/test/wallet/hd_public.cpp
+++ b/src/domain/test/wallet/hd_public.cpp
@@ -53,6 +53,26 @@ static_assert(hd_public::mainnet == 76067358);
 static_assert(hd_public::testnet == 70617039);
 static_assert(hd_public::to_prefix(0x1122334455667788ULL) == 0x55667788);
 
+// hd_private: `from_verified_parts(hd_public, ec_secret)` mirrors
+// hd_public's `from_verified_components` — takes an already-validated
+// pair and wraps it. Constexpr all the way through.
+constexpr ec_secret kSampleSecret = {{
+    0xa2, 0xbc, 0xa8, 0x37, 0x27, 0x86, 0x7f, 0x39,
+    0x76, 0x7e, 0x18, 0x0c, 0x7e, 0x9f, 0xd4, 0x84,
+    0xef, 0x99, 0x6e, 0xe3, 0x37, 0x9a, 0xf3, 0x4b,
+    0xd2, 0x8f, 0x60, 0xe1, 0xa6, 0x36, 0x93, 0x8c,
+}};
+
+constexpr auto kSamplePriv = hd_private::from_verified_parts(kSample, kSampleSecret);
+static_assert(kSamplePriv.secret() == kSampleSecret);
+static_assert(kSamplePriv.public_key() == kSample);
+static_assert(kSamplePriv.point() == kSamplePoint);
+static_assert(kSamplePriv.chain_code() == kSampleChain);
+static_assert(kSamplePriv.lineage() == kSampleLineage);
+static_assert(kSamplePriv == kSamplePriv);
+static_assert(hd_private::mainnet == to_prefixes(76066276, hd_public::mainnet));
+static_assert(hd_private::to_prefix(0x1122334455667788ULL) == 0x11223344);
+
 } // namespace
 
 constexpr char short_seed[] = "000102030405060708090a0b0c0d0e0f";


### PR DESCRIPTION
## Summary
Same shape as #446 (hd_public). Static constants (`mainnet`, `testnet`) and `to_prefix()` were already inline `static constexpr`. This picks up the remaining pure-value pieces:

- New `from_verified_parts(hd_public, ec_secret)` static factory — `constexpr` + `noexcept`. Mirrors `hd_public::from_verified_components`: takes an already-validated pair and just wraps it. There was no public constexpr-friendly factory previously (`from_verified_secret` is private and non-trivial).
- The private wrapping ctor `hd_private(hd_public, ec_secret const&)` becomes `constexpr` + `noexcept` so `from_verified_parts` can invoke it in a constant expression. Moved from the `.cpp` to inline in the header.
- Five accessors (`secret`, `public_key`, `chain_code`, `lineage`, `point`) pick up `constexpr`. `operator<=>` defaulted was already implicitly constexpr in C++20.

Runtime path stays runtime — every `parse_from` / `from_hd_key` / `from_seed` / `from_key_impl` reaches into base58 / secp256k1; `to_string` / `to_hd_key` / `to_public` / `derive_*` / `wipe` all touch base58 / secp256k1 / mutation.

## Verification
`test/wallet/hd_public.cpp` (which already covered the paired public-side in a `namespace {}` `static_assert` block) extends the same block with an `hd_private::from_verified_parts(sample, secret)` that evaluates at translation time and round-trips every accessor. Kept in the same TU because both sides share the fixtures.

## Test plan
- [x] `kth_domain_test` — 1,011,094 assertions / 3,869 test cases green
- [x] Compile-time `static_asserts` for both hd_* sides compile