### PR TITLE
refactor(domain/chain): make compact valid-by-construction

### DIFF
--- a/src/domain/include/kth/domain/chain/compact.hpp
+++ b/src/domain/include/kth/domain/chain/compact.hpp
@@ -5,26 +5,33 @@
 #ifndef KTH_DOMAIN_CHAIN_COMPACT_HPP
 #define KTH_DOMAIN_CHAIN_COMPACT_HPP
 
+#include <cstddef>
 #include <cstdint>
 
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/math/hash.hpp>
+#include <kth/domain/deserialization.hpp>
 
 namespace kth::domain::chain {
 
 /// A signed but zero-floored scientific notation in 32 bits.
+///
+/// Valid-by-construction: an existing `compact` always holds a target that
+/// fits in 256 bits. The fallible path (parsing an untrusted 32-bit compact
+/// number that may overflow) is `from_compact`, which returns
+/// `error::overflow` instead of a silently-flagged object.
 struct KD_API compact {
-    /// Construct a normal form compact number from a 32 bit compact number.
-    explicit
-    compact(uint32_t compact);
-
-    /// Construct a normal form compact number from a 256 bit number
+    /// Construct a normal form compact number from a 256 bit number.
+    /// Always valid: every 256-bit value has a representable compact form.
     explicit
     compact(uint256_t const& big);
 
-    /// True if construction overflowed.
-    [[nodiscard]]
-    bool is_overflowed() const;
+    /// Parse a 32 bit compact number. Returns `error::overflow` when the
+    /// exponent would shift the mantissa past 32 bytes (an invalid target
+    /// encoding). Negative encodings are consensus-floored to zero, not an
+    /// error.
+    static
+    expect<compact> from_compact(uint32_t compact);
 
     /// Consensus-normalized compact number value.
     /// This is derived from the construction parameter.
@@ -32,22 +39,22 @@ struct KD_API compact {
     uint32_t normal() const;
 
     /// Big number that the compact number represents.
-    /// This is either saved or generated from the construction parameter.
     operator uint256_t const&() const;
 
     [[nodiscard]]
     uint256_t const& big() const;
 
 private:
+    // Expands a 32-bit compact into a big number. Returns false on overflow
+    // (negatives are floored to zero and reported as success).
     static
-    bool from_compact(uint256_t& out, uint32_t compact);
+    bool expand(uint256_t& out, uint32_t compact);
 
     static
     uint32_t from_big(uint256_t const& big);
 
     uint256_t big_;
     uint32_t normal_;
-    bool overflowed_;
 };
 
 } // namespace kth::domain::chain

--- a/src/domain/src/chain/chain_state.cpp
+++ b/src/domain/src/chain/chain_state.cpp
@@ -960,16 +960,34 @@ auto select_1_3_unstable(T&& a, U&& b, V&& c, R r) {
 
 // DAA/aserti3-2d: 2020-Nov-15 Hard fork
 uint32_t chain_state::daa_aserti3_2d(data const& values, assert_anchor_block_info_t const& assert_anchor_block_info, uint32_t half_life) {
-    //TODO(fernando): pre and postconditions!
+    // Preconditions (checked in debug only; matches BCHN
+    // GetNextASERTWorkRequired):
+    //  - The ASERT anchor is an ancestor of the block being evaluated, so the
+    //    height difference is non-negative (`values.height` and the anchor
+    //    height are unsigned; a smaller `values.height` would underflow).
+    //  - `half_life` is a positive network constant; it is the divisor inside
+    //    `shifts_frac`, so zero would be a division by zero.
+    KTH_ASSERT(values.height >= assert_anchor_block_info.height);
+    KTH_ASSERT(half_life > 0);
 
-    static uint256_t const pow_limit(compact{retarget_proof_of_work_limit});
+    // `retarget_proof_of_work_limit` is a consensus constant and a valid
+    // compact encoding, so `from_compact` never fails and `.value()` cannot
+    // throw. Same rationale for every pow-limit `.value()` below.
+    static uint256_t const pow_limit(compact::from_compact(retarget_proof_of_work_limit).value());
 
     auto const time_diff = timestamp_high(values) - assert_anchor_block_info.ancestor_timestamp;
     auto const height_diff = values.height - assert_anchor_block_info.height;
 
-    uint256_t const anchor_target(compact{assert_anchor_block_info.bits});
+    // The ASERT anchor bits come from a fixed consensus checkpoint, so the
+    // compact is valid by definition and `.value()` cannot throw.
+    uint256_t const anchor_target(compact::from_compact(assert_anchor_block_info.bits).value());
 
     auto next_target = daa::aserti3_2d(anchor_target, target_spacing_seconds, time_diff, height_diff, pow_limit, half_life);
+
+    // Postcondition (matches BCHN): `aserti3_2d` clamps the target to
+    // [1, pow_limit] — a zero target is floored to 1 and anything above the
+    // limit is capped — so the result is always a valid, in-range target.
+    KTH_ASSERT(next_target >= uint256_t(1) && next_target <= pow_limit);
     return compact(next_target).normal();
 }
 
@@ -1012,7 +1030,8 @@ uint32_t chain_state::daa_cw144(data const& values) {
 
     work /= actual_timespan;
     auto next_target = (-1 * work) / work;  //Compute target result
-    uint256_t pow_limit(compact{retarget_proof_of_work_limit});
+    // Consensus pow-limit constant: valid compact, `.value()` cannot throw.
+    uint256_t pow_limit(compact::from_compact(retarget_proof_of_work_limit).value());
 
     if (next_target.compare(pow_limit) == 1) {
         return retarget_proof_of_work_limit;
@@ -1098,20 +1117,25 @@ uint32_t chain_state::work_required(data const& values, config::network network,
 
 #if defined(KTH_CURRENCY_BCH)
 uint32_t chain_state::work_required_adjust_cash(data const& values) {
-    compact const bits(bits_high(values));
-    uint256_t target(bits);
+    // Previous-block bits were already validated (non-overflowing) at block
+    // accept time, so the compact is known-good here and `.value()` cannot
+    // throw.
+    auto const bits = compact::from_compact(bits_high(values));
+    uint256_t target(bits.value());
     target = difficulty_adjustment_cash(target);  //target += (target >> 2);
-    static uint256_t const pow_limit(compact{retarget_proof_of_work_limit});
+    // Consensus pow-limit constant: valid compact, `.value()` cannot throw.
+    static uint256_t const pow_limit(compact::from_compact(retarget_proof_of_work_limit).value());
     return target > pow_limit ? retarget_proof_of_work_limit : compact(target).normal();
 }
 #endif  //KTH_CURRENCY_BCH
 
 // [CalculateNextWorkRequired]
 uint32_t chain_state::work_required_retarget(data const& values) {
-    compact const bits(bits_high(values));
+    // Previous-block bits were validated (non-overflowing) at accept time.
+    auto const bits = compact::from_compact(bits_high(values));
 
 #if defined(KTH_CURRENCY_LTC)
-    uint256_t target(bits);
+    uint256_t target(bits.value());
     static uint256_t const pow_limit("0x00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     // hash_number retarget_new;
     // retarget_new.set_compact(bits_high(values));
@@ -1139,10 +1163,11 @@ uint32_t chain_state::work_required_retarget(data const& values) {
     return target > pow_limit ? retarget_proof_of_work_limit : compact(target).normal();
 
 #else   //KTH_CURRENCY_LTC
-    static uint256_t const pow_limit(compact{retarget_proof_of_work_limit});
-    KTH_ASSERT_MSG( ! bits.is_overflowed(), "previous block has bad bits");
+    // Consensus pow-limit constant: valid compact, `.value()` cannot throw.
+    static uint256_t const pow_limit(compact::from_compact(retarget_proof_of_work_limit).value());
+    KTH_ASSERT_MSG(bits.has_value(), "previous block has bad bits");
 
-    uint256_t target(bits);
+    uint256_t target(bits.value());
     target *= retarget_timespan(values);
     target /= target_timespan_seconds;
 

--- a/src/domain/src/chain/compact.cpp
+++ b/src/domain/src/chain/compact.cpp
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 
+#include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/assert.hpp>
 
@@ -85,18 +86,17 @@ size_t logical_size(uint256_t value) {
 // Constructors
 //-----------------------------------------------------------------------------
 
-compact::compact(uint32_t compact) {
-    overflowed_ = !from_compact(big_, compact);
-    normal_ = from_big(big_);
-}
-
 compact::compact(uint256_t const& big)
-    : big_(big), overflowed_(false) {
-    normal_ = from_big(big_);
-}
+    : big_(big), normal_(from_big(big_))
+{}
 
-bool compact::is_overflowed() const {
-    return overflowed_;
+// static
+expect<compact> compact::from_compact(uint32_t compact) {
+    uint256_t big;
+    if ( ! expand(big, compact)) {
+        return std::unexpected(error::overflow);
+    }
+    return chain::compact(big);
 }
 
 uint32_t compact::normal() const {
@@ -112,7 +112,7 @@ uint256_t const& compact::big() const {
 }
 
 // Returns false on overflow, negatives are converted to zero.
-bool compact::from_compact(uint256_t& out, uint32_t compact) {
+bool compact::expand(uint256_t& out, uint32_t compact) {
     //*************************************************************************
     // CONSENSUS: The sign bit is not honored and it instead produces zero.
     // This results from having used a signed data structure for unsigned data.

--- a/src/domain/src/chain/header_members.cpp
+++ b/src/domain/src/chain/header_members.cpp
@@ -114,13 +114,13 @@ hash_digest hash(header const& hdr) {
 //-----------------------------------------------------------------------------
 
 uint256_t header::proof(uint32_t bits) {
-    compact const header_bits(bits);
+    auto const header_bits = compact::from_compact(bits);
 
-    if (header_bits.is_overflowed()) {
+    if ( ! header_bits) {
         return 0;
     }
 
-    uint256_t const& target = header_bits.big();
+    uint256_t const& target = header_bits->big();
 
     //*************************************************************************
     // CONSENSUS: satoshi will throw division by zero in the case where the
@@ -154,14 +154,17 @@ bool header::is_valid_timestamp() const {
 
 // [CheckProofOfWork]
 bool header::is_valid_proof_of_work(hash_digest const& hash, bool retarget) const {
-    compact const compact_bits(bits_);
-    static uint256_t const pow_limit(compact{work_limit(retarget)});
+    auto const compact_bits = compact::from_compact(bits_);
+    // `work_limit()` returns a consensus pow-limit constant (0x1d00ffff /
+    // 0x207fffff), which is a valid compact encoding by definition, so
+    // `from_compact` never fails here and `.value()` cannot throw.
+    static uint256_t const pow_limit(compact::from_compact(work_limit(retarget)).value());
 
-    if (compact_bits.is_overflowed()) {
+    if ( ! compact_bits) {
         return false;
     }
 
-    uint256_t const& target = compact_bits.big();
+    uint256_t const& target = compact_bits->big();
 
     // Ensure claimed work is within limits.
     if (target < 1 || target > pow_limit) {

--- a/src/domain/src/chain/header_raw.cpp
+++ b/src/domain/src/chain/header_raw.cpp
@@ -135,13 +135,13 @@ hash_digest hash(header const& hdr) {
 //-----------------------------------------------------------------------------
 
 uint256_t header::proof(uint32_t bits) {
-    compact const header_bits(bits);
+    auto const header_bits = compact::from_compact(bits);
 
-    if (header_bits.is_overflowed()) {
+    if ( ! header_bits) {
         return 0;
     }
 
-    uint256_t const& target = header_bits.big();
+    uint256_t const& target = header_bits->big();
 
     //*************************************************************************
     // CONSENSUS: satoshi will throw division by zero in the case where the
@@ -175,14 +175,17 @@ bool header::is_valid_timestamp() const {
 
 // [CheckProofOfWork]
 bool header::is_valid_proof_of_work(hash_digest const& hash, bool retarget) const {
-    compact const compact_bits(bits());
-    static uint256_t const pow_limit(compact{work_limit(retarget)});
+    auto const compact_bits = compact::from_compact(bits());
+    // `work_limit()` returns a consensus pow-limit constant (0x1d00ffff /
+    // 0x207fffff), which is a valid compact encoding by definition, so
+    // `from_compact` never fails here and `.value()` cannot throw.
+    static uint256_t const pow_limit(compact::from_compact(work_limit(retarget)).value());
 
-    if (compact_bits.is_overflowed()) {
+    if ( ! compact_bits) {
         return false;
     }
 
-    uint256_t const& target = compact_bits.big();
+    uint256_t const& target = compact_bits->big();
 
     // Ensure claimed work is within limits.
     if (target < 1 || target > pow_limit) {

--- a/src/domain/test/chain/block.cpp
+++ b/src/domain/test/chain/block.cpp
@@ -665,8 +665,9 @@ TEST_CASE("validate block is distinct tx set partialy distinct not adjacent by v
 #if defined(KTH_CURRENCY_BCH)
 TEST_CASE("validate block is cash pow valid true", "[block is distinct transaction set]") {
     constexpr uint32_t old_bits = 402736949;
-    domain::chain::compact const bits(old_bits);
-    uint256_t const target(bits);
+    auto const bits = domain::chain::compact::from_compact(old_bits);
+    REQUIRE(bits);
+    uint256_t const target(bits->big());
     REQUIRE(domain::chain::compact(domain::chain::chain_state::difficulty_adjustment_cash(target)).normal() == 402757890);
 }
 #endif  //KTH_CURRENCY_BCH

--- a/src/domain/test/chain/compact.cpp
+++ b/src/domain/test/chain/compact.cpp
@@ -28,167 +28,182 @@ static uint32_t factory(int32_t logical_exponent, bool negative, uint32_t mantis
     return exponent << 24 | (negative ? 1 : 0) << 23 | mantissa;
 }
 
-TEST_CASE("compact constructor1 proof of work limit normalizes unchanged", "[compact]") {
-    REQUIRE(compact(retarget_proof_of_work_limit).normal() == retarget_proof_of_work_limit);
+// Normalized value of a valid (non-overflowing) compact encoding. Fails the
+// test if the encoding overflows. Negative and zero-mantissa encodings are
+// consensus-floored to zero and are *valid* (they normalize to 0), distinct
+// from an overflow.
+static uint32_t normal_of(uint32_t bits) {
+    auto const c = compact::from_compact(bits);
+    REQUIRE(c);
+    return c->normal();
 }
 
-TEST_CASE("compact constructor1 no retarget proof of work limit normalizes unchanged", "[compact]") {
-    REQUIRE(compact(no_retarget_proof_of_work_limit).normal() == no_retarget_proof_of_work_limit);
+// True if the 32-bit compact encoding overflows 256 bits (an invalid target).
+static bool overflows(uint32_t bits) {
+    return ! compact::from_compact(bits);
 }
 
-// constructor1/normal
+TEST_CASE("compact from_compact proof of work limit normalizes unchanged", "[compact]") {
+    REQUIRE(normal_of(retarget_proof_of_work_limit) == retarget_proof_of_work_limit);
+}
 
-TEST_CASE("compact constructor1 negative3 exponent normalizes as expected", "[compact]") {
-    // negative, always zero
-    REQUIRE(compact(factory(-3, true, 0)).normal() == 0x00000000);
-    REQUIRE(compact(factory(-3, true, 0xff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(-3, true, 0xffff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(-3, true, 0x7fffff)).normal() == 0x00000000);
+TEST_CASE("compact from_compact no retarget proof of work limit normalizes unchanged", "[compact]") {
+    REQUIRE(normal_of(no_retarget_proof_of_work_limit) == no_retarget_proof_of_work_limit);
+}
+
+// from_compact/normal
+
+TEST_CASE("compact from_compact negative3 exponent normalizes as expected", "[compact]") {
+    // negative, always floored to zero (valid, not overflow)
+    REQUIRE(normal_of(factory(-3, true, 0)) == 0x00000000);
+    REQUIRE(normal_of(factory(-3, true, 0xff)) == 0x00000000);
+    REQUIRE(normal_of(factory(-3, true, 0xffff)) == 0x00000000);
+    REQUIRE(normal_of(factory(-3, true, 0x7fffff)) == 0x00000000);
 
     // positive
-    REQUIRE(compact(factory(-3, false, 0)).normal() == 0x00000000);
-    REQUIRE(compact(factory(-3, false, 0xff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(-3, false, 0xffff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(-3, false, 0x7fffff)).normal() == 0x00000000);
+    REQUIRE(normal_of(factory(-3, false, 0)) == 0x00000000);
+    REQUIRE(normal_of(factory(-3, false, 0xff)) == 0x00000000);
+    REQUIRE(normal_of(factory(-3, false, 0xffff)) == 0x00000000);
+    REQUIRE(normal_of(factory(-3, false, 0x7fffff)) == 0x00000000);
 }
 
-TEST_CASE("compact constructor1 negative2 exponent normalizes as expected", "[compact]") {
-    // negative, always zero
-    REQUIRE(compact(factory(-2, true, 0)).normal() == 0x00000000);
-    REQUIRE(compact(factory(-2, true, 0xff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(-2, true, 0xffff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(-2, true, 0x7fffff)).normal() == 0x00000000);
+TEST_CASE("compact from_compact negative2 exponent normalizes as expected", "[compact]") {
+    // negative, always floored to zero (valid, not overflow)
+    REQUIRE(normal_of(factory(-2, true, 0)) == 0x00000000);
+    REQUIRE(normal_of(factory(-2, true, 0xff)) == 0x00000000);
+    REQUIRE(normal_of(factory(-2, true, 0xffff)) == 0x00000000);
+    REQUIRE(normal_of(factory(-2, true, 0x7fffff)) == 0x00000000);
 
     // positive
-    REQUIRE(compact(factory(-2, false, 0)).normal() == 0x00000000);
-    REQUIRE(compact(factory(-2, false, 0xff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(-2, false, 0xffff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(-2, false, 0x7fffff)).normal() == 0x017f0000);
+    REQUIRE(normal_of(factory(-2, false, 0)) == 0x00000000);
+    REQUIRE(normal_of(factory(-2, false, 0xff)) == 0x00000000);
+    REQUIRE(normal_of(factory(-2, false, 0xffff)) == 0x00000000);
+    REQUIRE(normal_of(factory(-2, false, 0x7fffff)) == 0x017f0000);
 }
 
-TEST_CASE("compact constructor1 negative1 exponent normalizes as expected", "[compact]") {
-    // negative, always zero
-    REQUIRE(compact(factory(-1, true, 0)).normal() == 0x00000000);
-    REQUIRE(compact(factory(-1, true, 0xff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(-1, true, 0xffff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(-1, true, 0x7fffff)).normal() == 0x00000000);
+TEST_CASE("compact from_compact negative1 exponent normalizes as expected", "[compact]") {
+    // negative, always floored to zero (valid, not overflow)
+    REQUIRE(normal_of(factory(-1, true, 0)) == 0x00000000);
+    REQUIRE(normal_of(factory(-1, true, 0xff)) == 0x00000000);
+    REQUIRE(normal_of(factory(-1, true, 0xffff)) == 0x00000000);
+    REQUIRE(normal_of(factory(-1, true, 0x7fffff)) == 0x00000000);
 
     // positive
-    REQUIRE(compact(factory(-1, false, 0)).normal() == 0x00000000);
-    REQUIRE(compact(factory(-1, false, 0xff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(-1, false, 0xffff)).normal() == 0x0200ff00);
-    REQUIRE(compact(factory(-1, false, 0x7fffff)).normal() == 0x027fff00);
+    REQUIRE(normal_of(factory(-1, false, 0)) == 0x00000000);
+    REQUIRE(normal_of(factory(-1, false, 0xff)) == 0x00000000);
+    REQUIRE(normal_of(factory(-1, false, 0xffff)) == 0x0200ff00);
+    REQUIRE(normal_of(factory(-1, false, 0x7fffff)) == 0x027fff00);
 }
 
-TEST_CASE("compact constructor1 zero exponent normalizes as expected", "[compact]") {
-    // negative, always zero
-    REQUIRE(compact(factory(0, true, 0)).normal() == 0x00000000);
-    REQUIRE(compact(factory(0, true, 0xff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(0, true, 0xffff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(0, true, 0x7fffff)).normal() == 0x00000000);
+TEST_CASE("compact from_compact zero exponent normalizes as expected", "[compact]") {
+    // negative, always floored to zero (valid, not overflow)
+    REQUIRE(normal_of(factory(0, true, 0)) == 0x00000000);
+    REQUIRE(normal_of(factory(0, true, 0xff)) == 0x00000000);
+    REQUIRE(normal_of(factory(0, true, 0xffff)) == 0x00000000);
+    REQUIRE(normal_of(factory(0, true, 0x7fffff)) == 0x00000000);
 
     // positive
-    REQUIRE(compact(factory(0, false, 0)).normal() == 0x00000000);
-    REQUIRE(compact(factory(0, false, 0xff)).normal() == 0x0200ff00);
-    REQUIRE(compact(factory(0, false, 0xffff)).normal() == 0x0300ffff);
-    REQUIRE(compact(factory(0, false, 0x7fffff)).normal() == 0x037fffff);
+    REQUIRE(normal_of(factory(0, false, 0)) == 0x00000000);
+    REQUIRE(normal_of(factory(0, false, 0xff)) == 0x0200ff00);
+    REQUIRE(normal_of(factory(0, false, 0xffff)) == 0x0300ffff);
+    REQUIRE(normal_of(factory(0, false, 0x7fffff)) == 0x037fffff);
 }
 
-TEST_CASE("compact constructor1 positive1 exponent normalizes as expected", "[compact]") {
-    // negative, always zero
-    REQUIRE(compact(factory(1, true, 0)).normal() == 0x00000000);
-    REQUIRE(compact(factory(1, true, 0xff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(1, true, 0xffff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(1, true, 0x7fffff)).normal() == 0x00000000);
+TEST_CASE("compact from_compact positive1 exponent normalizes as expected", "[compact]") {
+    // negative, always floored to zero (valid, not overflow)
+    REQUIRE(normal_of(factory(1, true, 0)) == 0x00000000);
+    REQUIRE(normal_of(factory(1, true, 0xff)) == 0x00000000);
+    REQUIRE(normal_of(factory(1, true, 0xffff)) == 0x00000000);
+    REQUIRE(normal_of(factory(1, true, 0x7fffff)) == 0x00000000);
 
     // positive
-    REQUIRE(compact(factory(1, false, 0)).normal() == 0x00000000);
-    REQUIRE(compact(factory(1, false, 0xff)).normal() == 0x0300ff00);
-    REQUIRE(compact(factory(1, false, 0xffff)).normal() == 0x0400ffff);
-    REQUIRE(compact(factory(1, false, 0x7fffff)).normal() == 0x047fffff);
+    REQUIRE(normal_of(factory(1, false, 0)) == 0x00000000);
+    REQUIRE(normal_of(factory(1, false, 0xff)) == 0x0300ff00);
+    REQUIRE(normal_of(factory(1, false, 0xffff)) == 0x0400ffff);
+    REQUIRE(normal_of(factory(1, false, 0x7fffff)) == 0x047fffff);
 }
 
-TEST_CASE("compact constructor1 positive29 exponent normalizes as expected", "[compact]") {
-    // negative, always zero
-    REQUIRE(compact(factory(29, true, 0)).normal() == 0x00000000);
-    REQUIRE(compact(factory(29, true, 0xff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(29, true, 0xffff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(29, true, 0x7fffff)).normal() == 0x00000000);
+TEST_CASE("compact from_compact positive29 exponent normalizes as expected", "[compact]") {
+    // negative, always floored to zero (valid, not overflow)
+    REQUIRE(normal_of(factory(29, true, 0)) == 0x00000000);
+    REQUIRE(normal_of(factory(29, true, 0xff)) == 0x00000000);
+    REQUIRE(normal_of(factory(29, true, 0xffff)) == 0x00000000);
+    REQUIRE(normal_of(factory(29, true, 0x7fffff)) == 0x00000000);
 
     // positive
-    REQUIRE(compact(factory(29, false, 0)).normal() == 0x00000000);
-    REQUIRE(compact(factory(29, false, 0xff)).normal() == 0x1f00ff00);
-    REQUIRE(compact(factory(29, false, 0xffff)).normal() == 0x2000ffff);
-    REQUIRE(compact(factory(29, false, 0x7fffff)).normal() == 0x207fffff);
+    REQUIRE(normal_of(factory(29, false, 0)) == 0x00000000);
+    REQUIRE(normal_of(factory(29, false, 0xff)) == 0x1f00ff00);
+    REQUIRE(normal_of(factory(29, false, 0xffff)) == 0x2000ffff);
+    REQUIRE(normal_of(factory(29, false, 0x7fffff)) == 0x207fffff);
 }
 
-TEST_CASE("compact constructor1 positive30 exponent normalizes as expected", "[compact]") {
-    // negative, always zero
-    REQUIRE(compact(factory(30, true, 0)).normal() == 0x00000000);
-    REQUIRE(compact(factory(30, true, 0xff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(30, true, 0xffff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(30, true, 0x7fffff)).normal() == 0x00000000);
+TEST_CASE("compact from_compact positive30 exponent normalizes as expected", "[compact]") {
+    // negative, always floored to zero (valid, not overflow)
+    REQUIRE(normal_of(factory(30, true, 0)) == 0x00000000);
+    REQUIRE(normal_of(factory(30, true, 0xff)) == 0x00000000);
+    REQUIRE(normal_of(factory(30, true, 0xffff)) == 0x00000000);
+    REQUIRE(normal_of(factory(30, true, 0x7fffff)) == 0x00000000);
 
-    // positive, overflow above 0xffff
-    REQUIRE(compact(factory(30, false, 0)).normal() == 0x00000000);
-    REQUIRE(compact(factory(30, false, 0xff)).normal() == 0x2000ff00);
-    REQUIRE(compact(factory(30, false, 0xffff)).normal() == 0x2100ffff);
-    REQUIRE(compact(factory(30, false, 0x7fffff)).normal() == 0x00000000);
+    // positive; zero mantissa floors to zero, largest mantissa overflows
+    REQUIRE(normal_of(factory(30, false, 0)) == 0x00000000);
+    REQUIRE(normal_of(factory(30, false, 0xff)) == 0x2000ff00);
+    REQUIRE(normal_of(factory(30, false, 0xffff)) == 0x2100ffff);
+    REQUIRE(overflows(factory(30, false, 0x7fffff)));
 }
 
-TEST_CASE("compact constructor1 positive31 exponent normalizes as expected", "[compact]") {
-    // negative, always zero
-    REQUIRE(compact(factory(31, true, 0)).normal() == 0x00000000);
-    REQUIRE(compact(factory(31, true, 0xff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(31, true, 0xffff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(31, true, 0x7fffff)).normal() == 0x00000000);
+TEST_CASE("compact from_compact positive31 exponent normalizes as expected", "[compact]") {
+    // negative, always floored to zero (valid, not overflow)
+    REQUIRE(normal_of(factory(31, true, 0)) == 0x00000000);
+    REQUIRE(normal_of(factory(31, true, 0xff)) == 0x00000000);
+    REQUIRE(normal_of(factory(31, true, 0xffff)) == 0x00000000);
+    REQUIRE(normal_of(factory(31, true, 0x7fffff)) == 0x00000000);
 
-    // positive, overflow above 0xff
-    REQUIRE(compact(factory(31, false, 0)).normal() == 0x00000000);
-    REQUIRE(compact(factory(31, false, 0xff)).normal() == 0x2100ff00);
-    REQUIRE(compact(factory(31, false, 0xffff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(31, false, 0x7fffff)).normal() == 0x00000000);
+    // positive; zero mantissa floors to zero, larger mantissas overflow
+    REQUIRE(normal_of(factory(31, false, 0)) == 0x00000000);
+    REQUIRE(normal_of(factory(31, false, 0xff)) == 0x2100ff00);
+    REQUIRE(overflows(factory(31, false, 0xffff)));
+    REQUIRE(overflows(factory(31, false, 0x7fffff)));
 }
 
-TEST_CASE("compact constructor1 positive32 exponent normalizes as expected", "[compact]") {
-    // negative, always zero
-    REQUIRE(compact(factory(32, true, 0)).normal() == 0x00000000);
-    REQUIRE(compact(factory(32, true, 0xff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(32, true, 0xffff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(32, true, 0x7fffff)).normal() == 0x00000000);
+TEST_CASE("compact from_compact positive32 exponent normalizes as expected", "[compact]") {
+    // negative, always floored to zero (valid, not overflow)
+    REQUIRE(normal_of(factory(32, true, 0)) == 0x00000000);
+    REQUIRE(normal_of(factory(32, true, 0xff)) == 0x00000000);
+    REQUIRE(normal_of(factory(32, true, 0xffff)) == 0x00000000);
+    REQUIRE(normal_of(factory(32, true, 0x7fffff)) == 0x00000000);
 
-    // positive, always overflow
-    REQUIRE(compact(factory(32, false, 0)).normal() == 0x00000000);
-    REQUIRE(compact(factory(32, false, 0xff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(32, false, 0xffff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(32, false, 0x7fffff)).normal() == 0x00000000);
+    // positive; zero mantissa floors to zero, any non-zero mantissa overflows
+    REQUIRE(normal_of(factory(32, false, 0)) == 0x00000000);
+    REQUIRE(overflows(factory(32, false, 0xff)));
+    REQUIRE(overflows(factory(32, false, 0xffff)));
+    REQUIRE(overflows(factory(32, false, 0x7fffff)));
 }
 
-TEST_CASE("compact constructor1 positive252 exponent normalizes as expected", "[compact]") {
-    // negative, always zero
-    REQUIRE(compact(factory(252, true, 0)).normal() == 0x00000000);
-    REQUIRE(compact(factory(252, true, 0xff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(252, true, 0xffff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(252, true, 0x7fffff)).normal() == 0x00000000);
+TEST_CASE("compact from_compact positive252 exponent normalizes as expected", "[compact]") {
+    // negative, always floored to zero (valid, not overflow)
+    REQUIRE(normal_of(factory(252, true, 0)) == 0x00000000);
+    REQUIRE(normal_of(factory(252, true, 0xff)) == 0x00000000);
+    REQUIRE(normal_of(factory(252, true, 0xffff)) == 0x00000000);
+    REQUIRE(normal_of(factory(252, true, 0x7fffff)) == 0x00000000);
 
-    // positive, always overflow
-    REQUIRE(compact(factory(252, false, 0)).normal() == 0x00000000);
-    REQUIRE(compact(factory(252, false, 0xff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(252, false, 0xffff)).normal() == 0x00000000);
-    REQUIRE(compact(factory(252, false, 0x7fffff)).normal() == 0x00000000);
+    // positive; zero mantissa floors to zero, any non-zero mantissa overflows
+    REQUIRE(normal_of(factory(252, false, 0)) == 0x00000000);
+    REQUIRE(overflows(factory(252, false, 0xff)));
+    REQUIRE(overflows(factory(252, false, 0xffff)));
+    REQUIRE(overflows(factory(252, false, 0x7fffff)));
 }
 
-// constructor2/uint256_t
+// constructor uint256_t
 
-TEST_CASE("compact constructor2 zero round trips", "[compact]") {
+TEST_CASE("compact constructor uint256 zero round trips", "[compact]") {
     REQUIRE(uint256_t(0) == compact(uint256_t(0)));
 }
 
-TEST_CASE("compact constructor2 big value round trips", "[compact]") {
+TEST_CASE("compact constructor uint256 big value round trips", "[compact]") {
     REQUIRE(uint256_t(42) == compact(uint256_t(42)));
 }
 
-TEST_CASE("compact constructor2 hash round trips", "[compact]") {
+TEST_CASE("compact constructor uint256 hash round trips", "[compact]") {
     REQUIRE(to_uint256(primes) == compact(to_uint256(primes)));
 }
 


### PR DESCRIPTION
## Summary

Replaces the construct-then-check overflow flag on `chain::compact` with a
fallible factory, so a `compact` value always holds a target that fits in
256 bits.

- `compact(uint32_t)` (which set a hidden `overflowed_` flag) becomes
  `static expect<compact> from_compact(uint32_t)`, returning
  `error::overflow` when the exponent would shift the mantissa past 32
  bytes. Negative encodings are still consensus-floored to zero and
  reported as success — matching the previous behavior and BCHN's
  `SetCompact` (`pfOverflow`).
- Drop `is_overflowed()` and the `overflowed_` member.
- `compact(uint256_t const&)` stays a plain ctor — every 256-bit value has a
  representable compact form, so it never fails.

## Call sites

- `header::proof` / `header::is_valid_proof_of_work` (both `header_raw` and
  `header_members` impls): previous-block bits are untrusted, so they go
  through `from_compact` and bail on error (return `0` / `false`), exactly
  as the old `is_overflowed()` guard did.
- `chain_state` DAA/retarget: pow-limit constants and the ASERT anchor bits
  are consensus values (valid compact encodings by definition), and
  previous-block bits were already validated at accept time, so those sites
  use `.value()` — each annotated inline with why it cannot throw.

## Bonus

Fills the `daa_aserti3_2d` pre/postcondition TODO with debug-only
`KTH_ASSERT`s (non-negative height difference, positive half-life, and a
`[1, pow_limit]` result), matching BCHN's `GetNextASERTWorkRequired`.

## Tests

The `compact` suite is rewritten around `from_compact`, splitting the old
"overflow normalizes to 0" cases into genuine overflow (`overflows()`, now a
rejected encoding) vs. consensus-floored-to-zero (negative / zero mantissa,
still valid and normalizing to 0).

## Consensus note

This is PoW-target math. The transform is 1:1 with the prior overflow
semantics (verified against BCHN's `SetCompact` / `GetNextASERTWorkRequired`)
— no behavioral change, only the error is surfaced via `expected` instead of
a silent flag.

## Test plan

- [x] `cmake --build build/Release --target kth_domain_test`
- [x] `build/Release/src/domain/kth_domain_test` — 1,011,169 assertions in 3,863 test cases