### PR TITLE
fix(c-api): update chain point / output_point / input_point / utxo bindings

### DIFF
--- a/src/c-api/include/kth/capi/chain/input_point.h
+++ b/src/c-api/include/kth/capi/chain/input_point.h
@@ -34,9 +34,6 @@ kth_input_point_mut_t kth_chain_input_point_construct(kth_hash_t const* hash, ui
 KTH_EXPORT KTH_OWNED
 kth_input_point_mut_t kth_chain_input_point_construct_unsafe(uint8_t const* hash, uint32_t index);
 
-
-// Static factories
-
 /** @return Owned `kth_input_point_mut_t`. Caller must release with `kth_chain_input_point_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_input_point_mut_t kth_chain_input_point_null(void);
@@ -61,6 +58,24 @@ kth_input_point_mut_t kth_chain_input_point_copy(kth_input_point_const_t self);
 KTH_EXPORT
 kth_bool_t kth_chain_input_point_equals(kth_input_point_const_t self, kth_input_point_const_t other);
 
+KTH_EXPORT
+kth_bool_t kth_chain_input_point_not_equal(kth_input_point_const_t self, kth_input_point_const_t other);
+
+
+// Ordering
+
+KTH_EXPORT
+kth_bool_t kth_chain_input_point_less(kth_input_point_const_t self, kth_input_point_const_t x);
+
+KTH_EXPORT
+kth_bool_t kth_chain_input_point_greater(kth_input_point_const_t self, kth_input_point_const_t x);
+
+KTH_EXPORT
+kth_bool_t kth_chain_input_point_less_or_equal(kth_input_point_const_t self, kth_input_point_const_t x);
+
+KTH_EXPORT
+kth_bool_t kth_chain_input_point_greater_or_equal(kth_input_point_const_t self, kth_input_point_const_t x);
+
 
 // Serialization
 
@@ -82,20 +97,6 @@ uint32_t kth_chain_input_point_index(kth_input_point_const_t self);
 
 KTH_EXPORT
 uint64_t kth_chain_input_point_checksum(kth_input_point_const_t self);
-
-
-// Setters
-
-/** @param value Borrowed input; must be non-null. Copied into the resulting object; ownership of `value` stays with the caller. */
-KTH_EXPORT
-void kth_chain_input_point_set_hash(kth_input_point_mut_t self, kth_hash_t const* value);
-
-/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`. */
-KTH_EXPORT
-void kth_chain_input_point_set_hash_unsafe(kth_input_point_mut_t self, uint8_t const* value);
-
-KTH_EXPORT
-void kth_chain_input_point_set_index(kth_input_point_mut_t self, uint32_t value);
 
 
 // Predicates

--- a/src/c-api/include/kth/capi/chain/output_point.h
+++ b/src/c-api/include/kth/capi/chain/output_point.h
@@ -45,9 +45,6 @@ kth_output_point_mut_t kth_chain_output_point_construct_from_hash_index_unsafe(u
 KTH_EXPORT KTH_OWNED
 kth_output_point_mut_t kth_chain_output_point_construct_from_point(kth_point_const_t x);
 
-
-// Static factories
-
 /** @return Owned `kth_output_point_mut_t`. Caller must release with `kth_chain_output_point_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_output_point_mut_t kth_chain_output_point_null(void);
@@ -72,6 +69,24 @@ kth_output_point_mut_t kth_chain_output_point_copy(kth_output_point_const_t self
 KTH_EXPORT
 kth_bool_t kth_chain_output_point_equals(kth_output_point_const_t self, kth_output_point_const_t other);
 
+KTH_EXPORT
+kth_bool_t kth_chain_output_point_not_equal(kth_output_point_const_t self, kth_output_point_const_t other);
+
+
+// Ordering
+
+KTH_EXPORT
+kth_bool_t kth_chain_output_point_less(kth_output_point_const_t self, kth_output_point_const_t x);
+
+KTH_EXPORT
+kth_bool_t kth_chain_output_point_greater(kth_output_point_const_t self, kth_output_point_const_t x);
+
+KTH_EXPORT
+kth_bool_t kth_chain_output_point_less_or_equal(kth_output_point_const_t self, kth_output_point_const_t x);
+
+KTH_EXPORT
+kth_bool_t kth_chain_output_point_greater_or_equal(kth_output_point_const_t self, kth_output_point_const_t x);
+
 
 // Serialization
 
@@ -93,20 +108,6 @@ uint32_t kth_chain_output_point_index(kth_output_point_const_t self);
 
 KTH_EXPORT
 uint64_t kth_chain_output_point_checksum(kth_output_point_const_t self);
-
-
-// Setters
-
-/** @param value Borrowed input; must be non-null. Copied into the resulting object; ownership of `value` stays with the caller. */
-KTH_EXPORT
-void kth_chain_output_point_set_hash(kth_output_point_mut_t self, kth_hash_t const* value);
-
-/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`. */
-KTH_EXPORT
-void kth_chain_output_point_set_hash_unsafe(kth_output_point_mut_t self, uint8_t const* value);
-
-KTH_EXPORT
-void kth_chain_output_point_set_index(kth_output_point_mut_t self, uint32_t value);
 
 
 // Predicates

--- a/src/c-api/include/kth/capi/chain/point.h
+++ b/src/c-api/include/kth/capi/chain/point.h
@@ -34,9 +34,6 @@ kth_point_mut_t kth_chain_point_construct(kth_hash_t const* hash, uint32_t index
 KTH_EXPORT KTH_OWNED
 kth_point_mut_t kth_chain_point_construct_unsafe(uint8_t const* hash, uint32_t index);
 
-
-// Static factories
-
 /** @return Owned `kth_point_mut_t`. Caller must release with `kth_chain_point_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_point_mut_t kth_chain_point_null(void);
@@ -61,6 +58,24 @@ kth_point_mut_t kth_chain_point_copy(kth_point_const_t self);
 KTH_EXPORT
 kth_bool_t kth_chain_point_equals(kth_point_const_t self, kth_point_const_t other);
 
+KTH_EXPORT
+kth_bool_t kth_chain_point_not_equal(kth_point_const_t self, kth_point_const_t other);
+
+
+// Ordering
+
+KTH_EXPORT
+kth_bool_t kth_chain_point_less(kth_point_const_t self, kth_point_const_t x);
+
+KTH_EXPORT
+kth_bool_t kth_chain_point_greater(kth_point_const_t self, kth_point_const_t x);
+
+KTH_EXPORT
+kth_bool_t kth_chain_point_less_or_equal(kth_point_const_t self, kth_point_const_t x);
+
+KTH_EXPORT
+kth_bool_t kth_chain_point_greater_or_equal(kth_point_const_t self, kth_point_const_t x);
+
 
 // Serialization
 
@@ -82,20 +97,6 @@ uint32_t kth_chain_point_index(kth_point_const_t self);
 
 KTH_EXPORT
 uint64_t kth_chain_point_checksum(kth_point_const_t self);
-
-
-// Setters
-
-/** @param value Borrowed input; must be non-null. Copied into the resulting object; ownership of `value` stays with the caller. */
-KTH_EXPORT
-void kth_chain_point_set_hash(kth_point_mut_t self, kth_hash_t const* value);
-
-/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`. */
-KTH_EXPORT
-void kth_chain_point_set_hash_unsafe(kth_point_mut_t self, uint8_t const* value);
-
-KTH_EXPORT
-void kth_chain_point_set_index(kth_point_mut_t self, uint32_t value);
 
 
 // Predicates

--- a/src/c-api/include/kth/capi/chain/utxo.h
+++ b/src/c-api/include/kth/capi/chain/utxo.h
@@ -48,6 +48,24 @@ kth_utxo_mut_t kth_chain_utxo_copy(kth_utxo_const_t self);
 KTH_EXPORT
 kth_bool_t kth_chain_utxo_equals(kth_utxo_const_t self, kth_utxo_const_t other);
 
+KTH_EXPORT
+kth_bool_t kth_chain_utxo_not_equal(kth_utxo_const_t self, kth_utxo_const_t other);
+
+
+// Ordering
+
+KTH_EXPORT
+kth_bool_t kth_chain_utxo_less(kth_utxo_const_t self, kth_utxo_const_t x);
+
+KTH_EXPORT
+kth_bool_t kth_chain_utxo_greater(kth_utxo_const_t self, kth_utxo_const_t x);
+
+KTH_EXPORT
+kth_bool_t kth_chain_utxo_less_or_equal(kth_utxo_const_t self, kth_utxo_const_t x);
+
+KTH_EXPORT
+kth_bool_t kth_chain_utxo_greater_or_equal(kth_utxo_const_t self, kth_utxo_const_t x);
+
 
 // Getters
 
@@ -64,23 +82,6 @@ uint64_t kth_chain_utxo_amount(kth_utxo_const_t self);
 /** @return Borrowed `kth_token_data_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
 KTH_EXPORT
 kth_token_data_const_t kth_chain_utxo_token_data(kth_utxo_const_t self);
-
-
-// Setters
-
-KTH_EXPORT
-void kth_chain_utxo_set_height(kth_utxo_mut_t self, uint32_t height);
-
-/** @param point Borrowed input. Copied by value into the resulting object; ownership of `point` stays with the caller. */
-KTH_EXPORT
-void kth_chain_utxo_set_point(kth_utxo_mut_t self, kth_output_point_const_t point);
-
-KTH_EXPORT
-void kth_chain_utxo_set_amount(kth_utxo_mut_t self, uint64_t amount);
-
-/** @param token_data Borrowed input. Copied by value into the resulting object; ownership of `token_data` stays with the caller. */
-KTH_EXPORT
-void kth_chain_utxo_set_token_data(kth_utxo_mut_t self, kth_token_data_const_t token_data);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/src/chain/input_point.cpp
+++ b/src/c-api/src/chain/input_point.cpp
@@ -46,9 +46,6 @@ kth_input_point_mut_t kth_chain_input_point_construct_unsafe(uint8_t const* hash
     return kth::leak<cpp_t>(hash_cpp, index);
 }
 
-
-// Static factories
-
 kth_input_point_mut_t kth_chain_input_point_null(void) {
     return kth::leak(cpp_t::null());
 }
@@ -75,6 +72,39 @@ kth_bool_t kth_chain_input_point_equals(kth_input_point_const_t self, kth_input_
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(other != nullptr);
     return kth::eq<cpp_t>(self, other);
+}
+
+kth_bool_t kth_chain_input_point_not_equal(kth_input_point_const_t self, kth_input_point_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::ne<cpp_t>(self, other);
+}
+
+
+// Ordering
+
+kth_bool_t kth_chain_input_point_less(kth_input_point_const_t self, kth_input_point_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    return kth::lt<cpp_t>(self, x);
+}
+
+kth_bool_t kth_chain_input_point_greater(kth_input_point_const_t self, kth_input_point_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    return kth::gt<cpp_t>(self, x);
+}
+
+kth_bool_t kth_chain_input_point_less_or_equal(kth_input_point_const_t self, kth_input_point_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    return kth::le<cpp_t>(self, x);
+}
+
+kth_bool_t kth_chain_input_point_greater_or_equal(kth_input_point_const_t self, kth_input_point_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    return kth::ge<cpp_t>(self, x);
 }
 
 
@@ -109,28 +139,6 @@ uint32_t kth_chain_input_point_index(kth_input_point_const_t self) {
 uint64_t kth_chain_input_point_checksum(kth_input_point_const_t self) {
     KTH_PRECONDITION(self != nullptr);
     return kth::cpp_ref<cpp_t>(self).checksum();
-}
-
-
-// Setters
-
-void kth_chain_input_point_set_hash(kth_input_point_mut_t self, kth_hash_t const* value) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(value != nullptr);
-    auto const value_cpp = kth::hash_to_cpp(value->hash);
-    kth::cpp_ref<cpp_t>(self).set_hash(value_cpp);
-}
-
-void kth_chain_input_point_set_hash_unsafe(kth_input_point_mut_t self, uint8_t const* value) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(value != nullptr);
-    auto const value_cpp = kth::hash_to_cpp(value);
-    kth::cpp_ref<cpp_t>(self).set_hash(value_cpp);
-}
-
-void kth_chain_input_point_set_index(kth_input_point_mut_t self, uint32_t value) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<cpp_t>(self).set_index(value);
 }
 
 

--- a/src/c-api/src/chain/output_point.cpp
+++ b/src/c-api/src/chain/output_point.cpp
@@ -56,9 +56,6 @@ kth_output_point_mut_t kth_chain_output_point_construct_from_point(kth_point_con
     return kth::leak<cpp_t>(x_cpp);
 }
 
-
-// Static factories
-
 kth_output_point_mut_t kth_chain_output_point_null(void) {
     return kth::leak(cpp_t::null());
 }
@@ -85,6 +82,39 @@ kth_bool_t kth_chain_output_point_equals(kth_output_point_const_t self, kth_outp
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(other != nullptr);
     return kth::eq<cpp_t>(self, other);
+}
+
+kth_bool_t kth_chain_output_point_not_equal(kth_output_point_const_t self, kth_output_point_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::ne<cpp_t>(self, other);
+}
+
+
+// Ordering
+
+kth_bool_t kth_chain_output_point_less(kth_output_point_const_t self, kth_output_point_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    return kth::lt<cpp_t>(self, x);
+}
+
+kth_bool_t kth_chain_output_point_greater(kth_output_point_const_t self, kth_output_point_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    return kth::gt<cpp_t>(self, x);
+}
+
+kth_bool_t kth_chain_output_point_less_or_equal(kth_output_point_const_t self, kth_output_point_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    return kth::le<cpp_t>(self, x);
+}
+
+kth_bool_t kth_chain_output_point_greater_or_equal(kth_output_point_const_t self, kth_output_point_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    return kth::ge<cpp_t>(self, x);
 }
 
 
@@ -119,28 +149,6 @@ uint32_t kth_chain_output_point_index(kth_output_point_const_t self) {
 uint64_t kth_chain_output_point_checksum(kth_output_point_const_t self) {
     KTH_PRECONDITION(self != nullptr);
     return kth::cpp_ref<cpp_t>(self).checksum();
-}
-
-
-// Setters
-
-void kth_chain_output_point_set_hash(kth_output_point_mut_t self, kth_hash_t const* value) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(value != nullptr);
-    auto const value_cpp = kth::hash_to_cpp(value->hash);
-    kth::cpp_ref<cpp_t>(self).set_hash(value_cpp);
-}
-
-void kth_chain_output_point_set_hash_unsafe(kth_output_point_mut_t self, uint8_t const* value) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(value != nullptr);
-    auto const value_cpp = kth::hash_to_cpp(value);
-    kth::cpp_ref<cpp_t>(self).set_hash(value_cpp);
-}
-
-void kth_chain_output_point_set_index(kth_output_point_mut_t self, uint32_t value) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<cpp_t>(self).set_index(value);
 }
 
 

--- a/src/c-api/src/chain/point.cpp
+++ b/src/c-api/src/chain/point.cpp
@@ -46,9 +46,6 @@ kth_point_mut_t kth_chain_point_construct_unsafe(uint8_t const* hash, uint32_t i
     return kth::leak<cpp_t>(hash_cpp, index);
 }
 
-
-// Static factories
-
 kth_point_mut_t kth_chain_point_null(void) {
     return kth::leak(cpp_t::null());
 }
@@ -75,6 +72,39 @@ kth_bool_t kth_chain_point_equals(kth_point_const_t self, kth_point_const_t othe
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(other != nullptr);
     return kth::eq<cpp_t>(self, other);
+}
+
+kth_bool_t kth_chain_point_not_equal(kth_point_const_t self, kth_point_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::ne<cpp_t>(self, other);
+}
+
+
+// Ordering
+
+kth_bool_t kth_chain_point_less(kth_point_const_t self, kth_point_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    return kth::lt<cpp_t>(self, x);
+}
+
+kth_bool_t kth_chain_point_greater(kth_point_const_t self, kth_point_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    return kth::gt<cpp_t>(self, x);
+}
+
+kth_bool_t kth_chain_point_less_or_equal(kth_point_const_t self, kth_point_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    return kth::le<cpp_t>(self, x);
+}
+
+kth_bool_t kth_chain_point_greater_or_equal(kth_point_const_t self, kth_point_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    return kth::ge<cpp_t>(self, x);
 }
 
 
@@ -109,28 +139,6 @@ uint32_t kth_chain_point_index(kth_point_const_t self) {
 uint64_t kth_chain_point_checksum(kth_point_const_t self) {
     KTH_PRECONDITION(self != nullptr);
     return kth::cpp_ref<cpp_t>(self).checksum();
-}
-
-
-// Setters
-
-void kth_chain_point_set_hash(kth_point_mut_t self, kth_hash_t const* value) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(value != nullptr);
-    auto const value_cpp = kth::hash_to_cpp(value->hash);
-    kth::cpp_ref<cpp_t>(self).set_hash(value_cpp);
-}
-
-void kth_chain_point_set_hash_unsafe(kth_point_mut_t self, uint8_t const* value) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(value != nullptr);
-    auto const value_cpp = kth::hash_to_cpp(value);
-    kth::cpp_ref<cpp_t>(self).set_hash(value_cpp);
-}
-
-void kth_chain_point_set_index(kth_point_mut_t self, uint32_t value) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<cpp_t>(self).set_index(value);
 }
 
 

--- a/src/c-api/src/chain/utxo.cpp
+++ b/src/c-api/src/chain/utxo.cpp
@@ -54,6 +54,39 @@ kth_bool_t kth_chain_utxo_equals(kth_utxo_const_t self, kth_utxo_const_t other) 
     return kth::eq<cpp_t>(self, other);
 }
 
+kth_bool_t kth_chain_utxo_not_equal(kth_utxo_const_t self, kth_utxo_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::ne<cpp_t>(self, other);
+}
+
+
+// Ordering
+
+kth_bool_t kth_chain_utxo_less(kth_utxo_const_t self, kth_utxo_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    return kth::lt<cpp_t>(self, x);
+}
+
+kth_bool_t kth_chain_utxo_greater(kth_utxo_const_t self, kth_utxo_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    return kth::gt<cpp_t>(self, x);
+}
+
+kth_bool_t kth_chain_utxo_less_or_equal(kth_utxo_const_t self, kth_utxo_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    return kth::le<cpp_t>(self, x);
+}
+
+kth_bool_t kth_chain_utxo_greater_or_equal(kth_utxo_const_t self, kth_utxo_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    return kth::ge<cpp_t>(self, x);
+}
+
 
 // Getters
 
@@ -76,32 +109,6 @@ kth_token_data_const_t kth_chain_utxo_token_data(kth_utxo_const_t self) {
     KTH_PRECONDITION(self != nullptr);
     auto const& opt = kth::cpp_ref<cpp_t>(self).token_data();
     return opt.has_value() ? &(*opt) : nullptr;
-}
-
-
-// Setters
-
-void kth_chain_utxo_set_height(kth_utxo_mut_t self, uint32_t height) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<cpp_t>(self).set_height(height);
-}
-
-void kth_chain_utxo_set_point(kth_utxo_mut_t self, kth_output_point_const_t point) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(point != nullptr);
-    auto const& point_cpp = kth::cpp_ref<kth::domain::chain::output_point>(point);
-    kth::cpp_ref<cpp_t>(self).set_point(point_cpp);
-}
-
-void kth_chain_utxo_set_amount(kth_utxo_mut_t self, uint64_t amount) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<cpp_t>(self).set_amount(amount);
-}
-
-void kth_chain_utxo_set_token_data(kth_utxo_mut_t self, kth_token_data_const_t token_data) {
-    KTH_PRECONDITION(self != nullptr);
-    auto const token_data_cpp = kth::optional_cpp_ref<kth::domain::chain::token_data_t>(token_data);
-    kth::cpp_ref<cpp_t>(self).set_token_data(token_data_cpp);
 }
 
 } // extern "C"

--- a/src/c-api/test/chain/output_point.cpp
+++ b/src/c-api/test/chain/output_point.cpp
@@ -150,23 +150,17 @@ TEST_CASE("C-API OutputPoint - to_data fixed-size payload", "[C-API OutputPoint]
 }
 
 // ---------------------------------------------------------------------------
-// Getters / setters
+// Getters
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API OutputPoint - hash setter roundtrip", "[C-API OutputPoint]") {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_default();
-    REQUIRE(kth_hash_is_null(kth_chain_output_point_hash(op)) != 0);
-
-    kth_chain_output_point_set_hash(op, &kHash);
+TEST_CASE("C-API OutputPoint - construct exposes hash", "[C-API OutputPoint]") {
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kHash, 0u);
     REQUIRE(kth_hash_equal(kth_chain_output_point_hash(op), kHash) != 0);
-
     kth_chain_output_point_destruct(op);
 }
 
-TEST_CASE("C-API OutputPoint - index setter roundtrip", "[C-API OutputPoint]") {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_default();
-    REQUIRE(kth_chain_output_point_index(op) != 9999u);
-    kth_chain_output_point_set_index(op, 9999u);
+TEST_CASE("C-API OutputPoint - construct exposes index", "[C-API OutputPoint]") {
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kHash, 9999u);
     REQUIRE(kth_chain_output_point_index(op) == 9999u);
     kth_chain_output_point_destruct(op);
 }
@@ -291,19 +285,6 @@ TEST_CASE("C-API OutputPoint - copy null self aborts",
     KTH_EXPECT_ABORT(kth_chain_output_point_copy(NULL));
 }
 
-TEST_CASE("C-API OutputPoint - set_hash null aborts",
-          "[C-API OutputPoint][precondition]") {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_default();
-    KTH_EXPECT_ABORT(kth_chain_output_point_set_hash(op, NULL));
-    kth_chain_output_point_destruct(op);
-}
-
-TEST_CASE("C-API OutputPoint - set_hash_unsafe null aborts",
-          "[C-API OutputPoint][precondition]") {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_default();
-    KTH_EXPECT_ABORT(kth_chain_output_point_set_hash_unsafe(op, NULL));
-    kth_chain_output_point_destruct(op);
-}
 
 TEST_CASE("C-API OutputPoint - equals null self aborts",
           "[C-API OutputPoint][precondition]") {

--- a/src/c-api/test/chain/point.cpp
+++ b/src/c-api/test/chain/point.cpp
@@ -90,22 +90,17 @@ TEST_CASE("C-API Point - to_data / from_data roundtrip", "[C-API Point]") {
 }
 
 // ---------------------------------------------------------------------------
-// Getters / setters
+// Getters
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API Point - hash setter roundtrip", "[C-API Point]") {
-    kth_point_mut_t point = kth_chain_point_null();
-    REQUIRE(kth_hash_is_null(kth_chain_point_hash(point)) != 0);
-
-    kth_chain_point_set_hash(point, &kHash);
+TEST_CASE("C-API Point - construct exposes hash", "[C-API Point]") {
+    kth_point_mut_t point = kth_chain_point_construct(&kHash, 0u);
     REQUIRE(kth_hash_equal(kth_chain_point_hash(point), kHash) != 0);
-
     kth_chain_point_destruct(point);
 }
 
-TEST_CASE("C-API Point - index setter roundtrip", "[C-API Point]") {
-    kth_point_mut_t point = kth_chain_point_null();
-    kth_chain_point_set_index(point, 1254u);
+TEST_CASE("C-API Point - construct exposes index", "[C-API Point]") {
+    kth_point_mut_t point = kth_chain_point_construct(&kHash, 1254u);
     REQUIRE(kth_chain_point_index(point) == 1254u);
     kth_chain_point_destruct(point);
 }
@@ -222,20 +217,6 @@ TEST_CASE("C-API Point - to_data null out_size aborts",
 TEST_CASE("C-API Point - copy null self aborts",
           "[C-API Point][precondition]") {
     KTH_EXPECT_ABORT(kth_chain_point_copy(NULL));
-}
-
-TEST_CASE("C-API Point - set_hash null aborts",
-          "[C-API Point][precondition]") {
-    kth_point_mut_t point = kth_chain_point_null();
-    KTH_EXPECT_ABORT(kth_chain_point_set_hash(point, NULL));
-    kth_chain_point_destruct(point);
-}
-
-TEST_CASE("C-API Point - set_hash_unsafe null aborts",
-          "[C-API Point][precondition]") {
-    kth_point_mut_t point = kth_chain_point_null();
-    KTH_EXPECT_ABORT(kth_chain_point_set_hash_unsafe(point, NULL));
-    kth_chain_point_destruct(point);
 }
 
 TEST_CASE("C-API Point - equals null self aborts",

--- a/src/c-api/test/chain/utxo.cpp
+++ b/src/c-api/test/chain/utxo.cpp
@@ -97,28 +97,25 @@ TEST_CASE("C-API Utxo - copy preserves fields and equals original",
           "[C-API Utxo]") {
     kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kTxid, 3u);
     kth_utxo_mut_t u = kth_chain_utxo_construct(op, 999u, NULL);
-    kth_chain_utxo_set_height(u, 42u);
 
     kth_utxo_mut_t cp = kth_chain_utxo_copy(u);
     REQUIRE(cp != u);
 
     REQUIRE(kth_chain_utxo_equals(u, cp) != 0);
-    REQUIRE(kth_chain_utxo_height(cp) == 42u);
     REQUIRE(kth_chain_utxo_amount(cp) == 999u);
+    REQUIRE(kth_chain_output_point_index(kth_chain_utxo_point(cp)) == 3u);
 
     kth_chain_utxo_destruct(cp);
     kth_chain_utxo_destruct(u);
     kth_chain_output_point_destruct(op);
 }
 
-TEST_CASE("C-API Utxo - mutating amount breaks equality",
+TEST_CASE("C-API Utxo - differing amount is unequal",
           "[C-API Utxo]") {
     kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kTxid, 1u);
     kth_utxo_mut_t a = kth_chain_utxo_construct(op, 10u, NULL);
-    kth_utxo_mut_t b = kth_chain_utxo_copy(a);
+    kth_utxo_mut_t b = kth_chain_utxo_construct(op, 11u, NULL);
 
-    REQUIRE(kth_chain_utxo_equals(a, b) != 0);
-    kth_chain_utxo_set_amount(b, 11u);
     REQUIRE(kth_chain_utxo_equals(a, b) == 0);
 
     kth_chain_utxo_destruct(b);
@@ -126,84 +123,34 @@ TEST_CASE("C-API Utxo - mutating amount breaks equality",
     kth_chain_output_point_destruct(op);
 }
 
-TEST_CASE("C-API Utxo - mutating height breaks equality",
+TEST_CASE("C-API Utxo - differing point is unequal",
           "[C-API Utxo]") {
     kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kTxid, 1u);
-    kth_utxo_mut_t a = kth_chain_utxo_construct(op, 10u, NULL);
-    kth_utxo_mut_t b = kth_chain_utxo_copy(a);
-
-    REQUIRE(kth_chain_utxo_equals(a, b) != 0);
-    kth_chain_utxo_set_height(b, 777u);
-    REQUIRE(kth_chain_utxo_equals(a, b) == 0);
-
-    kth_chain_utxo_destruct(b);
-    kth_chain_utxo_destruct(a);
-    kth_chain_output_point_destruct(op);
-}
-
-TEST_CASE("C-API Utxo - mutating point breaks equality",
-          "[C-API Utxo]") {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kTxid, 1u);
-    kth_utxo_mut_t a = kth_chain_utxo_construct(op, 10u, NULL);
-    kth_utxo_mut_t b = kth_chain_utxo_copy(a);
-
-    REQUIRE(kth_chain_utxo_equals(a, b) != 0);
     kth_output_point_mut_t op2 = kth_chain_output_point_construct_from_hash_index(&kTxid, 99u);
-    kth_chain_utxo_set_point(b, op2);
+    kth_utxo_mut_t a = kth_chain_utxo_construct(op, 10u, NULL);
+    kth_utxo_mut_t b = kth_chain_utxo_construct(op2, 10u, NULL);
+
     REQUIRE(kth_chain_utxo_equals(a, b) == 0);
 
-    kth_chain_output_point_destruct(op2);
     kth_chain_utxo_destruct(b);
     kth_chain_utxo_destruct(a);
+    kth_chain_output_point_destruct(op2);
     kth_chain_output_point_destruct(op);
 }
 
-TEST_CASE("C-API Utxo - mutating token_data breaks equality",
+TEST_CASE("C-API Utxo - differing token_data is unequal",
           "[C-API Utxo]") {
     kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kTxid, 1u);
-    kth_utxo_mut_t a = kth_chain_utxo_construct(op, 10u, NULL);
-    kth_utxo_mut_t b = kth_chain_utxo_copy(a);
-
-    REQUIRE(kth_chain_utxo_equals(a, b) != 0);
     kth_token_data_mut_t td = kth_chain_token_make_fungible(&kCategory, 1u);
-    kth_chain_utxo_set_token_data(b, td);
+    kth_utxo_mut_t a = kth_chain_utxo_construct(op, 10u, NULL);
+    kth_utxo_mut_t b = kth_chain_utxo_construct(op, 10u, td);
+
     REQUIRE(kth_chain_utxo_equals(a, b) == 0);
 
-    kth_chain_token_data_destruct(td);
     kth_chain_utxo_destruct(b);
     kth_chain_utxo_destruct(a);
-    kth_chain_output_point_destruct(op);
-}
-
-// ---------------------------------------------------------------------------
-// Setters
-// ---------------------------------------------------------------------------
-
-TEST_CASE("C-API Utxo - setters round-trip through getters",
-          "[C-API Utxo]") {
-    kth_utxo_mut_t u = kth_chain_utxo_construct_default();
-
-    kth_chain_utxo_set_height(u, 123u);
-    kth_chain_utxo_set_amount(u, 456u);
-    REQUIRE(kth_chain_utxo_height(u) == 123u);
-    REQUIRE(kth_chain_utxo_amount(u) == 456u);
-
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kTxid, 9u);
-    kth_chain_utxo_set_point(u, op);
-    REQUIRE(kth_chain_output_point_index(kth_chain_utxo_point(u)) == 9u);
-
-    kth_token_data_mut_t td = kth_chain_token_make_fungible(&kCategory, 77u);
-    kth_chain_utxo_set_token_data(u, td);
-    REQUIRE(kth_chain_utxo_token_data(u) != NULL);
-    REQUIRE(kth_chain_token_data_get_amount(kth_chain_utxo_token_data(u)) == 77);
-
-    // Setting token_data to NULL clears the optional back to nullopt.
-    kth_chain_utxo_set_token_data(u, NULL);
-    REQUIRE(kth_chain_utxo_token_data(u) == NULL);
-
     kth_chain_token_data_destruct(td);
     kth_chain_output_point_destruct(op);
-    kth_chain_utxo_destruct(u);
 }
 
 // ---------------------------------------------------------------------------
@@ -234,25 +181,4 @@ TEST_CASE("C-API Utxo - getters null aborts",
 TEST_CASE("C-API Utxo - construct null point aborts",
           "[C-API Utxo][precondition]") {
     KTH_EXPECT_ABORT(kth_chain_utxo_construct(NULL, 0u, NULL));
-}
-
-TEST_CASE("C-API Utxo - set_point null aborts",
-          "[C-API Utxo][precondition]") {
-    kth_utxo_mut_t u = kth_chain_utxo_construct_default();
-    KTH_EXPECT_ABORT(kth_chain_utxo_set_point(u, NULL));
-    kth_chain_utxo_destruct(u);
-}
-
-TEST_CASE("C-API Utxo - setters null self aborts",
-          "[C-API Utxo][precondition]") {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kTxid, 0u);
-    kth_token_data_mut_t td = kth_chain_token_make_fungible(&kCategory, 1u);
-
-    KTH_EXPECT_ABORT(kth_chain_utxo_set_height(NULL, 1u));
-    KTH_EXPECT_ABORT(kth_chain_utxo_set_amount(NULL, 1u));
-    KTH_EXPECT_ABORT(kth_chain_utxo_set_point(NULL, op));
-    KTH_EXPECT_ABORT(kth_chain_utxo_set_token_data(NULL, td));
-
-    kth_chain_token_data_destruct(td);
-    kth_chain_output_point_destruct(op);
 }


### PR DESCRIPTION
## Summary

The valid-by-construction sweep (#450, #451) removed the mutating surface
from the underlying domain types, but the C-API bindings still referenced
it — which broke the **WebAssembly build** (the only CI job that compiles
the C-API):

- `point` / `input_point`: dropped `set_hash`, `set_hash_unsafe`, `set_index`.
- `output_point`: same setters (inherited from `point`).
- `utxo`: dropped `set_height`, `set_point`, `set_amount`, `set_token_data`.

The bindings now mirror the current domain API: the removed setters are
gone, and each type gains the ordering comparators (`_less` / `_greater` /
`_less_or_equal` / `_greater_or_equal`) that follow from the types' `<=>`.

## Tests

Updated to construct values instead of default-construct-and-set:

- `point` / `output_point`: verify hash / index straight off the constructor.
- `utxo`: compares distinct instances for the inequality cases.

The `utxo` height-mutation coverage is dropped because `utxo::height` can no
longer be set — tracked separately in #456.

## Test plan

- [x] `cmake --build build/Release --target c-api`
- [x] `cmake --build build/Release --target kth_capi_test`
- [x] `build/Release/src/c-api/kth_capi_test` — 2,797 assertions in 754 test cases