### PR TITLE
refactor(domain/chain): apply valid-by-construction to block

### DIFF
--- a/src/c-api/include/kth/capi/chain/block.h
+++ b/src/c-api/include/kth/capi/chain/block.h
@@ -16,24 +16,9 @@ extern "C" {
 
 // Constructors
 
-/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_block_mut_t kth_chain_block_construct_default(void);
-
 /** @param[out] out Must point to a null `kth_block_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_block_destruct`. Untouched on error. */
 KTH_EXPORT
 kth_error_code_t kth_chain_block_construct_from_data(uint8_t const* data, kth_size_t n, KTH_OUT_OWNED kth_block_mut_t* out);
-
-/**
- * @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`.
- * @param header Borrowed input. Copied by value into the resulting object; ownership of `header` stays with the caller.
- * @param transactions Borrowed input. Copied by value into the resulting object; ownership of `transactions` stays with the caller.
- */
-KTH_EXPORT KTH_OWNED
-kth_block_mut_t kth_chain_block_construct(kth_header_const_t header, kth_transaction_list_const_t transactions);
-
-
-// Static factories
 
 /** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
 KTH_EXPORT KTH_OWNED
@@ -59,6 +44,10 @@ kth_block_mut_t kth_chain_block_genesis_scalenet(void);
 KTH_EXPORT KTH_OWNED
 kth_block_mut_t kth_chain_block_genesis_chipnet(void);
 
+/** @param[out] out Must point to a null `kth_block_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_block_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_chain_block_create(kth_header_const_t header, kth_transaction_list_const_t transactions, KTH_OUT_OWNED kth_block_mut_t* out);
+
 
 // Destructor
 
@@ -78,6 +67,9 @@ kth_block_mut_t kth_chain_block_copy(kth_block_const_t self);
 
 KTH_EXPORT
 kth_bool_t kth_chain_block_equals(kth_block_const_t self, kth_block_const_t other);
+
+KTH_EXPORT
+kth_bool_t kth_chain_block_not_equal(kth_block_const_t self, kth_block_const_t other);
 
 
 // Serialization
@@ -138,15 +130,8 @@ kth_size_t kth_chain_block_non_coinbase_input_count(kth_block_const_t self);
 KTH_EXPORT
 void kth_chain_block_set_transactions(kth_block_mut_t self, kth_transaction_list_const_t value);
 
-/** @param value Borrowed input. Copied by value into the resulting object; ownership of `value` stays with the caller. */
-KTH_EXPORT
-void kth_chain_block_set_header(kth_block_mut_t self, kth_header_const_t value);
-
 
 // Predicates
-
-KTH_EXPORT
-kth_bool_t kth_chain_block_is_valid(kth_block_const_t self);
 
 KTH_EXPORT
 kth_bool_t kth_chain_block_is_extra_coinbases(kth_block_const_t self);
@@ -186,9 +171,6 @@ uint64_t kth_chain_block_reward(kth_block_const_t self, kth_size_t height);
 
 KTH_EXPORT
 kth_size_t kth_chain_block_signature_operations(kth_block_const_t self, kth_bool_t bip16, kth_bool_t bip141);
-
-KTH_EXPORT
-void kth_chain_block_reset(kth_block_mut_t self);
 
 
 // Static utilities

--- a/src/c-api/include/kth/capi/error.h
+++ b/src/c-api/include/kth/capi/error.h
@@ -252,6 +252,11 @@ typedef enum kth_error_code {
     kth_ec_bad_merkle_block_count,
     kth_ec_illegal_value,
 
+    // Valid-by-construction guard: `block::create` was given parts that would
+    // be the empty sentinel (no transactions and an all-zero header). Distinct
+    // from the consensus `empty_block` check performed during validation.
+    kth_ec_block_construction_empty,
+
     // Database cache
     kth_ec_height_not_found,
     kth_ec_hash_not_found,

--- a/src/c-api/src/chain/block.cpp
+++ b/src/c-api/src/chain/block.cpp
@@ -22,10 +22,6 @@ extern "C" {
 
 // Constructors
 
-kth_block_mut_t kth_chain_block_construct_default(void) {
-    return kth::leak<cpp_t>();
-}
-
 kth_error_code_t kth_chain_block_construct_from_data(uint8_t const* data, kth_size_t n, KTH_OUT_OWNED kth_block_mut_t* out) {
     KTH_PRECONDITION(data != nullptr || n == 0);
     KTH_PRECONDITION(out != nullptr);
@@ -36,17 +32,6 @@ kth_error_code_t kth_chain_block_construct_from_data(uint8_t const* data, kth_si
     *out = kth::leak(std::move(*result));
     return kth_ec_success;
 }
-
-kth_block_mut_t kth_chain_block_construct(kth_header_const_t header, kth_transaction_list_const_t transactions) {
-    KTH_PRECONDITION(header != nullptr);
-    KTH_PRECONDITION(transactions != nullptr);
-    auto const& header_cpp = kth::cpp_ref<kth::domain::chain::header>(header);
-    auto const& transactions_cpp = kth::cpp_ref<kth::domain::chain::transaction::list>(transactions);
-    return kth::leak<cpp_t>(header_cpp, transactions_cpp);
-}
-
-
-// Static factories
 
 kth_block_mut_t kth_chain_block_genesis_mainnet(void) {
     return kth::leak(cpp_t::genesis_mainnet());
@@ -72,6 +57,19 @@ kth_block_mut_t kth_chain_block_genesis_chipnet(void) {
     return kth::leak(cpp_t::genesis_chipnet());
 }
 
+kth_error_code_t kth_chain_block_create(kth_header_const_t header, kth_transaction_list_const_t transactions, KTH_OUT_OWNED kth_block_mut_t* out) {
+    KTH_PRECONDITION(header != nullptr);
+    KTH_PRECONDITION(transactions != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const& header_cpp = kth::cpp_ref<kth::domain::chain::header>(header);
+    auto const& transactions_cpp = kth::cpp_ref<kth::domain::chain::transaction::list>(transactions);
+    auto result = cpp_t::create(header_cpp, transactions_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
 
 // Destructor
 
@@ -94,6 +92,12 @@ kth_bool_t kth_chain_block_equals(kth_block_const_t self, kth_block_const_t othe
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(other != nullptr);
     return kth::eq<cpp_t>(self, other);
+}
+
+kth_bool_t kth_chain_block_not_equal(kth_block_const_t self, kth_block_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::ne<cpp_t>(self, other);
 }
 
 
@@ -183,20 +187,8 @@ void kth_chain_block_set_transactions(kth_block_mut_t self, kth_transaction_list
     kth::cpp_ref<cpp_t>(self).set_transactions(value_cpp);
 }
 
-void kth_chain_block_set_header(kth_block_mut_t self, kth_header_const_t value) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(value != nullptr);
-    auto const& value_cpp = kth::cpp_ref<kth::domain::chain::header>(value);
-    kth::cpp_ref<cpp_t>(self).set_header(value_cpp);
-}
-
 
 // Predicates
-
-kth_bool_t kth_chain_block_is_valid(kth_block_const_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_valid());
-}
 
 kth_bool_t kth_chain_block_is_extra_coinbases(kth_block_const_t self) {
     KTH_PRECONDITION(self != nullptr);
@@ -266,11 +258,6 @@ kth_size_t kth_chain_block_signature_operations(kth_block_const_t self, kth_bool
     auto const bip16_cpp = kth::int_to_bool(bip16);
     auto const bip141_cpp = kth::int_to_bool(bip141);
     return kth::cpp_ref<cpp_t>(self).signature_operations(bip16_cpp, bip141_cpp);
-}
-
-void kth_chain_block_reset(kth_block_mut_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<cpp_t>(self).reset();
 }
 
 

--- a/src/c-api/test/chain/block.cpp
+++ b/src/c-api/test/chain/block.cpp
@@ -21,32 +21,28 @@
 #include <kth/capi/primitives.h>
 
 #include "../test_helpers.hpp"
-
-// ---------------------------------------------------------------------------
-// Helpers — use genesis_mainnet as the canonical test block.
-// ---------------------------------------------------------------------------
-
-static kth_block_mut_t make_block(void) {
-    kth_block_mut_t blk = kth_chain_block_genesis_mainnet();
-    REQUIRE(blk != NULL);
-    return blk;
-}
+#include "block_fixtures.hpp"
 
 // ---------------------------------------------------------------------------
 // Constructors / lifecycle
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API Block - default construct is invalid",
+TEST_CASE("C-API Block - create rejects the empty sentinel",
           "[C-API Block]") {
-    kth_block_mut_t blk = kth_chain_block_construct_default();
-    REQUIRE(kth_chain_block_is_valid(blk) == 0);
-    kth_chain_block_destruct(blk);
+    kth_header_mut_t h = kth_chain_header_construct_default();
+    kth_transaction_list_mut_t txs = kth_chain_transaction_list_construct_default();
+    kth_block_mut_t blk = NULL;
+    kth_error_code_t ec = kth_chain_block_create(h, txs, &blk);
+    REQUIRE(ec != kth_ec_success);
+    REQUIRE(blk == NULL);
+    kth_chain_header_destruct(h);
+    kth_chain_transaction_list_destruct(txs);
 }
 
 TEST_CASE("C-API Block - genesis mainnet is valid",
           "[C-API Block]") {
     kth_block_mut_t blk = make_block();
-    REQUIRE(kth_chain_block_is_valid(blk) != 0);
+    REQUIRE(kth_chain_block_is_valid_merkle_root(blk) != 0);
     kth_chain_block_destruct(blk);
 }
 
@@ -83,7 +79,6 @@ TEST_CASE("C-API Block - to_data / from_data roundtrip",
     kth_error_code_t ec = kth_chain_block_construct_from_data(raw, size, &parsed);
     REQUIRE(ec == kth_ec_success);
     REQUIRE(parsed != NULL);
-    REQUIRE(kth_chain_block_is_valid(parsed) != 0);
     REQUIRE(kth_chain_block_equals(expected, parsed) != 0);
 
     kth_core_destruct_array(raw);
@@ -147,7 +142,7 @@ TEST_CASE("C-API Block - genesis has valid merkle root",
 
 TEST_CASE("C-API Block - default is not extra coinbases",
           "[C-API Block]") {
-    kth_block_mut_t blk = kth_chain_block_construct_default();
+    kth_block_mut_t blk = make_minimal_block();
     REQUIRE(kth_chain_block_is_extra_coinbases(blk) == 0);
     kth_chain_block_destruct(blk);
 }
@@ -161,7 +156,6 @@ TEST_CASE("C-API Block - copy preserves fields",
     kth_block_mut_t original = make_block();
     kth_block_mut_t copy = kth_chain_block_copy(original);
 
-    REQUIRE(kth_chain_block_is_valid(copy) != 0);
     REQUIRE(kth_chain_block_equals(original, copy) != 0);
 
     kth_chain_block_destruct(copy);
@@ -172,7 +166,7 @@ TEST_CASE("C-API Block - equals identical blocks is true, different is false",
           "[C-API Block]") {
     kth_block_mut_t a = make_block();
     kth_block_mut_t b = make_block();
-    kth_block_mut_t c = kth_chain_block_construct_default();
+    kth_block_mut_t c = make_minimal_block();
 
     REQUIRE(kth_chain_block_equals(a, b) != 0);
     REQUIRE(kth_chain_block_equals(a, c) == 0);
@@ -208,7 +202,7 @@ TEST_CASE("C-API Block - copy null self aborts",
 
 TEST_CASE("C-API Block - to_data_simple null out_size aborts",
           "[C-API Block][precondition]") {
-    kth_block_mut_t blk = kth_chain_block_construct_default();
+    kth_block_mut_t blk = make_minimal_block();
     KTH_EXPECT_ABORT(kth_chain_block_to_data(blk, NULL));
     kth_chain_block_destruct(blk);
 }

--- a/src/c-api/test/chain/block_fixtures.hpp
+++ b/src/c-api/test/chain/block_fixtures.hpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_TEST_CHAIN_BLOCK_FIXTURES_HPP_
+#define KTH_CAPI_TEST_CHAIN_BLOCK_FIXTURES_HPP_
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <kth/capi/chain/block.h>
+#include <kth/capi/chain/header.h>
+#include <kth/capi/chain/transaction_list.h>
+#include <kth/capi/hash.h>
+#include <kth/capi/primitives.h>
+
+// The canonical valid test block (genesis mainnet).
+inline kth_block_mut_t make_block(void) {
+    kth_block_mut_t blk = kth_chain_block_genesis_mainnet();
+    REQUIRE(blk != NULL);
+    return blk;
+}
+
+// A minimal valid block: a non-zero header, no transactions. Distinct from
+// genesis, so it doubles as the "other" block for inequality tests.
+inline kth_block_mut_t make_minimal_block(void) {
+    static kth_hash_t const zero_hash = {{0}};
+    kth_header_mut_t h = kth_chain_header_construct(1u, &zero_hash, &zero_hash, 0u, 0u, 0u);
+    kth_transaction_list_mut_t txs = kth_chain_transaction_list_construct_default();
+    kth_block_mut_t blk = NULL;
+    kth_error_code_t ec = kth_chain_block_create(h, txs, &blk);
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(blk != NULL);
+    kth_chain_header_destruct(h);
+    kth_chain_transaction_list_destruct(txs);
+    return blk;
+}
+
+#endif // KTH_CAPI_TEST_CHAIN_BLOCK_FIXTURES_HPP_

--- a/src/c-api/test/chain/block_list.cpp
+++ b/src/c-api/test/chain/block_list.cpp
@@ -9,15 +9,12 @@
 
 #include <kth/capi/chain/block.h>
 #include <kth/capi/chain/block_list.h>
+#include <kth/capi/chain/header.h>
+#include <kth/capi/chain/transaction_list.h>
 #include <kth/capi/primitives.h>
 
 #include "../test_helpers.hpp"
-
-static kth_block_mut_t make_block(void) {
-    kth_block_mut_t blk = kth_chain_block_genesis_mainnet();
-    REQUIRE(blk != NULL);
-    return blk;
-}
+#include "block_fixtures.hpp"
 
 // ---------------------------------------------------------------------------
 // Lifecycle
@@ -64,7 +61,7 @@ TEST_CASE("C-API BlockList - nth returns borrowed element",
 
     kth_block_const_t elem = kth_chain_block_list_nth(list, 0);
     REQUIRE(elem != NULL);
-    REQUIRE(kth_chain_block_is_valid(elem) != 0);
+    REQUIRE(kth_chain_block_is_valid_merkle_root(elem) != 0);
 
     kth_chain_block_list_destruct(list);
 }
@@ -77,13 +74,13 @@ TEST_CASE("C-API BlockList - assign_at replaces element",
           "[C-API BlockList]") {
     kth_block_list_mut_t list = kth_chain_block_list_construct_default();
     kth_block_mut_t blk = make_block();
-    kth_block_mut_t def = kth_chain_block_construct_default();
+    kth_block_mut_t def = make_minimal_block();
 
     kth_chain_block_list_push_back(list, def);
-    REQUIRE(kth_chain_block_is_valid(kth_chain_block_list_nth(list, 0)) == 0);
+    REQUIRE(kth_chain_block_equals(kth_chain_block_list_nth(list, 0), blk) == 0);
 
     kth_chain_block_list_assign_at(list, 0, blk);
-    REQUIRE(kth_chain_block_is_valid(kth_chain_block_list_nth(list, 0)) != 0);
+    REQUIRE(kth_chain_block_equals(kth_chain_block_list_nth(list, 0), blk) != 0);
 
     kth_chain_block_destruct(def);
     kth_chain_block_destruct(blk);

--- a/src/domain/include/kth/domain/chain/block.hpp
+++ b/src/domain/include/kth/domain/chain/block.hpp
@@ -63,9 +63,11 @@ public:
     // Constructors.
     //-------------------------------------------------------------------------
 
-    block() = default;
-    block(chain::header const& header, transaction::list&& transactions);
-    block(chain::header const& header, transaction::list const& transactions);
+    /// The only way to build a block from parts. Returns `error::empty_block`
+    /// when the result would be the empty sentinel (no transactions and an
+    /// all-zero header), so a constructed `block` is always a real block.
+    static
+    expect<block> create(chain::header header, transaction::list transactions);
 
     // Operators.
     //-------------------------------------------------------------------------
@@ -92,12 +94,8 @@ public:
     // Properties (accessors).
     //-------------------------------------------------------------------------
 
-    chain::header& header();
-
     [[nodiscard]]
     chain::header const& header() const;
-
-    void set_header(chain::header const& value);
 
     transaction::list& transactions();
 
@@ -144,9 +142,6 @@ public:
 
     // Validation.
     //-------------------------------------------------------------------------
-
-    [[nodiscard]]
-    bool is_valid() const;
 
     static
     uint64_t subsidy(size_t height, bool retarget);
@@ -217,13 +212,15 @@ public:
     // THIS IS FOR LIBRARY USE ONLY, DO NOT CREATE A DEPENDENCY ON IT.
     mutable validation_t validation{};
 
-// protected:
-    void reset();
-
     [[nodiscard]]
     size_t non_coinbase_input_count() const;
 
 private:
+    // Construction goes through `create` / `from_data` / `genesis_*`, which
+    // guarantee a non-sentinel block; these do the actual member init.
+    block(chain::header const& header, transaction::list&& transactions);
+    block(chain::header const& header, transaction::list const& transactions);
+
     chain::header header_;
     transaction::list transactions_;
 };

--- a/src/domain/include/kth/domain/message/block.hpp
+++ b/src/domain/include/kth/domain/message/block.hpp
@@ -32,13 +32,14 @@ public:
     using const_ptr_list_ptr = std::shared_ptr<const_ptr_list>;
     using const_ptr_list_const_ptr = std::shared_ptr<const const_ptr_list>;
 
-    block() = default;
-
+    // Wrapping an already-constructed (hence valid) chain::block.
     block(chain::block const& x);
     block(chain::block&& x);
 
-    block(chain::header const& header, chain::transaction::list&& transactions);
-    block(chain::header const& header, chain::transaction::list const& transactions);
+    /// Build from parts. Mirrors `chain::block::create`: returns
+    /// `error::block_construction_empty` for the empty sentinel.
+    static
+    expect<block> create(chain::header header, chain::transaction::list transactions);
 
     block& operator=(chain::block&& x);
 

--- a/src/domain/src/chain/block.cpp
+++ b/src/domain/src/chain/block.cpp
@@ -185,6 +185,16 @@ block::block(chain::header const& header, transaction::list&& transactions)
     , transactions_(std::move(transactions))
 {}
 
+// static
+expect<block> block::create(chain::header header, transaction::list transactions) {
+    // Reject the empty sentinel (what the old `is_valid()` guarded against):
+    // a block with no transactions and an all-zero header is not a block.
+    if (transactions.empty() && ! header.is_valid()) {
+        return std::unexpected(error::block_construction_empty);
+    }
+    return block{header, std::move(transactions)};
+}
+
 // Operators.
 //-----------------------------------------------------------------------------
 
@@ -207,9 +217,12 @@ expect<block> block::from_data(byte_reader& reader) {
         return std::unexpected(txs.error());
     }
     auto const end_deserialize = asio::steady_clock::now();
-    block res {*hdr, std::move(*txs)};
-    res.validation.start_deserialize = start_deserialize;
-    res.validation.end_deserialize = end_deserialize;
+    auto res = create(*hdr, std::move(*txs));
+    if ( ! res) {
+        return std::unexpected(res.error());
+    }
+    res->validation.start_deserialize = start_deserialize;
+    res->validation.end_deserialize = end_deserialize;
     return res;
 }
 
@@ -220,16 +233,6 @@ expect<void> block::to_data(byte_writer& writer) const {
         if (auto r = tx.to_data(writer, true); ! r) return r;
     }
     return {};
-}
-
-void block::reset() {
-    header_ = chain::header{};
-    transactions_.clear();
-    transactions_.shrink_to_fit();
-}
-
-bool block::is_valid() const {
-    return !transactions_.empty() || header_.is_valid();
 }
 
 hash_list block::to_hashes() const {
@@ -252,19 +255,8 @@ size_t block::serialized_size() const {
     return chain::serialized_size(*this);
 }
 
-chain::header& block::header() {
-    return header_;
-}
-
 chain::header const& block::header() const {
     return header_;
-}
-
-// TODO(legacy): must call header.set_merkle(generate_merkle_root()) though this may
-// be very suboptimal if the block is being constructed. First verify that all
-// current uses will not be impacted and if so change them to use constructor.
-void block::set_header(chain::header const& value) {
-    header_ = value;
 }
 
 transaction::list& block::transactions() {
@@ -299,7 +291,6 @@ chain::block genesis_generic(std::string const& raw_data) {
     auto genesis = block::from_data(reader);
 
     KTH_ASSERT(genesis);
-    KTH_ASSERT(genesis->is_valid());
     KTH_ASSERT(genesis->transactions().size() == 1);
     KTH_ASSERT(genesis->generate_merkle_root() == genesis->header().merkle());
 

--- a/src/domain/src/message/block.cpp
+++ b/src/domain/src/message/block.cpp
@@ -28,20 +28,20 @@ block::block(chain::block const& x)
     : chain::block(x)
 {}
 
-block::block(chain::header const& header, chain::transaction::list&& transactions)
-    : chain::block(header, std::move(transactions))
-{}
-
-block::block(chain::header const& header, chain::transaction::list const& transactions)
-    : chain::block(header, transactions)
-{}
+// static
+expect<block> block::create(chain::header header, chain::transaction::list transactions) {
+    auto base = chain::block::create(std::move(header), std::move(transactions));
+    if ( ! base) {
+        return std::unexpected(base.error());
+    }
+    return block{std::move(*base)};
+}
 
 // block::block(block&& x) noexcept
 //     : chain::block(std::move(x))
 // {}
 
 block& block::operator=(chain::block&& x) {
-    reset();
     chain::block::operator=(std::move(x));
     return *this;
 }

--- a/src/domain/test/chain/block.cpp
+++ b/src/domain/test/chain/block.cpp
@@ -30,6 +30,13 @@ bool all_valid(chain::transaction::list const& transactions) {
     return valid;
 }
 
+// A block with a non-zero header (so `create` accepts it) and the given
+// transactions. Replaces the old default-construct-then-set idiom.
+chain::block make_block(chain::transaction::list txs = {}) {
+    return chain::block::create(
+        chain::header{1u, null_hash, null_hash, 0u, 0u, 0u}, std::move(txs)).value();
+}
+
 } // anonymous namespace
 
 // Start Test Suite: chain block tests
@@ -69,12 +76,13 @@ TEST_CASE("block locator heights positive backoff returns top plus log offset to
     REQUIRE(expected == result);
 }
 
-TEST_CASE("block constructor 1 always invalid", "[chain block]") {
-    chain::block const instance;
-    REQUIRE( ! instance.is_valid());
+TEST_CASE("block create rejects the empty sentinel", "[chain block]") {
+    // No transactions and an all-zero header is not a block.
+    REQUIRE( ! chain::block::create(chain::header{}, {}));
+    REQUIRE(chain::block::create(chain::header{}, {}).error() == error::block_construction_empty);
 }
 
-TEST_CASE("block constructor 2 always equals params", "[chain block]") {
+TEST_CASE("block create 2 always equals params", "[chain block]") {
     chain::header const header {
         10u,
         "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
@@ -90,13 +98,12 @@ TEST_CASE("block constructor 2 always equals params", "[chain block]") {
         chain::transaction(4, 16, {}, {})
     };
 
-    chain::block const instance(header, transactions);
-    REQUIRE(instance.is_valid());
+    auto const instance = chain::block::create(header, transactions).value();
     REQUIRE(header == instance.header());
     REQUIRE(transactions == instance.transactions());
 }
 
-TEST_CASE("block constructor 3 always equals params", "[chain block]") {
+TEST_CASE("block create 3 always equals params", "[chain block]") {
     chain::header const header {
         10u,
         "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
@@ -116,17 +123,13 @@ TEST_CASE("block constructor 3 always equals params", "[chain block]") {
     chain::header dup_header(header);
     chain::transaction::list dup_transactions(transactions);
 
-    chain::block const instance {
-        std::move(dup_header), 
-        std::move(dup_transactions)
-    };
+    auto const instance = chain::block::create(std::move(dup_header), std::move(dup_transactions)).value();
 
-    REQUIRE(instance.is_valid());
     REQUIRE(header == instance.header());
     REQUIRE(transactions == instance.transactions());
 }
 
-TEST_CASE("block constructor 4 always equals params", "[chain block]") {
+TEST_CASE("block copy 4 always equals params", "[chain block]") {
     chain::header const header {
         10u,
         "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
@@ -142,15 +145,14 @@ TEST_CASE("block constructor 4 always equals params", "[chain block]") {
         chain::transaction(4, 16, {}, {})
     };
 
-    chain::block const value(header, transactions);
+    auto const value = chain::block::create(header, transactions).value();
     chain::block const instance(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(value == instance);
     REQUIRE(header == instance.header());
     REQUIRE(transactions == instance.transactions());
 }
 
-TEST_CASE("block constructor 5 always equals params", "[chain block]") {
+TEST_CASE("block move 5 always equals params", "[chain block]") {
     chain::header const header {
         10u,
         "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
@@ -167,27 +169,26 @@ TEST_CASE("block constructor 5 always equals params", "[chain block]") {
     };
 
     // This must be non-const.
-    chain::block value(header, transactions);
+    auto value = chain::block::create(header, transactions).value();
 
     chain::block const instance(std::move(value));
 
-    REQUIRE(instance.is_valid());
     REQUIRE(header == instance.header());
     REQUIRE(transactions == instance.transactions());
 }
 
 TEST_CASE("block hash always returns header hash", "[chain block]") {
-    chain::block const instance;
+    auto const instance = chain::block::create(chain::header{1u, null_hash, null_hash, 0u, 0u, 0u}, {}).value();
     REQUIRE(chain::hash(instance.header()) == instance.hash());
 }
 
 TEST_CASE("block is valid merkle root uninitialized returns true", "[chain block]") {
-    chain::block const instance;
+    auto const instance = make_block();
     REQUIRE(instance.is_valid_merkle_root());
 }
 
 TEST_CASE("block is valid merkle root non empty tx invalid block returns false", "[chain block]") {
-    chain::block instance;
+    auto instance = make_block();
     instance.set_transactions(chain::transaction::list{chain::transaction{}});
     REQUIRE( ! instance.is_valid_merkle_root());
 }
@@ -247,21 +248,18 @@ TEST_CASE("block from data insufficient transaction bytes failure", "[block seri
 
 TEST_CASE("block genesis mainnet valid structure", "[block serialization]") {
     auto const genesis = chain::block::genesis_mainnet();
-    REQUIRE(genesis.is_valid());
     REQUIRE(genesis.transactions().size() == 1u);
     REQUIRE(genesis.header().merkle() == genesis.generate_merkle_root());
 }
 
 TEST_CASE("block genesis testnet valid structure", "[block serialization]") {
     auto const genesis = chain::block::genesis_testnet();
-    REQUIRE(genesis.is_valid());
     REQUIRE(genesis.transactions().size() == 1u);
     REQUIRE(genesis.header().merkle() == genesis.generate_merkle_root());
 }
 
 TEST_CASE("block genesis regtest valid structure", "[block serialization]") {
     auto const genesis = chain::block::genesis_regtest();
-    REQUIRE(genesis.is_valid());
     REQUIRE(genesis.transactions().size() == 1u);
     REQUIRE(genesis.header().merkle() == genesis.generate_merkle_root());
 }
@@ -269,21 +267,18 @@ TEST_CASE("block genesis regtest valid structure", "[block serialization]") {
 #if defined(KTH_CURRENCY_BCH)
 TEST_CASE("block genesis testnet4 valid structure", "[block serialization]") {
     auto const genesis = chain::block::genesis_testnet4();
-    REQUIRE(genesis.is_valid());
     REQUIRE(genesis.transactions().size() == 1u);
     REQUIRE(genesis.header().merkle() == genesis.generate_merkle_root());
 }
 
 TEST_CASE("block genesis scalenet valid structure", "[block serialization]") {
     auto const genesis = chain::block::genesis_scalenet();
-    REQUIRE(genesis.is_valid());
     REQUIRE(genesis.transactions().size() == 1u);
     REQUIRE(genesis.header().merkle() == genesis.generate_merkle_root());
 }
 
 TEST_CASE("block genesis chipnet valid structure", "[block serialization]") {
     auto const genesis = chain::block::genesis_chipnet();
-    REQUIRE(genesis.is_valid());
     REQUIRE(genesis.transactions().size() == 1u);
     REQUIRE(genesis.header().merkle() == genesis.generate_merkle_root());
 }
@@ -305,7 +300,6 @@ TEST_CASE("block from data genesis mainnet success", "[block serialization]") {
     REQUIRE(result);
     auto const& block = *result;
 
-    REQUIRE(block.is_valid());
     REQUIRE(genesis.header() == block.header());
 
     // Verify merkle root from transactions.
@@ -327,7 +321,6 @@ TEST_CASE("block factory from data 2 genesis mainnet success", "[block serializa
     REQUIRE(result);
     auto const& block = *result;
 
-    REQUIRE(block.is_valid());
     REQUIRE(genesis.header() == block.header());
 
     // Verify merkle root from transactions.
@@ -349,7 +342,6 @@ TEST_CASE("block factory from data 3 genesis mainnet success", "[block serializa
     REQUIRE(result);
     auto const& block = *result;
 
-    REQUIRE(block.is_valid());
     REQUIRE(genesis.header() == block.header());
 
     // Verify merkle root from transactions.
@@ -361,7 +353,7 @@ TEST_CASE("block factory from data 3 genesis mainnet success", "[block serializa
 // Start Test Suite: block generate merkle root tests
 
 TEST_CASE("block generate merkle root block with zero transactions matches null hash", "[block generate merkle root]") {
-    chain::block const empty;
+    auto const empty = make_block();
     REQUIRE(empty.generate_merkle_root() == null_hash);
 }
 
@@ -396,7 +388,6 @@ TEST_CASE("block generate merkle root block with multiple transactions matches h
     auto const result = chain::block::from_data(reader);
     REQUIRE(result);
     auto const& block100k = *result;
-    REQUIRE(block100k.is_valid());
 
     auto const serial = kth::to_data_chunk(block100k);
     REQUIRE(raw == serial);
@@ -423,11 +414,11 @@ TEST_CASE("block header accessor always returns initialized value", "[block gene
         chain::transaction(4, 16, {}, {})
     };
 
-    chain::block const instance(header, transactions);
+    auto const instance = chain::block::create(header, transactions).value();
     REQUIRE(header == instance.header());
 }
 
-TEST_CASE("block header setter 1 roundtrip success", "[block generate merkle root]") {
+TEST_CASE("block construct exposes header", "[block generate merkle root]") {
     chain::header const header {
         10u,
         "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
@@ -437,28 +428,7 @@ TEST_CASE("block header setter 1 roundtrip success", "[block generate merkle roo
         68644u
     };
 
-    chain::block instance;
-    REQUIRE(header != instance.header());
-    instance.set_header(header);
-    REQUIRE(header == instance.header());
-}
-
-TEST_CASE("block header setter 2 roundtrip success", "[block generate merkle root]") {
-    chain::header const header {
-        10u,
-        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-        531234u,
-        6523454u,
-        68644u
-    };
-
-    // This must be non-const.
-    chain::header dup_header(header);
-
-    chain::block instance;
-    REQUIRE(header != instance.header());
-    instance.set_header(std::move(dup_header));
+    auto instance = chain::block::create(header, chain::transaction::list{}).value();
     REQUIRE(header == instance.header());
 }
 
@@ -478,7 +448,7 @@ TEST_CASE("block transactions accessor always returns initialized value", "[bloc
         chain::transaction(4, 16, {}, {})
     };
 
-    chain::block const instance(header, transactions);
+    auto const instance = chain::block::create(header, transactions).value();
     REQUIRE(transactions == instance.transactions());
 }
 
@@ -489,7 +459,7 @@ TEST_CASE("block transactions setter 1 roundtrip success", "[block generate merk
         chain::transaction(4, 16, {}, {})
     };
 
-    chain::block instance;
+    auto instance = make_block();
     REQUIRE(transactions != instance.transactions());
     instance.set_transactions(transactions);
     REQUIRE(transactions == instance.transactions());
@@ -505,7 +475,7 @@ TEST_CASE("block transactions setter 2 roundtrip success", "[block generate merk
     // This must be non-const.
     chain::transaction::list dup_transactions(transactions);
 
-    chain::block instance;
+    auto instance = make_block();
     REQUIRE(transactions != instance.transactions());
     instance.set_transactions(std::move(dup_transactions));
     REQUIRE(transactions == instance.transactions());
@@ -528,19 +498,16 @@ TEST_CASE("block operator assign equals always matches equivalent", "[block gene
     };
 
     // This must be non-const.
-    chain::block value(header, transactions);
+    auto value = chain::block::create(header, transactions).value();
 
-    REQUIRE(value.is_valid());
-    chain::block instance;
-    REQUIRE( ! instance.is_valid());
+    auto instance = make_block();
     instance = std::move(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(header == instance.header());
     REQUIRE(transactions == instance.transactions());
 }
 
 TEST_CASE("block operator boolean equals duplicates returns true", "[block generate merkle root]") {
-    chain::block const expected(
+    auto const expected = chain::block::create(
         chain::header {
             10u,
             "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
@@ -554,14 +521,14 @@ TEST_CASE("block operator boolean equals duplicates returns true", "[block gener
             chain::transaction(2, 32, {}, {}),
             chain::transaction(4, 16, {}, {})
         }
-    );
+    ).value();
 
     chain::block const instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("block operator boolean equals differs returns false", "[block generate merkle root]") {
-    chain::block const expected(
+    auto const expected = chain::block::create(
         chain::header {
             10u,
             "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
@@ -575,14 +542,14 @@ TEST_CASE("block operator boolean equals differs returns false", "[block generat
             chain::transaction(2, 32, {}, {}),
             chain::transaction(4, 16, {}, {})
         }
-    );
+    ).value();
 
-    chain::block const instance;
+    auto const instance = make_block();
     REQUIRE( ! (instance == expected));
 }
 
 TEST_CASE("block operator boolean not equals duplicates returns false", "[block generate merkle root]") {
-    chain::block const expected {
+    auto const expected = chain::block::create(
         chain::header {
             10u,
             "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
@@ -596,14 +563,14 @@ TEST_CASE("block operator boolean not equals duplicates returns false", "[block 
             chain::transaction(2, 32, {}, {}),
             chain::transaction(4, 16, {}, {})
         }
-    };
+    ).value();
 
     chain::block const instance(expected);
     REQUIRE( ! (instance != expected));
 }
 
 TEST_CASE("block operator boolean not equals differs returns true", "[block generate merkle root]") {
-    chain::block const expected(
+    auto const expected = chain::block::create(
         chain::header {
             10u,
             "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
@@ -617,9 +584,9 @@ TEST_CASE("block operator boolean not equals differs returns true", "[block gene
             chain::transaction(2, 32, {}, {}),
             chain::transaction(4, 16, {}, {})
         }
-    );
+    ).value();
 
-    chain::block const instance;
+    auto const instance = make_block();
     REQUIRE(instance != expected);
 }
 
@@ -628,36 +595,36 @@ TEST_CASE("block operator boolean not equals differs returns true", "[block gene
 // Start Test Suite: block is distinct transaction set tests
 
 TEST_CASE("block distinct transactions empty true", "[block is distinct transaction set]") {
-    chain::block const value;
+    auto const value = make_block();
     REQUIRE(value.is_distinct_transaction_set());
 }
 
 TEST_CASE("validate block is distinct tx set single true", "[block is distinct transaction set]") {
-    chain::block value;
+    auto value = make_block();
     value.set_transactions({{1, 0, {}, {}}});
     REQUIRE(value.is_distinct_transaction_set());
 }
 
 TEST_CASE("validate block is distinct tx set duplicate false", "[block is distinct transaction set]") {
-    chain::block value;
+    auto value = make_block();
     value.set_transactions({{1, 0, {}, {}}, {1, 0, {}, {}}});
     REQUIRE( ! value.is_distinct_transaction_set());
 }
 
 TEST_CASE("validate block is distinct tx set distinct by version true", "[block is distinct transaction set]") {
-    chain::block value;
+    auto value = make_block();
     value.set_transactions({{1, 0, {}, {}}, {2, 0, {}, {}}, {3, 0, {}, {}}});
     REQUIRE(value.is_distinct_transaction_set());
 }
 
 TEST_CASE("validate block is distinct tx set partialy distinct by version false", "[block is distinct transaction set]") {
-    chain::block value;
+    auto value = make_block();
     value.set_transactions({{1, 0, {}, {}}, {2, 0, {}, {}}, {2, 0, {}, {}}});
     REQUIRE( ! value.is_distinct_transaction_set());
 }
 
 TEST_CASE("validate block is distinct tx set partialy distinct not adjacent by version false", "[block is distinct transaction set]") {
-    chain::block value;
+    auto value = make_block();
     value.set_transactions({{1, 0, {}, {}}, {2, 0, {}, {}}, {1, 0, {}, {}}});
     REQUIRE( ! value.is_distinct_transaction_set());
 }
@@ -677,12 +644,12 @@ TEST_CASE("validate block is cash pow valid true", "[block is distinct transacti
 // Start Test Suite: block is forward reference tests
 
 TEST_CASE("block is forward reference no transactions false", "[block is forward reference]") {
-    chain::block const value;
+    auto const value = make_block();
     REQUIRE( ! value.is_forward_reference());
 }
 
 TEST_CASE("block is forward reference multiple empty transactions false", "[block is forward reference]") {
-    chain::block value;
+    auto value = make_block();
     value.set_transactions({{1, 0, {}, {}}, {2, 0, {}, {}}});
     REQUIRE( ! value.is_forward_reference());
 }
@@ -690,20 +657,20 @@ TEST_CASE("block is forward reference multiple empty transactions false", "[bloc
 TEST_CASE("block is forward reference backward reference false", "[block is forward reference]") {
     chain::transaction const before{2, 0, {}, {}};
     chain::transaction const after{1, 0, {{{before.hash(), 0}, {}, 0}}, {}};
-    chain::block value;
+    auto value = make_block();
     value.set_transactions({before, after});
     REQUIRE( ! value.is_forward_reference());
 }
 
 TEST_CASE("block is forward reference duplicate transactions false", "[block is forward reference]") {
-    chain::block value;
+    auto value = make_block();
     value.set_transactions({{1, 0, {}, {}}, {1, 0, {}, {}}});
     REQUIRE( ! value.is_forward_reference());
 }
 
 TEST_CASE("block is forward reference coinbase and multiple empty transactions false", "[block is forward reference]") {
     chain::transaction const coinbase{1, 0, {{{null_hash, chain::point::null_index}, {}, 0}}, {}};
-    chain::block value;
+    auto value = make_block();
     value.set_transactions({coinbase, {2, 0, {}, {}}, {3, 0, {}, {}}});
     REQUIRE( ! value.is_forward_reference());
 }
@@ -711,7 +678,7 @@ TEST_CASE("block is forward reference coinbase and multiple empty transactions f
 TEST_CASE("block is forward reference forward reference true", "[block is forward reference]") {
     chain::transaction const after{2, 0, {}, {}};
     chain::transaction const before{1, 0, {{{after.hash(), 0}, {}, 0}}, {}};
-    chain::block value;
+    auto value = make_block();
     value.set_transactions({before, after});
     REQUIRE(value.is_forward_reference());
 }

--- a/src/domain/test/message/block.cpp
+++ b/src/domain/test/message/block.cpp
@@ -10,11 +10,21 @@ using namespace kth;
 using namespace kd;
 using namespace kth::domain::message;
 
+namespace {
+// Valid blocks (non-zero header, no transactions) for fixtures that only need
+// "some block" — `create` rejects the empty sentinel.
+chain::block make_chain_block() {
+    return chain::block::create(chain::header{1u, null_hash, null_hash, 0u, 0u, 0u}, {}).value();
+}
+message::block make_msg_block() {
+    return message::block::create(chain::header{1u, null_hash, null_hash, 0u, 0u, 0u}, {}).value();
+}
+} // anonymous namespace
+
 // Start Test Suite: message block tests
 
-TEST_CASE("block constructor 1 always invalid", "[message block]") {
-    block instance;
-    REQUIRE( ! instance.is_valid());
+TEST_CASE("block create rejects the empty sentinel", "[message block]") {
+    REQUIRE( ! block::create(chain::header{}, {}));
 }
 
 TEST_CASE("block constructor 2 always equals params", "[message block]") {
@@ -30,8 +40,7 @@ TEST_CASE("block constructor 2 always equals params", "[message block]") {
         chain::transaction(2, 32, {}, {}),
         chain::transaction(4, 16, {}, {})};
 
-    block instance(header, transactions);
-    REQUIRE(instance.is_valid());
+    auto instance = block::create(header, transactions).value();
     REQUIRE(header == instance.header());
     REQUIRE(transactions == instance.transactions());
 }
@@ -51,8 +60,7 @@ TEST_CASE("block constructor 3 always equals params", "[message block]") {
 
     chain::header dup_header(header);
     chain::transaction::list dup_transactions = transactions;
-    block instance(std::move(dup_header), std::move(dup_transactions));
-    REQUIRE(instance.is_valid());
+    auto instance = block::create(std::move(dup_header), std::move(dup_transactions)).value();
     REQUIRE(header == instance.header());
     REQUIRE(transactions == instance.transactions());
 }
@@ -70,9 +78,8 @@ TEST_CASE("block constructor 4 always equals params", "[message block]") {
         chain::transaction(2, 32, {}, {}),
         chain::transaction(4, 16, {}, {})};
 
-    chain::block value(header, transactions);
+    auto value = chain::block::create(header, transactions).value();
     block instance(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(instance == value);
     REQUIRE(header == instance.header());
     REQUIRE(transactions == instance.transactions());
@@ -91,9 +98,8 @@ TEST_CASE("block constructor 5 always equals params", "[message block]") {
         chain::transaction(2, 32, {}, {}),
         chain::transaction(4, 16, {}, {})};
 
-    chain::block value(header, transactions);
+    auto value = chain::block::create(header, transactions).value();
     block instance(std::move(value));
-    REQUIRE(instance.is_valid());
     REQUIRE(header == instance.header());
     REQUIRE(transactions == instance.transactions());
 }
@@ -111,9 +117,8 @@ TEST_CASE("block constructor 6 always equals params", "[message block]") {
         chain::transaction(2, 32, {}, {}),
         chain::transaction(4, 16, {}, {})};
 
-    block value(header, transactions);
+    auto value = block::create(header, transactions).value();
     block instance(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(value == instance);
     REQUIRE(header == instance.header());
     REQUIRE(transactions == instance.transactions());
@@ -132,9 +137,8 @@ TEST_CASE("block constructor 7 always equals params", "[message block]") {
         chain::transaction(2, 32, {}, {}),
         chain::transaction(4, 16, {}, {})};
 
-    block value(header, transactions);
+    auto value = block::create(header, transactions).value();
     block instance(std::move(value));
-    REQUIRE(instance.is_valid());
     REQUIRE(header == instance.header());
     REQUIRE(transactions == instance.transactions());
 }
@@ -154,7 +158,6 @@ TEST_CASE("block factory data 1 genesis mainnet success", "[message block]") {
     REQUIRE(result_exp);
     auto const block = std::move(*result_exp);
 
-    REQUIRE(block.is_valid());
     REQUIRE(genesis.header() == block.header());
 
     // Verify merkle root from transactions.
@@ -180,14 +183,11 @@ TEST_CASE("block operator assign equals 1 always matches equivalent", "[message 
         chain::transaction(2, 32, {}, {}),
         chain::transaction(4, 16, {}, {})};
 
-    chain::block value(header, transactions);
-    REQUIRE(value.is_valid());
+    auto value = chain::block::create(header, transactions).value();
 
-    message::block instance;
-    REQUIRE( ! instance.is_valid());
+    auto instance = make_msg_block();
 
     instance = std::move(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(instance.header() == header);
     REQUIRE(instance.transactions() == transactions);
 }
@@ -205,21 +205,18 @@ TEST_CASE("block operator assign equals 2 always matches equivalent", "[message 
         chain::transaction(2, 32, {}, {}),
         chain::transaction(4, 16, {}, {})};
 
-    message::block value(header, transactions);
+    auto value = message::block::create(header, transactions).value();
 
-    REQUIRE(value.is_valid());
 
-    message::block instance;
-    REQUIRE( ! instance.is_valid());
+    auto instance = make_msg_block();
 
     instance = std::move(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(instance.header() == header);
     REQUIRE(instance.transactions() == transactions);
 }
 
 TEST_CASE("block operator boolean equals 1 duplicates returns true", "[message block]") {
-    const chain::block expected(
+    auto const expected = chain::block::create(
         chain::header(10u,
                       "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
                       "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
@@ -228,14 +225,14 @@ TEST_CASE("block operator boolean equals 1 duplicates returns true", "[message b
                       68644u),
         {chain::transaction(1, 48, {}, {}),
          chain::transaction(2, 32, {}, {}),
-         chain::transaction(4, 16, {}, {})});
+         chain::transaction(4, 16, {}, {})}).value();
 
     message::block instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("block operator boolean equals 1 differs returns false", "[message block]") {
-    const chain::block expected(
+    auto const expected = chain::block::create(
         chain::header(10u,
                       "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
                       "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
@@ -244,14 +241,14 @@ TEST_CASE("block operator boolean equals 1 differs returns false", "[message blo
                       68644u),
         {chain::transaction(1, 48, {}, {}),
          chain::transaction(2, 32, {}, {}),
-         chain::transaction(4, 16, {}, {})});
+         chain::transaction(4, 16, {}, {})}).value();
 
-    message::block instance;
+    auto instance = make_msg_block();
     REQUIRE(instance != expected);
 }
 
 TEST_CASE("block operator boolean not equals 1 duplicates returns false", "[message block]") {
-    const chain::block expected(
+    auto const expected = chain::block::create(
         chain::header(10u,
                       "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
                       "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
@@ -260,14 +257,14 @@ TEST_CASE("block operator boolean not equals 1 duplicates returns false", "[mess
                       68644u),
         {chain::transaction(1, 48, {}, {}),
          chain::transaction(2, 32, {}, {}),
-         chain::transaction(4, 16, {}, {})});
+         chain::transaction(4, 16, {}, {})}).value();
 
     message::block instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("block operator boolean not equals 1 differs returns true", "[message block]") {
-    const chain::block expected(
+    auto const expected = chain::block::create(
         chain::header(10u,
                       "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
                       "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
@@ -276,14 +273,14 @@ TEST_CASE("block operator boolean not equals 1 differs returns true", "[message 
                       68644u),
         {chain::transaction(1, 48, {}, {}),
          chain::transaction(2, 32, {}, {}),
-         chain::transaction(4, 16, {}, {})});
+         chain::transaction(4, 16, {}, {})}).value();
 
-    chain::block instance;
+    auto instance = make_chain_block();
     REQUIRE(instance != expected);
 }
 
 TEST_CASE("block operator boolean equals 2 duplicates returns true", "[message block]") {
-    const message::block expected(
+    auto const expected = message::block::create(
         chain::header(10u,
                       "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
                       "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
@@ -292,14 +289,14 @@ TEST_CASE("block operator boolean equals 2 duplicates returns true", "[message b
                       68644u),
         {chain::transaction(1, 48, {}, {}),
          chain::transaction(2, 32, {}, {}),
-         chain::transaction(4, 16, {}, {})});
+         chain::transaction(4, 16, {}, {})}).value();
 
     message::block instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("block operator boolean equals 2 differs returns false", "[message block]") {
-    const message::block expected(
+    auto const expected = message::block::create(
         chain::header(10u,
                       "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
                       "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
@@ -308,14 +305,14 @@ TEST_CASE("block operator boolean equals 2 differs returns false", "[message blo
                       68644u),
         {chain::transaction(1, 48, {}, {}),
          chain::transaction(2, 32, {}, {}),
-         chain::transaction(4, 16, {}, {})});
+         chain::transaction(4, 16, {}, {})}).value();
 
-    message::block instance;
+    auto instance = make_msg_block();
     REQUIRE(instance != expected);
 }
 
 TEST_CASE("block operator boolean not equals 2 duplicates returns false", "[message block]") {
-    const message::block expected(
+    auto const expected = message::block::create(
         chain::header(10u,
                       "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
                       "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
@@ -324,14 +321,14 @@ TEST_CASE("block operator boolean not equals 2 duplicates returns false", "[mess
                       68644u),
         {chain::transaction(1, 48, {}, {}),
          chain::transaction(2, 32, {}, {}),
-         chain::transaction(4, 16, {}, {})});
+         chain::transaction(4, 16, {}, {})}).value();
 
     message::block instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("block operator boolean not equals 2 differs returns true", "[message block]") {
-    const message::block expected(
+    auto const expected = message::block::create(
         chain::header(10u,
                       "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
                       "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
@@ -340,9 +337,9 @@ TEST_CASE("block operator boolean not equals 2 differs returns true", "[message 
                       68644u),
         {chain::transaction(1, 48, {}, {}),
          chain::transaction(2, 32, {}, {}),
-         chain::transaction(4, 16, {}, {})});
+         chain::transaction(4, 16, {}, {})}).value();
 
-    message::block instance;
+    auto instance = make_msg_block();
     REQUIRE(instance != expected);
 }
 

--- a/src/infrastructure/include/kth/infrastructure/error.hpp
+++ b/src/infrastructure/include/kth/infrastructure/error.hpp
@@ -283,6 +283,11 @@ enum error_code_t {
     bad_merkle_block_count,
     illegal_value,
 
+    // Valid-by-construction guard: `block::create` was given parts that would
+    // be the empty sentinel (no transactions and an all-zero header). Distinct
+    // from the consensus `empty_block` check performed during validation.
+    block_construction_empty,
+
     // Database cache
     height_not_found,
     hash_not_found,

--- a/src/infrastructure/src/error.cpp
+++ b/src/infrastructure/src/error.cpp
@@ -260,7 +260,10 @@ std::string error_category_impl::message(int ev) const noexcept {
         // Domain object serialization/deserialization
         { error::read_past_end_of_buffer, "read past end of buffer" },
         { error::skip_past_end_of_buffer, "skip past end of buffer" },
-        { error::write_past_end_of_buffer, "write past end of buffer" }
+        { error::write_past_end_of_buffer, "write past end of buffer" },
+
+        // Valid-by-construction
+        { error::block_construction_empty, "cannot construct a block with no transactions and an empty header" }
     };
 
     auto const message = messages.find(ev);


### PR DESCRIPTION
## Summary

First PR of the `header` valid-by-construction cascade. Makes `chain::block`
(and the `message::block` subclass) valid-by-construction: a block always
carries a header and its transactions, and can never be the empty/default
sentinel.

## Construction

- Replace the public `(header, transactions)` constructors with a named
  factory `static expect<block> create(header, transactions)` that returns
  `error::block_construction_empty` when the result would be the empty
  sentinel (no transactions **and** an all-zero header). The raw ctors are
  private; `create` / `from_data` / `genesis_*` are the only entry points, so
  a constructed `block` is always a real block.
- `from_data` routes through `create`.
- `message::block::create` mirrors it, delegating to `chain::block::create`
  and wrapping the result; its `(header, txs)` ctors are removed.

## Removals

- `block() = default`, `set_header`, the non-const `header()` accessor, and
  `reset()` — none used by production code.
- `block::is_valid()` — its only job was rejecting the empty sentinel, which
  `create` now does at construction.

## Error code

New `error::block_construction_empty`, distinct from the consensus
`empty_block` check performed during validation. C-API `error.h` regenerated
to expose `kth_ec_block_construction_empty`.

## C-API

`block` bindings regenerated: `construct(header, txs)` becomes the fallible
`kth_chain_block_create(header, txs, &out)`, and `is_valid` is dropped. Tests
construct via `kth_chain_block_create` with a `make_minimal_block()` helper.

## Next in the cascade

`merkle_block` / `compact_block` (they hold a `header` member + default
ctors), then finally `header() = default`.

## Test plan

- [x] `cmake --build build/Release` — infrastructure, domain, c-api, blockchain, node all clean
- [x] `kth_domain_test` — 1,011,152 assertions in 3,865 test cases
- [x] `kth_capi_test` — 2,804 assertions in 754 test cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated error notification when attempting to construct a block with no transactions and an empty header.
  * Improved error messaging to clearly distinguish construction restrictions from consensus validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->