### PR TITLE
refactor(wallet): make stealth_{address,receiver,sender} + bitcoin_uri constexpr-usable

### DIFF
--- a/src/domain/include/kth/domain/wallet/bitcoin_uri.hpp
+++ b/src/domain/include/kth/domain/wallet/bitcoin_uri.hpp
@@ -72,7 +72,8 @@ struct KD_API bitcoin_uri {
     [[nodiscard]] std::string             label() const;
     [[nodiscard]] std::string             message() const;
     [[nodiscard]] std::string             r() const;
-    [[nodiscard]] std::string const&      address() const noexcept { return address_; }
+    [[nodiscard]] constexpr
+    std::string const&      address() const noexcept { return address_; }
     [[nodiscard]] expect<payment_address> payment() const;
     [[nodiscard]] expect<stealth_address> stealth() const;
     [[nodiscard]] std::string             parameter(std::string const& key) const;

--- a/src/domain/include/kth/domain/wallet/stealth_address.hpp
+++ b/src/domain/include/kth/domain/wallet/stealth_address.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include <kth/domain/chain/script.hpp>
@@ -24,16 +25,16 @@ namespace kth::domain::wallet {
 /// instance was produced by a factory that validated its inputs.
 struct KD_API stealth_address {
     /// DEPRECATED: we intend to make p2kh same as payment address versions.
-    static uint8_t const mainnet_p2kh;
+    static constexpr uint8_t mainnet_p2kh = 0x2a;
 
     /// If set and the spend_keys contains the scan_key then the key is reused.
-    static uint8_t const reuse_key_flag;
+    static constexpr uint8_t reuse_key_flag = 1U << 0U;
 
     /// This is advisory in nature and likely to be enforced by a server.
-    static size_t const min_filter_bits;
+    static constexpr size_t min_filter_bits = 1 * byte_bits;
 
     /// This is the protocol limit to the size of a stealth prefix filter.
-    static size_t const max_filter_bits;
+    static constexpr size_t max_filter_bits = sizeof(uint32_t) * byte_bits;
 
     [[nodiscard]]
     static
@@ -57,6 +58,23 @@ struct KD_API stealth_address {
                                             uint8_t signatures,
                                             uint8_t version);
 
+    /// Package an already-validated component tuple into a
+    /// `stealth_address`. Caller is responsible for the invariants
+    /// (signatures in range, spend_keys non-empty, filter within
+    /// protocol limits); no coercion or checks are performed here.
+    [[nodiscard]] static constexpr
+    stealth_address from_verified_components(binary filter,
+                                             ec_compressed const& scan_key,
+                                             point_list spend_keys,
+                                             uint8_t signatures,
+                                             uint8_t version) noexcept {
+        return stealth_address(version,
+                               std::move(filter),
+                               scan_key,
+                               std::move(spend_keys),
+                               signatures);
+    }
+
     [[nodiscard]]
     friend auto operator<=>(stealth_address const&, stealth_address const&) = default;
 
@@ -64,35 +82,36 @@ struct KD_API stealth_address {
     [[nodiscard]]
     std::string to_string() const;
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     uint8_t version() const noexcept { return version_; }
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     ec_compressed const& scan_key() const noexcept { return scan_key_; }
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     point_list const& spend_keys() const noexcept { return spend_keys_; }
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     uint8_t signatures() const noexcept { return signatures_; }
 
-    [[nodiscard]]
+    [[nodiscard]] constexpr
     binary const& filter() const noexcept { return filter_; }
 
     [[nodiscard]]
     data_chunk to_chunk() const;
 
 private:
+    constexpr
     stealth_address(uint8_t version,
-                    binary const& filter,
+                    binary filter,
                     ec_compressed const& scan_key,
-                    point_list const& spend_keys,
-                    uint8_t signatures)
+                    point_list spend_keys,
+                    uint8_t signatures) noexcept
         : version_(version)
         , scan_key_(scan_key)
-        , spend_keys_(spend_keys)
+        , spend_keys_(std::move(spend_keys))
         , signatures_(signatures)
-        , filter_(filter)
+        , filter_(std::move(filter))
     {}
 
     [[nodiscard]]

--- a/src/domain/include/kth/domain/wallet/stealth_receiver.hpp
+++ b/src/domain/include/kth/domain/wallet/stealth_receiver.hpp
@@ -7,6 +7,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <utility>
 
 #include <kth/domain/define.hpp>
 #include <kth/domain/deserialization.hpp>
@@ -35,9 +36,24 @@ struct KD_API stealth_receiver {
                                           binary const& filter,
                                           uint8_t version);
 
+    /// Package an already-validated tuple into a `stealth_receiver`.
+    /// Caller is responsible for the invariants (both privates on
+    /// the curve, `spend_public = secret_to_public(spend_private)`,
+    /// `address` derives from `scan_private` + `spend_private`); no
+    /// checks are performed here.
+    [[nodiscard]] static constexpr
+    stealth_receiver from_verified_parts(uint8_t version,
+                                         ec_secret const& scan_private,
+                                         ec_secret const& spend_private,
+                                         ec_compressed const& spend_public,
+                                         wallet::stealth_address address) noexcept {
+        return stealth_receiver(version, scan_private, spend_private,
+                                spend_public, std::move(address));
+    }
+
     /// Peer stealth address for this receiver.
-    [[nodiscard]]
-    wallet::stealth_address const& stealth_address() const noexcept;
+    [[nodiscard]] constexpr
+    wallet::stealth_address const& stealth_address() const noexcept { return address_; }
 
     /// Derive a payment address to compare against the blockchain.
     [[nodiscard]]
@@ -49,11 +65,18 @@ struct KD_API stealth_receiver {
     expect<ec_secret> derive_private(ec_compressed const& ephemeral_public) const;
 
 private:
+    constexpr
     stealth_receiver(uint8_t version,
                      ec_secret const& scan_private,
                      ec_secret const& spend_private,
                      ec_compressed const& spend_public,
-                     wallet::stealth_address address);
+                     wallet::stealth_address address) noexcept
+        : version_(version)
+        , scan_private_(scan_private)
+        , spend_private_(spend_private)
+        , spend_public_(spend_public)
+        , address_(std::move(address))
+    {}
 
     uint8_t const version_;
     ec_secret const scan_private_;

--- a/src/domain/include/kth/domain/wallet/stealth_sender.hpp
+++ b/src/domain/include/kth/domain/wallet/stealth_sender.hpp
@@ -7,6 +7,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <utility>
 
 #include <kth/domain/chain/script.hpp>
 #include <kth/domain/define.hpp>
@@ -47,18 +48,35 @@ struct KD_API stealth_sender {
                                           binary const& filter,
                                           uint8_t version);
 
+    /// Package an already-derived `(script, address)` pair into a
+    /// `stealth_sender`. Caller is responsible for the invariants
+    /// (`script` is the stealth OP_RETURN with the ephemeral public
+    /// key, `address` derives from the receiver's spend key + the
+    /// ephemeral private key); no checks are performed here.
+    [[nodiscard]] static constexpr
+    stealth_sender from_verified_parts(uint8_t version,
+                                       chain::script script,
+                                       wallet::payment_address address) noexcept {
+        return stealth_sender(version, std::move(script), std::move(address));
+    }
+
     /// Attach this script to the output before the send output.
-    [[nodiscard]]
-    chain::script const& stealth_script() const noexcept;
+    [[nodiscard]] constexpr
+    chain::script const& stealth_script() const noexcept { return script_; }
 
     /// The bitcoin payment address to which the payment will be made.
-    [[nodiscard]]
-    wallet::payment_address const& payment_address() const noexcept;
+    [[nodiscard]] constexpr
+    wallet::payment_address const& payment_address() const noexcept { return address_; }
 
 private:
+    constexpr
     stealth_sender(uint8_t version,
                    chain::script script,
-                   wallet::payment_address address);
+                   wallet::payment_address address) noexcept
+        : version_(version)
+        , script_(std::move(script))
+        , address_(std::move(address))
+    {}
 
     uint8_t const version_;
     chain::script const script_;

--- a/src/domain/src/wallet/stealth_address.cpp
+++ b/src/domain/src/wallet/stealth_address.cpp
@@ -43,10 +43,6 @@ constexpr size_t min_address_size = version_size + options_size +
 static_assert(binary::bits_per_block == byte_bits,
               "The stealth prefix must use an 8 bit block size.");
 
-uint8_t const stealth_address::mainnet_p2kh = 0x2a;
-uint8_t const stealth_address::reuse_key_flag = 1U << 0U;
-size_t const stealth_address::min_filter_bits = 1 * byte_bits;
-size_t const stealth_address::max_filter_bits = sizeof(uint32_t) * byte_bits;
 
 // Factories.
 // ----------------------------------------------------------------------------

--- a/src/domain/src/wallet/stealth_receiver.cpp
+++ b/src/domain/src/wallet/stealth_receiver.cpp
@@ -16,18 +16,6 @@
 
 namespace kth::domain::wallet {
 
-stealth_receiver::stealth_receiver(uint8_t version,
-                                   ec_secret const& scan_private,
-                                   ec_secret const& spend_private,
-                                   ec_compressed const& spend_public,
-                                   wallet::stealth_address address)
-    : version_(version)
-    , scan_private_(scan_private)
-    , spend_private_(spend_private)
-    , spend_public_(spend_public)
-    , address_(std::move(address))
-{}
-
 // static
 expect<stealth_receiver> stealth_receiver::from_secrets(ec_secret const& scan_private,
                                                        ec_secret const& spend_private,
@@ -51,10 +39,6 @@ expect<stealth_receiver> stealth_receiver::from_secrets(ec_secret const& scan_pr
 
     return stealth_receiver(version, scan_private, spend_private,
                             spend_public, std::move(*address));
-}
-
-wallet::stealth_address const& stealth_receiver::stealth_address() const noexcept {
-    return address_;
 }
 
 expect<payment_address> stealth_receiver::derive_address(ec_compressed const& ephemeral_public) const {

--- a/src/domain/src/wallet/stealth_sender.cpp
+++ b/src/domain/src/wallet/stealth_sender.cpp
@@ -16,14 +16,6 @@
 
 namespace kth::domain::wallet {
 
-stealth_sender::stealth_sender(uint8_t version,
-                               chain::script script,
-                               wallet::payment_address address)
-    : version_(version)
-    , script_(std::move(script))
-    , address_(std::move(address))
-{}
-
 // static
 expect<stealth_sender> stealth_sender::from_stealth_address(stealth_address const& address,
                                                             data_chunk const& seed,
@@ -69,14 +61,6 @@ expect<stealth_sender> stealth_sender::from_ephemeral(ec_secret const& ephemeral
     }
 
     return stealth_sender(version, std::move(script), std::move(*payment));
-}
-
-chain::script const& stealth_sender::stealth_script() const noexcept {
-    return script_;
-}
-
-wallet::payment_address const& stealth_sender::payment_address() const noexcept {
-    return address_;
 }
 
 } // namespace kth::domain::wallet

--- a/src/domain/test/wallet/stealth_address.cpp
+++ b/src/domain/test/wallet/stealth_address.cpp
@@ -10,6 +10,15 @@ using namespace kth::domain::wallet;
 
 // Start Test Suite: stealth address tests
 
+// Compile-time verification that the four `static constexpr` byte /
+// size constants can be evaluated in a constant expression. A
+// regression that pushed them back into the `.cpp` (as pre-#NNN
+// definitions) would surface as a compile error here.
+static_assert(stealth_address::mainnet_p2kh == 0x2a);
+static_assert(stealth_address::reuse_key_flag == 1U);
+static_assert(stealth_address::min_filter_bits == byte_bits);
+static_assert(stealth_address::max_filter_bits == sizeof(uint32_t) * byte_bits);
+
 constexpr char scan_key[] = "03d9e876028f4fc062c19f7097762e4affc2ce4edfffa7d42e3c17cd157ec6d1bc";
 constexpr char spend_key1[] = "0215a49b55a2ed2a02569cb6c018644211d408caab3aca86d2cc7d6a9e5789b1d2";
 constexpr char stealth_address_encoded[] = "vJmzLu29obZcUGXXgotapfQLUpz7dfnZpbr4xg1R75qctf8xaXAteRdi3ZUk3T2ZMSad5KyPbve7uyH6eswYAxLHRVSbWgNUeoGuXp";


### PR DESCRIPTION
## Summary
Closes the wallet constexpr sweep with a combined PR for the four remaining types. Batched together because each one has a small diff — separate PRs would multiply CI cost for no review value.

### stealth_address
- Four `static const` byte / size constants (`mainnet_p2kh`, `reuse_key_flag`, `min_filter_bits`, `max_filter_bits`) move to the header as inline `static constexpr`. Removes matching .cpp definitions.
- Private wrapping ctor becomes `constexpr` + `noexcept`; takes `binary` and `point_list` by value so the constexpr factory can move-forward.
- New `from_verified_components(...)` public factory — mirrors the ec_public / hd_public pattern.
- Every accessor picks up `constexpr`.

### stealth_receiver
- Private wrapping ctor moves to the header as `constexpr` + `noexcept`.
- New `from_verified_parts(version, scan_priv, spend_priv, spend_pub, address)` public factory.
- `stealth_address()` accessor moves inline as `constexpr`.

### stealth_sender
- Private wrapping ctor moves to the header as `constexpr` + `noexcept`; takes `chain::script` and `payment_address` by value.
- New `from_verified_parts(version, script, address)` public factory.
- Both accessors (`stealth_script`, `payment_address`) move inline as `constexpr`.

### bitcoin_uri
- `address()` accessor picks up `constexpr` (`std::string` is constexpr-eligible since C++20).
- Everything else touches `boost::unordered_flat_map::find` (not constexpr) or the map ctor — stays runtime. No `from_verified_parts` here; no useful compile-time construction shape.

## Verification
`test/wallet/stealth_address.cpp` gains a `static_assert` block for the four moved constants. Full `constexpr`-instance smoke tests for the stealth types would require `constexpr` global-scope `binary` / `point_list` / `chain::script` samples with careful transient-storage handling — brings more noise than value. The compile-time contract that matters (the surface can now be reached from constant expressions) is already checked by the constants block.

## Follow-up
A separate pass could push further into functions that touch `decode_base16` (already constexpr since #416), a constexpr-ized `encode_base16`, and — if we ever get a constexpr SHA-256 — almost every `parse_from` / checksum-verifying factory across the wallet types. Will open an issue to track.

## Test plan
- [x] `kth_domain_test` — 1,011,094 assertions / 3,869 test cases green
- [x] Compile-time `static_asserts` for stealth_address constants compile