### PR TITLE
refactor(domain/chain): apply valid-by-construction to point

### DIFF
--- a/src/domain/include/kth/domain/chain/point.hpp
+++ b/src/domain/include/kth/domain/chain/point.hpp
@@ -87,30 +87,17 @@ struct KD_API point {
     [[nodiscard]]
     point_iterator end() const;
 
-    // Properties (accessors, cache).
+    // Properties (accessors).
     //-------------------------------------------------------------------------
 
-    // deprecated (unsafe)
-    constexpr hash_digest& hash() {
+    [[nodiscard]]
+    constexpr hash_digest const& hash() const noexcept {
         return hash_;
     }
 
     [[nodiscard]]
-    constexpr hash_digest const& hash() const {
-        return hash_;
-    }
-
-    constexpr void set_hash(hash_digest const& value) {
-        hash_ = value;
-    }
-
-    [[nodiscard]]
-    constexpr uint32_t index() const {
+    constexpr uint32_t index() const noexcept {
         return index_;
-    }
-
-    constexpr void set_index(uint32_t value) {
-        index_ = value;
     }
 
     // Utilities.

--- a/src/domain/src/config/point.cpp
+++ b/src/domain/src/config/point.cpp
@@ -35,12 +35,10 @@ expect<point> point::parse_from(std::string_view text) {
         return std::unexpected(kth::error::illegal_value);
     }
 
-    chain::output_point op;
-    hash_digest const& txhash = digest_res->value();
-    std::copy(txhash.begin(), txhash.end(), op.hash().begin());
-    op.set_index(deserialize<uint32_t>(tokens[1], true));
-
-    return point{op};
+    return point{chain::output_point{
+        digest_res->value(),
+        deserialize<uint32_t>(tokens[1], true),
+    }};
 }
 
 std::string point::to_string() const {

--- a/src/domain/test/chain/point.cpp
+++ b/src/domain/test/chain/point.cpp
@@ -107,35 +107,6 @@ TEST_CASE("point from data roundtrip success 2", "[point]") {
 
 
 
-TEST_CASE("point hash setter 1 roundtrip success", "[point]") {
-    auto const value = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
-
-    chain::point instance{null_hash, 0u};
-    REQUIRE(value != instance.hash());
-    instance.set_hash(value);
-    REQUIRE(value == instance.hash());
-}
-
-TEST_CASE("point hash setter 2 roundtrip success", "[point]") {
-    auto const value = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
-
-    // This must be non-const.
-    auto dup_value = value;
-
-    chain::point instance{null_hash, 0u};
-    REQUIRE(value != instance.hash());
-    instance.set_hash(std::move(dup_value));
-    REQUIRE(value == instance.hash());
-}
-
-TEST_CASE("point index roundtrip success", "[point]") {
-    uint32_t value = 1254u;
-    chain::point instance{null_hash, 0u};
-    REQUIRE(value != instance.index());
-    instance.set_index(value);
-    REQUIRE(value == instance.index());
-}
-
 TEST_CASE("point operator assign equals 1 always matches equivalent", "[point]") {
     byte_reader reader(valid_raw_point);
     auto result = chain::point::from_data(reader);

--- a/src/domain/test/chain/transaction.cpp
+++ b/src/domain/test/chain/transaction.cpp
@@ -570,9 +570,7 @@ TEST_CASE("chain transaction is oversized coinbase non coinbase tx returns false
 
 TEST_CASE("chain transaction is oversized coinbase script size below min returns true", "[chain transaction]") {
     chain::transaction instance;
-    instance.inputs().emplace_back(chain::output_point{null_hash, 0u}, chain::script{}, 0u);
-    instance.inputs().back().previous_output().set_index(chain::point::null_index);
-    instance.inputs().back().previous_output().set_hash(null_hash);
+    instance.inputs().emplace_back(chain::output_point::null(), chain::script{}, 0u);
     REQUIRE(instance.is_coinbase());
     REQUIRE(instance.inputs().back().script().serialized_size(false) < min_coinbase_size);
     REQUIRE(instance.is_oversized_coinbase());
@@ -581,10 +579,8 @@ TEST_CASE("chain transaction is oversized coinbase script size below min returns
 TEST_CASE("chain transaction is oversized coinbase script size above max returns true", "[chain transaction]") {
     chain::transaction instance;
     auto& inputs = instance.inputs();
-    inputs.emplace_back(chain::output_point{}, chain::script{}, 0u);
-    inputs.back().previous_output().set_index(chain::point::null_index);
-    inputs.back().previous_output().set_hash(null_hash);
-    
+    inputs.emplace_back(chain::output_point::null(), chain::script{}, 0u);
+
     data_chunk oversized_script(max_coinbase_size + 10);
     byte_reader reader(oversized_script);
     auto result = chain::script::from_data(reader, false);
@@ -599,9 +595,7 @@ TEST_CASE("chain transaction is oversized coinbase script size above max returns
 TEST_CASE("chain transaction is oversized coinbase script size within bounds returns false", "[chain transaction]") {
     chain::transaction instance;
     auto& inputs = instance.inputs();
-    inputs.emplace_back(chain::output_point{}, chain::script{}, 0u);
-    inputs.back().previous_output().set_index(chain::point::null_index);
-    inputs.back().previous_output().set_hash(null_hash);
+    inputs.emplace_back(chain::output_point::null(), chain::script{}, 0u);
 
     data_chunk valid_script(50);
     byte_reader reader(valid_script);
@@ -632,10 +626,8 @@ TEST_CASE("chain transaction is null non coinbase no null input prevout returns 
 TEST_CASE("chain transaction is null non coinbase null input prevout returns true", "[chain transaction]") {
     chain::transaction instance;
     auto& inputs = instance.inputs();
-    inputs.emplace_back(chain::output_point{}, chain::script{}, 0u);
-    inputs.emplace_back(chain::output_point{}, chain::script{}, 0u);
-    inputs.back().previous_output().set_index(chain::point::null_index);
-    inputs.back().previous_output().set_hash(null_hash);
+    inputs.emplace_back(chain::output_point{null_hash, 0u}, chain::script{}, 0u);
+    inputs.emplace_back(chain::output_point::null(), chain::script{}, 0u);
     REQUIRE( ! instance.is_coinbase());
     REQUIRE(instance.inputs().back().previous_output().is_null());
     REQUIRE(instance.is_null_non_coinbase());


### PR DESCRIPTION
## Summary

First PR in the chain-types sweep — mirrors the pattern already applied to the wallet types (#441–#448).

Removes the mutating surface on `chain::point`:

- Drop `set_hash(hash_digest)` / `set_index(uint32_t)`.
- Drop the non-const `hash()` overload that returned a mutable
  reference to the internal digest.

`point` (and its `output_point` derivative) already offer a
`(hash, index)` constructor and a `null()` factory for the coinbase
sentinel, so there is no reason for a default-construct + late-mutate
path.

## Notes

- `config::point::parse_from` no longer builds an `output_point` by
  default-constructing and copying into the exposed hash reference —
  it uses the `(hash, index)` ctor directly.
- Three `point hash setter` / `index setter` tests are removed —
  they exercised the deleted API.
- Four `transaction` tests that built a null coinbase prevout via
  `emplace_back(output_point{}, ...); back().set_hash(null_hash);
  back().set_index(null_index);` now use `output_point::null()`.

Follow-ups (tracked separately, not in this PR):

- `output_point` still has a default ctor because several aggregate
  types (`history`, `token_genesis_params`, `utxo`,
  `config::point`) rely on it as a default-init member. See
  #390.
- The C-API generator will pick up the removed setters on the next
  bulk regen; the wallet-sweep C-API regen already tolerates this.

## Test plan

- [x] `cmake --build build/Release --target kth_domain_test`
- [x] `build/Release/src/domain/kth_domain_test` — 1,011,088 assertions in 3,866 test cases (−3 cases from the deleted setter tests)