### PR TITLE
fix(domain/chain): make history_compact / history comparison usable

### DIFF
--- a/src/domain/CMakeLists.txt
+++ b/src/domain/CMakeLists.txt
@@ -561,6 +561,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         test/chain/chain_state.cpp
         test/chain/compact.cpp
         test/chain/header.cpp
+        test/chain/history.cpp
         test/chain/input.cpp
         test/chain/light_block.cpp
         test/chain/output.cpp

--- a/src/domain/include/kth/domain/chain/history.hpp
+++ b/src/domain/include/kth/domain/chain/history.hpp
@@ -44,8 +44,27 @@ struct KD_API history_compact {
         uint64_t previous_checksum;
     };
 
+    // Hand-written rather than `= default`: a defaulted comparison on a
+    // class with an anonymous union member is defined as deleted (per
+    // [class.compare.default]). Both union alternatives are `uint64_t`
+    // occupying the same bytes, so reading either one compares the same
+    // value regardless of which is "active". `==` is provided alongside
+    // because a user-defined `<=>` does not synthesize it.
     friend
-    auto operator<=>(history_compact const&, history_compact const&) = default;
+    auto operator<=>(history_compact const& x, history_compact const& y) {
+        if (auto c = x.kind <=> y.kind; c != 0) return c;
+        if (auto c = x.point <=> y.point; c != 0) return c;
+        if (auto c = x.height <=> y.height; c != 0) return c;
+        return x.value <=> y.value;
+    }
+
+    friend
+    bool operator==(history_compact const& x, history_compact const& y) {
+        return x.kind == y.kind
+            && x.point == y.point
+            && x.height == y.height
+            && x.value == y.value;
+    }
 };
 
 /// This structure is used between client and API callers in v3.
@@ -72,8 +91,26 @@ struct KD_API history {
         uint64_t temporary_checksum;
     };
 
+    // See the note on `history_compact` — hand-written for the same
+    // reason (anonymous union deletes the defaulted comparison). Both
+    // union alternatives are `uint64_t`.
     friend
-    auto operator<=>(history const&, history const&) = default;
+    auto operator<=>(history const& x, history const& y) {
+        if (auto c = x.output <=> y.output; c != 0) return c;
+        if (auto c = x.output_height <=> y.output_height; c != 0) return c;
+        if (auto c = x.value <=> y.value; c != 0) return c;
+        if (auto c = x.spend <=> y.spend; c != 0) return c;
+        return x.spend_height <=> y.spend_height;
+    }
+
+    friend
+    bool operator==(history const& x, history const& y) {
+        return x.output == y.output
+            && x.output_height == y.output_height
+            && x.value == y.value
+            && x.spend == y.spend
+            && x.spend_height == y.spend_height;
+    }
 };
 
 } // namespace kth::domain::chain

--- a/src/domain/test/chain/history.cpp
+++ b/src/domain/test/chain/history.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+using namespace kth;
+using namespace kd;
+using namespace kth::domain::chain;
+
+// Start Test Suite: history tests
+
+// These tests exist mainly to ODR-use the comparison operators. Both
+// `history_compact` and `history` carry an anonymous union, so a defaulted
+// `<=>` would be *deleted* (per [class.compare.default]) and only fail at
+// the first use — which no test previously exercised. Comparing values here
+// keeps the hand-written operators honest.
+
+static auto const hash_a = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
+static auto const hash_b = "00000000000000000000000000000000000000000000000000000000000000ff"_hash;
+
+TEST_CASE("history_compact equality and ordering", "[history]") {
+    history_compact const a{point_kind::output, {hash_a, 1}, 100, {.value = 5000}};
+    history_compact const b = a;
+    history_compact const c{point_kind::output, {hash_a, 1}, 100, {.value = 6000}};
+
+    REQUIRE(a == b);
+    REQUIRE( ! (a != b));
+    REQUIRE(a != c);
+    REQUIRE(a < c);        // differs only by the union value (5000 < 6000)
+    REQUIRE(c > a);
+    REQUIRE(a <= b);
+    REQUIRE(a >= b);
+}
+
+TEST_CASE("history_compact ordering walks fields before the union", "[history]") {
+    history_compact const lo{point_kind::output, {hash_a, 1}, 100, {.value = 9999}};
+    history_compact const hi{point_kind::output, {hash_a, 1}, 101, {.value = 0}};
+
+    // Higher `height` sorts after regardless of the (smaller) union value.
+    REQUIRE(lo < hi);
+}
+
+TEST_CASE("history equality and ordering", "[history]") {
+    history const a{output_point{hash_a, 0}, 10, 5000, input_point{hash_b, 1}, {.spend_height = 20}};
+    history const b = a;
+    history const c{output_point{hash_a, 0}, 10, 5000, input_point{hash_b, 1}, {.spend_height = 21}};
+
+    REQUIRE(a == b);
+    REQUIRE( ! (a != b));
+    REQUIRE(a != c);
+    REQUIRE(a < c);        // differs only by the union spend_height (20 < 21)
+    REQUIRE(c > a);
+    REQUIRE(a <= b);
+    REQUIRE(a >= b);
+}
+
+// End Test Suite


### PR DESCRIPTION
## Summary

Both `history_compact` and `history` carry an anonymous union (`value` /
`previous_checksum` and `spend_height` / `temporary_checksum`), so the
`friend auto operator<=>(...) = default` added in #453 is actually
**deleted** per `[class.compare.default]` — a defaulted comparison on a
class with a variant (union) member is defined as deleted, not generated.

It compiled and merged only because nothing ODR-used it. The first real use
(a `history_compact ==` in generated C-API bindings) fails with *"use of
deleted function"*.

## Fix

Replace the defaulted comparisons with hand-written `<=>` + `==` that walk
the fields and read one union alternative explicitly. Both alternatives are
`uint64_t` occupying the same bytes, so the read is well-defined regardless
of which is "active". `==` is provided alongside because a user-defined
`<=>` does not synthesize it.

Add `test/chain/history.cpp` exercising equality and ordering for both types
so the operators are **ODR-used** — a defaulted (deleted) form would now
fail at build time instead of slipping through silently.

## Test plan

- [x] `cmake --build build/Release --target kth_domain_test`
- [x] `build/Release/src/domain/kth_domain_test` — 1,011,110 assertions in 3,866 test cases