### PR TITLE
refactor(domain/chain): valid-by-construction for merkle_block + compact_block

### DIFF
--- a/src/blockchain/src/pools/transaction_pool.cpp
+++ b/src/blockchain/src/pools/transaction_pool.cpp
@@ -25,9 +25,7 @@ transaction_pool::transaction_pool(settings const& /*settings*/)
 // TODO(legacy): implement block template discovery.
 awaitable_expected<std::pair<merkle_block_ptr, size_t>>
 transaction_pool::fetch_template() const {
-    size_t const height = max_size_t;
-    auto const block = std::make_shared<domain::message::merkle_block>();
-    co_return std::pair{block, height};
+    co_return std::unexpected(error::not_implemented);
 }
 
 // TODO(legacy): implement mempool message payload discovery.

--- a/src/c-api/include/kth/capi/chain/compact_block.h
+++ b/src/c-api/include/kth/capi/chain/compact_block.h
@@ -16,22 +16,13 @@ extern "C" {
 
 // Constructors
 
-/** @return Owned `kth_compact_block_mut_t`. Caller must release with `kth_chain_compact_block_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_compact_block_mut_t kth_chain_compact_block_construct_default(void);
-
 /** @param[out] out Must point to a null `kth_compact_block_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_compact_block_destruct`. Untouched on error. */
 KTH_EXPORT
 kth_error_code_t kth_chain_compact_block_construct_from_data(uint8_t const* data, kth_size_t n, uint32_t version, KTH_OUT_OWNED kth_compact_block_mut_t* out);
 
-/**
- * @return Owned `kth_compact_block_mut_t`. Caller must release with `kth_chain_compact_block_destruct`.
- * @param header Borrowed input. Copied by value into the resulting object; ownership of `header` stays with the caller.
- * @param short_ids Borrowed input. Copied by value into the resulting object; ownership of `short_ids` stays with the caller.
- * @param transactions Borrowed input. Copied by value into the resulting object; ownership of `transactions` stays with the caller.
- */
-KTH_EXPORT KTH_OWNED
-kth_compact_block_mut_t kth_chain_compact_block_construct(kth_header_const_t header, uint64_t nonce, kth_u64_list_const_t short_ids, kth_prefilled_transaction_list_const_t transactions);
+/** @param[out] out Must point to a null `kth_compact_block_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_compact_block_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_chain_compact_block_create(kth_header_const_t header, uint64_t nonce, kth_u64_list_const_t short_ids, kth_prefilled_transaction_list_const_t transactions, KTH_OUT_OWNED kth_compact_block_mut_t* out);
 
 
 // Destructor
@@ -52,6 +43,9 @@ kth_compact_block_mut_t kth_chain_compact_block_copy(kth_compact_block_const_t s
 
 KTH_EXPORT
 kth_bool_t kth_chain_compact_block_equals(kth_compact_block_const_t self, kth_compact_block_const_t other);
+
+KTH_EXPORT
+kth_bool_t kth_chain_compact_block_not_equal(kth_compact_block_const_t self, kth_compact_block_const_t other);
 
 
 // Serialization
@@ -80,36 +74,6 @@ kth_u64_list_mut_t kth_chain_compact_block_short_ids(kth_compact_block_const_t s
 /** @return Borrowed `kth_prefilled_transaction_list_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
 KTH_EXPORT
 kth_prefilled_transaction_list_const_t kth_chain_compact_block_transactions(kth_compact_block_const_t self);
-
-
-// Setters
-
-/** @param value Borrowed input. Copied by value into the resulting object; ownership of `value` stays with the caller. */
-KTH_EXPORT
-void kth_chain_compact_block_set_header(kth_compact_block_mut_t self, kth_header_const_t value);
-
-KTH_EXPORT
-void kth_chain_compact_block_set_nonce(kth_compact_block_mut_t self, uint64_t value);
-
-/** @param value Borrowed input. Copied by value into the resulting object; ownership of `value` stays with the caller. */
-KTH_EXPORT
-void kth_chain_compact_block_set_short_ids(kth_compact_block_mut_t self, kth_u64_list_const_t value);
-
-/** @param value Borrowed input. Copied by value into the resulting object; ownership of `value` stays with the caller. */
-KTH_EXPORT
-void kth_chain_compact_block_set_transactions(kth_compact_block_mut_t self, kth_prefilled_transaction_list_const_t value);
-
-
-// Predicates
-
-KTH_EXPORT
-kth_bool_t kth_chain_compact_block_is_valid(kth_compact_block_const_t self);
-
-
-// Operations
-
-KTH_EXPORT
-void kth_chain_compact_block_reset(kth_compact_block_mut_t self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/include/kth/capi/chain/merkle_block.h
+++ b/src/c-api/include/kth/capi/chain/merkle_block.h
@@ -16,28 +16,20 @@ extern "C" {
 
 // Constructors
 
-/** @return Owned `kth_merkle_block_mut_t`. Caller must release with `kth_chain_merkle_block_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_merkle_block_mut_t kth_chain_merkle_block_construct_default(void);
-
 /** @param[out] out Must point to a null `kth_merkle_block_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_merkle_block_destruct`. Untouched on error. */
 KTH_EXPORT
 kth_error_code_t kth_chain_merkle_block_construct_from_data(uint8_t const* data, kth_size_t n, uint32_t version, KTH_OUT_OWNED kth_merkle_block_mut_t* out);
 
 /**
  * @return Owned `kth_merkle_block_mut_t`. Caller must release with `kth_chain_merkle_block_destruct`.
- * @param header Borrowed input. Copied by value into the resulting object; ownership of `header` stays with the caller.
- * @param hashes Borrowed input. Copied by value into the resulting object; ownership of `hashes` stays with the caller.
- */
-KTH_EXPORT KTH_OWNED
-kth_merkle_block_mut_t kth_chain_merkle_block_construct_from_header_total_transactions_hashes_flags(kth_header_const_t header, kth_size_t total_transactions, kth_hash_list_const_t hashes, uint8_t const* flags, kth_size_t n);
-
-/**
- * @return Owned `kth_merkle_block_mut_t`. Caller must release with `kth_chain_merkle_block_destruct`.
  * @param block Borrowed input. Copied by value into the resulting object; ownership of `block` stays with the caller.
  */
 KTH_EXPORT KTH_OWNED
-kth_merkle_block_mut_t kth_chain_merkle_block_construct_from_block(kth_block_const_t block);
+kth_merkle_block_mut_t kth_chain_merkle_block_construct(kth_block_const_t block);
+
+/** @param[out] out Must point to a null `kth_merkle_block_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_merkle_block_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_chain_merkle_block_create(kth_header_const_t header, kth_size_t total_transactions, kth_hash_list_const_t hashes, uint8_t const* flags, kth_size_t n, KTH_OUT_OWNED kth_merkle_block_mut_t* out);
 
 
 // Destructor
@@ -58,6 +50,9 @@ kth_merkle_block_mut_t kth_chain_merkle_block_copy(kth_merkle_block_const_t self
 
 KTH_EXPORT
 kth_bool_t kth_chain_merkle_block_equals(kth_merkle_block_const_t self, kth_merkle_block_const_t other);
+
+KTH_EXPORT
+kth_bool_t kth_chain_merkle_block_not_equal(kth_merkle_block_const_t self, kth_merkle_block_const_t other);
 
 
 // Serialization
@@ -86,35 +81,6 @@ kth_hash_list_const_t kth_chain_merkle_block_hashes(kth_merkle_block_const_t sel
 /** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
 KTH_EXPORT KTH_OWNED
 uint8_t* kth_chain_merkle_block_flags(kth_merkle_block_const_t self, kth_size_t* out_size);
-
-
-// Setters
-
-/** @param value Borrowed input. Copied by value into the resulting object; ownership of `value` stays with the caller. */
-KTH_EXPORT
-void kth_chain_merkle_block_set_header(kth_merkle_block_mut_t self, kth_header_const_t value);
-
-KTH_EXPORT
-void kth_chain_merkle_block_set_total_transactions(kth_merkle_block_mut_t self, kth_size_t value);
-
-/** @param value Borrowed input. Copied by value into the resulting object; ownership of `value` stays with the caller. */
-KTH_EXPORT
-void kth_chain_merkle_block_set_hashes(kth_merkle_block_mut_t self, kth_hash_list_const_t value);
-
-KTH_EXPORT
-void kth_chain_merkle_block_set_flags(kth_merkle_block_mut_t self, uint8_t const* value, kth_size_t n);
-
-
-// Predicates
-
-KTH_EXPORT
-kth_bool_t kth_chain_merkle_block_is_valid(kth_merkle_block_const_t self);
-
-
-// Operations
-
-KTH_EXPORT
-void kth_chain_merkle_block_reset(kth_merkle_block_mut_t self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/include/kth/capi/error.h
+++ b/src/c-api/include/kth/capi/error.h
@@ -257,6 +257,12 @@ typedef enum kth_error_code {
     // from the consensus `empty_block` check performed during validation.
     kth_ec_block_construction_empty,
 
+    // Valid-by-construction guards for the message wrappers: `create` was
+    // given parts that would be the all-default sentinel (an all-zero header
+    // and no payload).
+    kth_ec_merkle_block_construction_empty,
+    kth_ec_compact_block_construction_empty,
+
     // Database cache
     kth_ec_height_not_found,
     kth_ec_hash_not_found,

--- a/src/c-api/src/chain/compact_block.cpp
+++ b/src/c-api/src/chain/compact_block.cpp
@@ -22,10 +22,6 @@ extern "C" {
 
 // Constructors
 
-kth_compact_block_mut_t kth_chain_compact_block_construct_default(void) {
-    return kth::leak<cpp_t>();
-}
-
 kth_error_code_t kth_chain_compact_block_construct_from_data(uint8_t const* data, kth_size_t n, uint32_t version, KTH_OUT_OWNED kth_compact_block_mut_t* out) {
     KTH_PRECONDITION(data != nullptr || n == 0);
     KTH_PRECONDITION(out != nullptr);
@@ -37,14 +33,19 @@ kth_error_code_t kth_chain_compact_block_construct_from_data(uint8_t const* data
     return kth_ec_success;
 }
 
-kth_compact_block_mut_t kth_chain_compact_block_construct(kth_header_const_t header, uint64_t nonce, kth_u64_list_const_t short_ids, kth_prefilled_transaction_list_const_t transactions) {
+kth_error_code_t kth_chain_compact_block_create(kth_header_const_t header, uint64_t nonce, kth_u64_list_const_t short_ids, kth_prefilled_transaction_list_const_t transactions, KTH_OUT_OWNED kth_compact_block_mut_t* out) {
     KTH_PRECONDITION(header != nullptr);
     KTH_PRECONDITION(short_ids != nullptr);
     KTH_PRECONDITION(transactions != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
     auto const& header_cpp = kth::cpp_ref<kth::domain::chain::header>(header);
     auto const& short_ids_cpp = kth::cpp_ref<std::vector<uint64_t>>(short_ids);
     auto const& transactions_cpp = kth::cpp_ref<kth::domain::message::prefilled_transaction::list>(transactions);
-    return kth::leak<cpp_t>(header_cpp, nonce, short_ids_cpp, transactions_cpp);
+    auto result = cpp_t::create(header_cpp, nonce, short_ids_cpp, transactions_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
 }
 
 
@@ -69,6 +70,12 @@ kth_bool_t kth_chain_compact_block_equals(kth_compact_block_const_t self, kth_co
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(other != nullptr);
     return kth::eq<cpp_t>(self, other);
+}
+
+kth_bool_t kth_chain_compact_block_not_equal(kth_compact_block_const_t self, kth_compact_block_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::ne<cpp_t>(self, other);
 }
 
 
@@ -107,51 +114,6 @@ kth_u64_list_mut_t kth_chain_compact_block_short_ids(kth_compact_block_const_t s
 kth_prefilled_transaction_list_const_t kth_chain_compact_block_transactions(kth_compact_block_const_t self) {
     KTH_PRECONDITION(self != nullptr);
     return &(kth::cpp_ref<cpp_t>(self).transactions());
-}
-
-
-// Setters
-
-void kth_chain_compact_block_set_header(kth_compact_block_mut_t self, kth_header_const_t value) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(value != nullptr);
-    auto const& value_cpp = kth::cpp_ref<kth::domain::chain::header>(value);
-    kth::cpp_ref<cpp_t>(self).set_header(value_cpp);
-}
-
-void kth_chain_compact_block_set_nonce(kth_compact_block_mut_t self, uint64_t value) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<cpp_t>(self).set_nonce(value);
-}
-
-void kth_chain_compact_block_set_short_ids(kth_compact_block_mut_t self, kth_u64_list_const_t value) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(value != nullptr);
-    auto const& value_cpp = kth::cpp_ref<std::vector<uint64_t>>(value);
-    kth::cpp_ref<cpp_t>(self).set_short_ids(value_cpp);
-}
-
-void kth_chain_compact_block_set_transactions(kth_compact_block_mut_t self, kth_prefilled_transaction_list_const_t value) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(value != nullptr);
-    auto const& value_cpp = kth::cpp_ref<kth::domain::message::prefilled_transaction::list>(value);
-    kth::cpp_ref<cpp_t>(self).set_transactions(value_cpp);
-}
-
-
-// Predicates
-
-kth_bool_t kth_chain_compact_block_is_valid(kth_compact_block_const_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_valid());
-}
-
-
-// Operations
-
-void kth_chain_compact_block_reset(kth_compact_block_mut_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<cpp_t>(self).reset();
 }
 
 } // extern "C"

--- a/src/c-api/src/chain/merkle_block.cpp
+++ b/src/c-api/src/chain/merkle_block.cpp
@@ -22,10 +22,6 @@ extern "C" {
 
 // Constructors
 
-kth_merkle_block_mut_t kth_chain_merkle_block_construct_default(void) {
-    return kth::leak<cpp_t>();
-}
-
 kth_error_code_t kth_chain_merkle_block_construct_from_data(uint8_t const* data, kth_size_t n, uint32_t version, KTH_OUT_OWNED kth_merkle_block_mut_t* out) {
     KTH_PRECONDITION(data != nullptr || n == 0);
     KTH_PRECONDITION(out != nullptr);
@@ -37,21 +33,26 @@ kth_error_code_t kth_chain_merkle_block_construct_from_data(uint8_t const* data,
     return kth_ec_success;
 }
 
-kth_merkle_block_mut_t kth_chain_merkle_block_construct_from_header_total_transactions_hashes_flags(kth_header_const_t header, kth_size_t total_transactions, kth_hash_list_const_t hashes, uint8_t const* flags, kth_size_t n) {
+kth_merkle_block_mut_t kth_chain_merkle_block_construct(kth_block_const_t block) {
+    KTH_PRECONDITION(block != nullptr);
+    auto const& block_cpp = kth::cpp_ref<kth::domain::chain::block>(block);
+    return kth::leak<cpp_t>(block_cpp);
+}
+
+kth_error_code_t kth_chain_merkle_block_create(kth_header_const_t header, kth_size_t total_transactions, kth_hash_list_const_t hashes, uint8_t const* flags, kth_size_t n, KTH_OUT_OWNED kth_merkle_block_mut_t* out) {
     KTH_PRECONDITION(header != nullptr);
     KTH_PRECONDITION(hashes != nullptr);
     KTH_PRECONDITION(flags != nullptr || n == 0);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
     auto const& header_cpp = kth::cpp_ref<kth::domain::chain::header>(header);
     auto const total_transactions_cpp = kth::sz(total_transactions);
     auto const& hashes_cpp = kth::cpp_ref<kth::hash_list>(hashes);
     auto const flags_cpp = n != 0 ? kth::data_chunk(flags, flags + n) : kth::data_chunk{};
-    return kth::leak<cpp_t>(header_cpp, total_transactions_cpp, hashes_cpp, flags_cpp);
-}
-
-kth_merkle_block_mut_t kth_chain_merkle_block_construct_from_block(kth_block_const_t block) {
-    KTH_PRECONDITION(block != nullptr);
-    auto const& block_cpp = kth::cpp_ref<kth::domain::chain::block>(block);
-    return kth::leak<cpp_t>(block_cpp);
+    auto result = cpp_t::create(header_cpp, total_transactions_cpp, hashes_cpp, flags_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
 }
 
 
@@ -76,6 +77,12 @@ kth_bool_t kth_chain_merkle_block_equals(kth_merkle_block_const_t self, kth_merk
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(other != nullptr);
     return kth::eq<cpp_t>(self, other);
+}
+
+kth_bool_t kth_chain_merkle_block_not_equal(kth_merkle_block_const_t self, kth_merkle_block_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::ne<cpp_t>(self, other);
 }
 
 
@@ -115,52 +122,6 @@ uint8_t* kth_chain_merkle_block_flags(kth_merkle_block_const_t self, kth_size_t*
     KTH_PRECONDITION(out_size != nullptr);
     auto const& data = kth::cpp_ref<cpp_t>(self).flags();
     return kth::create_c_array(data, *out_size);
-}
-
-
-// Setters
-
-void kth_chain_merkle_block_set_header(kth_merkle_block_mut_t self, kth_header_const_t value) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(value != nullptr);
-    auto const& value_cpp = kth::cpp_ref<kth::domain::chain::header>(value);
-    kth::cpp_ref<cpp_t>(self).set_header(value_cpp);
-}
-
-void kth_chain_merkle_block_set_total_transactions(kth_merkle_block_mut_t self, kth_size_t value) {
-    KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth::sz(value);
-    kth::cpp_ref<cpp_t>(self).set_total_transactions(value_cpp);
-}
-
-void kth_chain_merkle_block_set_hashes(kth_merkle_block_mut_t self, kth_hash_list_const_t value) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(value != nullptr);
-    auto const& value_cpp = kth::cpp_ref<kth::hash_list>(value);
-    kth::cpp_ref<cpp_t>(self).set_hashes(value_cpp);
-}
-
-void kth_chain_merkle_block_set_flags(kth_merkle_block_mut_t self, uint8_t const* value, kth_size_t n) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(value != nullptr || n == 0);
-    auto const value_cpp = n != 0 ? kth::data_chunk(value, value + n) : kth::data_chunk{};
-    kth::cpp_ref<cpp_t>(self).set_flags(value_cpp);
-}
-
-
-// Predicates
-
-kth_bool_t kth_chain_merkle_block_is_valid(kth_merkle_block_const_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_valid());
-}
-
-
-// Operations
-
-void kth_chain_merkle_block_reset(kth_merkle_block_mut_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<cpp_t>(self).reset();
 }
 
 } // extern "C"

--- a/src/c-api/test/chain/compact_block.cpp
+++ b/src/c-api/test/chain/compact_block.cpp
@@ -94,8 +94,11 @@ static kth_compact_block_mut_t make_fixture(void) {
     kth_transaction_mut_t tx = make_tx();
     kth_prefilled_transaction_list_mut_t txs = make_prefilled_list(tx);
 
-    kth_compact_block_mut_t cb = kth_chain_compact_block_construct(
-        header, 0xCAFEBABEu, short_ids, txs);
+    kth_compact_block_mut_t cb = NULL;
+    kth_error_code_t ec = kth_chain_compact_block_create(
+        header, 0xCAFEBABEu, short_ids, txs, &cb);
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(cb != NULL);
 
     kth_chain_prefilled_transaction_list_destruct(txs);
     kth_chain_transaction_destruct(tx);
@@ -108,18 +111,27 @@ static kth_compact_block_mut_t make_fixture(void) {
 // Constructors / lifecycle
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API CompactBlock - default construct is invalid",
+TEST_CASE("C-API CompactBlock - create rejects the empty sentinel",
           "[C-API CompactBlock]") {
-    kth_compact_block_mut_t cb = kth_chain_compact_block_construct_default();
-    REQUIRE(kth_chain_compact_block_is_valid(cb) == 0);
-    kth_chain_compact_block_destruct(cb);
+    kth_header_mut_t header = kth_chain_header_construct_default();
+    kth_u64_list_mut_t short_ids = kth_core_u64_list_construct_default();
+    kth_prefilled_transaction_list_mut_t txs =
+        kth_chain_prefilled_transaction_list_construct_default();
+    kth_compact_block_mut_t cb = NULL;
+    kth_error_code_t ec = kth_chain_compact_block_create(
+        header, 0u, short_ids, txs, &cb);
+    REQUIRE(ec != kth_ec_success);
+    REQUIRE(cb == NULL);
+    kth_chain_prefilled_transaction_list_destruct(txs);
+    kth_core_u64_list_destruct(short_ids);
+    kth_chain_header_destruct(header);
 }
 
-TEST_CASE("C-API CompactBlock - field constructor is valid",
+TEST_CASE("C-API CompactBlock - field constructor preserves fields",
           "[C-API CompactBlock]") {
     kth_compact_block_mut_t cb = make_fixture();
     REQUIRE(cb != NULL);
-    REQUIRE(kth_chain_compact_block_is_valid(cb) != 0);
+    REQUIRE(kth_chain_compact_block_nonce(cb) == 0xCAFEBABEu);
     kth_chain_compact_block_destruct(cb);
 }
 
@@ -183,17 +195,8 @@ TEST_CASE("C-API CompactBlock - copy preserves equality",
     kth_chain_compact_block_destruct(original);
 }
 
-TEST_CASE("C-API CompactBlock - equals distinguishes different instances",
-          "[C-API CompactBlock]") {
-    kth_compact_block_mut_t a = make_fixture();
-    kth_compact_block_mut_t b = kth_chain_compact_block_construct_default();
-    REQUIRE(kth_chain_compact_block_equals(a, b) == 0);
-    kth_chain_compact_block_destruct(a);
-    kth_chain_compact_block_destruct(b);
-}
-
 // ---------------------------------------------------------------------------
-// Getters / setters
+// Getters
 // ---------------------------------------------------------------------------
 
 TEST_CASE("C-API CompactBlock - header getter returns borrowed view",
@@ -205,11 +208,10 @@ TEST_CASE("C-API CompactBlock - header getter returns borrowed view",
     kth_chain_compact_block_destruct(cb);
 }
 
-TEST_CASE("C-API CompactBlock - nonce round-trips",
+TEST_CASE("C-API CompactBlock - nonce getter reflects input",
           "[C-API CompactBlock]") {
-    kth_compact_block_mut_t cb = kth_chain_compact_block_construct_default();
-    kth_chain_compact_block_set_nonce(cb, 0xDEADBEEFu);
-    REQUIRE(kth_chain_compact_block_nonce(cb) == 0xDEADBEEFu);
+    kth_compact_block_mut_t cb = make_fixture();
+    REQUIRE(kth_chain_compact_block_nonce(cb) == 0xCAFEBABEu);
     kth_chain_compact_block_destruct(cb);
 }
 
@@ -240,51 +242,42 @@ TEST_CASE("C-API CompactBlock - transactions getter reflects input",
 }
 
 // ---------------------------------------------------------------------------
-// Operations
-// ---------------------------------------------------------------------------
-
-TEST_CASE("C-API CompactBlock - reset clears the object",
-          "[C-API CompactBlock]") {
-    kth_compact_block_mut_t cb = make_fixture();
-    kth_chain_compact_block_reset(cb);
-    REQUIRE(kth_chain_compact_block_is_valid(cb) == 0);
-    kth_chain_compact_block_destruct(cb);
-}
-
-// ---------------------------------------------------------------------------
 // Preconditions (death tests via fork)
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API CompactBlock - construct null header aborts",
+TEST_CASE("C-API CompactBlock - create null header aborts",
           "[C-API CompactBlock][precondition]") {
     kth_u64_list_mut_t short_ids = make_short_ids();
     kth_transaction_mut_t tx = make_tx();
     kth_prefilled_transaction_list_mut_t txs = make_prefilled_list(tx);
+    kth_compact_block_mut_t out = NULL;
     KTH_EXPECT_ABORT(
-        kth_chain_compact_block_construct(NULL, 0u, short_ids, txs));
+        kth_chain_compact_block_create(NULL, 0u, short_ids, txs, &out));
     kth_chain_prefilled_transaction_list_destruct(txs);
     kth_chain_transaction_destruct(tx);
     kth_core_u64_list_destruct(short_ids);
 }
 
-TEST_CASE("C-API CompactBlock - construct null short_ids aborts",
+TEST_CASE("C-API CompactBlock - create null short_ids aborts",
           "[C-API CompactBlock][precondition]") {
     kth_header_mut_t header = make_header();
     kth_transaction_mut_t tx = make_tx();
     kth_prefilled_transaction_list_mut_t txs = make_prefilled_list(tx);
+    kth_compact_block_mut_t out = NULL;
     KTH_EXPECT_ABORT(
-        kth_chain_compact_block_construct(header, 0u, NULL, txs));
+        kth_chain_compact_block_create(header, 0u, NULL, txs, &out));
     kth_chain_prefilled_transaction_list_destruct(txs);
     kth_chain_transaction_destruct(tx);
     kth_chain_header_destruct(header);
 }
 
-TEST_CASE("C-API CompactBlock - construct null transactions aborts",
+TEST_CASE("C-API CompactBlock - create null transactions aborts",
           "[C-API CompactBlock][precondition]") {
     kth_header_mut_t header = make_header();
     kth_u64_list_mut_t short_ids = make_short_ids();
+    kth_compact_block_mut_t out = NULL;
     KTH_EXPECT_ABORT(
-        kth_chain_compact_block_construct(header, 0u, short_ids, NULL));
+        kth_chain_compact_block_create(header, 0u, short_ids, NULL, &out));
     kth_core_u64_list_destruct(short_ids);
     kth_chain_header_destruct(header);
 }
@@ -307,7 +300,7 @@ TEST_CASE("C-API CompactBlock - construct_from_data null out aborts",
 
 TEST_CASE("C-API CompactBlock - to_data null out_size aborts",
           "[C-API CompactBlock][precondition]") {
-    kth_compact_block_mut_t cb = kth_chain_compact_block_construct_default();
+    kth_compact_block_mut_t cb = make_fixture();
     KTH_EXPECT_ABORT(kth_chain_compact_block_to_data(cb, kProtoVersion, NULL));
     kth_chain_compact_block_destruct(cb);
 }
@@ -319,12 +312,7 @@ TEST_CASE("C-API CompactBlock - copy null aborts",
 
 TEST_CASE("C-API CompactBlock - equals null aborts",
           "[C-API CompactBlock][precondition]") {
-    kth_compact_block_mut_t other = kth_chain_compact_block_construct_default();
+    kth_compact_block_mut_t other = make_fixture();
     KTH_EXPECT_ABORT(kth_chain_compact_block_equals(NULL, other));
     kth_chain_compact_block_destruct(other);
-}
-
-TEST_CASE("C-API CompactBlock - is_valid null aborts",
-          "[C-API CompactBlock][precondition]") {
-    KTH_EXPECT_ABORT(kth_chain_compact_block_is_valid(NULL));
 }

--- a/src/c-api/test/chain/merkle_block.cpp
+++ b/src/c-api/test/chain/merkle_block.cpp
@@ -78,9 +78,11 @@ static kth_hash_list_mut_t make_two_hashes(void) {
 static kth_merkle_block_mut_t make_fixture(void) {
     kth_header_mut_t header = make_header();
     kth_hash_list_mut_t hashes = make_two_hashes();
-    kth_merkle_block_mut_t mb =
-        kth_chain_merkle_block_construct_from_header_total_transactions_hashes_flags(
-            header, 2u, hashes, kFlags, sizeof(kFlags));
+    kth_merkle_block_mut_t mb = NULL;
+    kth_error_code_t ec = kth_chain_merkle_block_create(
+        header, 2u, hashes, kFlags, sizeof(kFlags), &mb);
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(mb != NULL);
     kth_core_hash_list_destruct(hashes);
     kth_chain_header_destruct(header);
     return mb;
@@ -90,18 +92,23 @@ static kth_merkle_block_mut_t make_fixture(void) {
 // Constructors / lifecycle
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API MerkleBlock - default construct is invalid",
+TEST_CASE("C-API MerkleBlock - create rejects the empty sentinel",
           "[C-API MerkleBlock]") {
-    kth_merkle_block_mut_t mb = kth_chain_merkle_block_construct_default();
-    REQUIRE(kth_chain_merkle_block_is_valid(mb) == 0);
-    kth_chain_merkle_block_destruct(mb);
+    kth_header_mut_t header = kth_chain_header_construct_default();
+    kth_hash_list_mut_t hashes = kth_core_hash_list_construct_default();
+    kth_merkle_block_mut_t mb = NULL;
+    kth_error_code_t ec = kth_chain_merkle_block_create(
+        header, 0u, hashes, NULL, 0, &mb);
+    REQUIRE(ec != kth_ec_success);
+    REQUIRE(mb == NULL);
+    kth_core_hash_list_destruct(hashes);
+    kth_chain_header_destruct(header);
 }
 
 TEST_CASE("C-API MerkleBlock - field constructor preserves fields",
           "[C-API MerkleBlock]") {
     kth_merkle_block_mut_t mb = make_fixture();
     REQUIRE(mb != NULL);
-    REQUIRE(kth_chain_merkle_block_is_valid(mb) != 0);
     REQUIRE(kth_chain_merkle_block_total_transactions(mb) == 2u);
     kth_chain_merkle_block_destruct(mb);
 }
@@ -130,7 +137,6 @@ TEST_CASE("C-API MerkleBlock - to_data / from_data round-trip",
         raw, out_size, kProtoVersion, &decoded);
     REQUIRE(ec == kth_ec_success);
     REQUIRE(decoded != NULL);
-    REQUIRE(kth_chain_merkle_block_is_valid(decoded) != 0);
     REQUIRE(kth_chain_merkle_block_equals(original, decoded) != 0);
 
     kth_core_destruct_array(raw);
@@ -168,17 +174,8 @@ TEST_CASE("C-API MerkleBlock - copy preserves equality",
     kth_chain_merkle_block_destruct(original);
 }
 
-TEST_CASE("C-API MerkleBlock - equals distinguishes different instances",
-          "[C-API MerkleBlock]") {
-    kth_merkle_block_mut_t a = make_fixture();
-    kth_merkle_block_mut_t b = kth_chain_merkle_block_construct_default();
-    REQUIRE(kth_chain_merkle_block_equals(a, b) == 0);
-    kth_chain_merkle_block_destruct(a);
-    kth_chain_merkle_block_destruct(b);
-}
-
 // ---------------------------------------------------------------------------
-// Getters / setters
+// Getters
 // ---------------------------------------------------------------------------
 
 TEST_CASE("C-API MerkleBlock - header getter returns borrowed view",
@@ -219,64 +216,6 @@ TEST_CASE("C-API MerkleBlock - flags round-trip", "[C-API MerkleBlock]") {
     kth_chain_merkle_block_destruct(mb);
 }
 
-TEST_CASE("C-API MerkleBlock - set_total_transactions updates field",
-          "[C-API MerkleBlock]") {
-    kth_merkle_block_mut_t mb = kth_chain_merkle_block_construct_default();
-    kth_chain_merkle_block_set_total_transactions(mb, 42u);
-    REQUIRE(kth_chain_merkle_block_total_transactions(mb) == 42u);
-    kth_chain_merkle_block_destruct(mb);
-}
-
-TEST_CASE("C-API MerkleBlock - set_hashes updates list",
-          "[C-API MerkleBlock]") {
-    kth_merkle_block_mut_t mb = kth_chain_merkle_block_construct_default();
-    kth_hash_list_mut_t hashes = make_two_hashes();
-    kth_chain_merkle_block_set_hashes(mb, hashes);
-
-    kth_hash_list_const_t view = kth_chain_merkle_block_hashes(mb);
-    REQUIRE(kth_core_hash_list_count(view) == 2u);
-
-    kth_core_hash_list_destruct(hashes);
-    kth_chain_merkle_block_destruct(mb);
-}
-
-TEST_CASE("C-API MerkleBlock - set_flags updates byte buffer",
-          "[C-API MerkleBlock]") {
-    kth_merkle_block_mut_t mb = kth_chain_merkle_block_construct_default();
-    uint8_t const bytes[2] = { 0xAA, 0xBB };
-    kth_chain_merkle_block_set_flags(mb, bytes, sizeof(bytes));
-
-    kth_size_t out_size = 0;
-    uint8_t* raw = kth_chain_merkle_block_flags(mb, &out_size);
-    REQUIRE(raw != NULL);
-    REQUIRE(out_size == 2u);
-    REQUIRE(raw[0] == 0xAA);
-    REQUIRE(raw[1] == 0xBB);
-
-    kth_core_destruct_array(raw);
-    kth_chain_merkle_block_destruct(mb);
-}
-
-// ---------------------------------------------------------------------------
-// Operations
-// ---------------------------------------------------------------------------
-
-TEST_CASE("C-API MerkleBlock - reset clears the object",
-          "[C-API MerkleBlock]") {
-    kth_merkle_block_mut_t mb = make_fixture();
-    kth_chain_merkle_block_reset(mb);
-    REQUIRE(kth_chain_merkle_block_is_valid(mb) == 0);
-    REQUIRE(kth_chain_merkle_block_total_transactions(mb) == 0u);
-    REQUIRE(kth_core_hash_list_count(kth_chain_merkle_block_hashes(mb)) == 0u);
-
-    kth_size_t flags_size = 0;
-    uint8_t* flags = kth_chain_merkle_block_flags(mb, &flags_size);
-    REQUIRE(flags_size == 0u);
-    kth_core_destruct_array(flags);
-
-    kth_chain_merkle_block_destruct(mb);
-}
-
 // ---------------------------------------------------------------------------
 // Preconditions (death tests via fork)
 // ---------------------------------------------------------------------------
@@ -302,29 +241,29 @@ TEST_CASE("C-API MerkleBlock - construct_from_data non-null out slot aborts",
     // fresh slot. Overwriting a slot that already owns a handle would
     // silently leak the previous object, so the contract rejects it.
     uint8_t data[2] = { 0x00, 0x00 };
-    kth_merkle_block_mut_t out = kth_chain_merkle_block_construct_default();
+    kth_merkle_block_mut_t out = make_fixture();
     KTH_EXPECT_ABORT(kth_chain_merkle_block_construct_from_data(
         data, 2, kProtoVersion, &out));
     kth_chain_merkle_block_destruct(out);
 }
 
-TEST_CASE("C-API MerkleBlock - construct_from_header null header aborts",
+TEST_CASE("C-API MerkleBlock - create null header aborts",
           "[C-API MerkleBlock][precondition]") {
     kth_hash_list_mut_t hashes = make_two_hashes();
-    KTH_EXPECT_ABORT(
-        kth_chain_merkle_block_construct_from_header_total_transactions_hashes_flags(
-            NULL, 2u, hashes, kFlags, sizeof(kFlags)));
+    kth_merkle_block_mut_t out = NULL;
+    KTH_EXPECT_ABORT(kth_chain_merkle_block_create(
+        NULL, 2u, hashes, kFlags, sizeof(kFlags), &out));
     kth_core_hash_list_destruct(hashes);
 }
 
-TEST_CASE("C-API MerkleBlock - construct_from_block null block aborts",
+TEST_CASE("C-API MerkleBlock - construct null block aborts",
           "[C-API MerkleBlock][precondition]") {
-    KTH_EXPECT_ABORT(kth_chain_merkle_block_construct_from_block(NULL));
+    KTH_EXPECT_ABORT(kth_chain_merkle_block_construct(NULL));
 }
 
 TEST_CASE("C-API MerkleBlock - to_data null out_size aborts",
           "[C-API MerkleBlock][precondition]") {
-    kth_merkle_block_mut_t mb = kth_chain_merkle_block_construct_default();
+    kth_merkle_block_mut_t mb = make_fixture();
     KTH_EXPECT_ABORT(kth_chain_merkle_block_to_data(mb, kProtoVersion, NULL));
     kth_chain_merkle_block_destruct(mb);
 }
@@ -336,38 +275,12 @@ TEST_CASE("C-API MerkleBlock - copy null aborts",
 
 TEST_CASE("C-API MerkleBlock - equals null aborts",
           "[C-API MerkleBlock][precondition]") {
-    kth_merkle_block_mut_t other = kth_chain_merkle_block_construct_default();
+    kth_merkle_block_mut_t other = make_fixture();
     KTH_EXPECT_ABORT(kth_chain_merkle_block_equals(NULL, other));
     kth_chain_merkle_block_destruct(other);
-}
-
-TEST_CASE("C-API MerkleBlock - is_valid null aborts",
-          "[C-API MerkleBlock][precondition]") {
-    KTH_EXPECT_ABORT(kth_chain_merkle_block_is_valid(NULL));
 }
 
 TEST_CASE("C-API MerkleBlock - header getter null aborts",
           "[C-API MerkleBlock][precondition]") {
     KTH_EXPECT_ABORT(kth_chain_merkle_block_header(NULL));
-}
-
-TEST_CASE("C-API MerkleBlock - set_header null value aborts",
-          "[C-API MerkleBlock][precondition]") {
-    kth_merkle_block_mut_t mb = kth_chain_merkle_block_construct_default();
-    KTH_EXPECT_ABORT(kth_chain_merkle_block_set_header(mb, NULL));
-    kth_chain_merkle_block_destruct(mb);
-}
-
-TEST_CASE("C-API MerkleBlock - set_hashes null value aborts",
-          "[C-API MerkleBlock][precondition]") {
-    kth_merkle_block_mut_t mb = kth_chain_merkle_block_construct_default();
-    KTH_EXPECT_ABORT(kth_chain_merkle_block_set_hashes(mb, NULL));
-    kth_chain_merkle_block_destruct(mb);
-}
-
-TEST_CASE("C-API MerkleBlock - set_flags null with non-zero size aborts",
-          "[C-API MerkleBlock][precondition]") {
-    kth_merkle_block_mut_t mb = kth_chain_merkle_block_construct_default();
-    KTH_EXPECT_ABORT(kth_chain_merkle_block_set_flags(mb, NULL, 1));
-    kth_chain_merkle_block_destruct(mb);
 }

--- a/src/domain/include/kth/domain/message/compact_block.hpp
+++ b/src/domain/include/kth/domain/message/compact_block.hpp
@@ -27,56 +27,35 @@ struct KD_API compact_block {
     using short_id = uint64_t;
     using short_id_list = std::vector<short_id>;
 
+    /// Derive a compact block from an (already valid) block.
     static
     compact_block factory_from_block(message::block const& blk);
 
-    compact_block() = default;
-    compact_block(chain::header const& header, uint64_t nonce, short_id_list const& short_ids, prefilled_transaction::list const& transactions);
-    compact_block(chain::header const& header, uint64_t nonce, short_id_list&& short_ids, prefilled_transaction::list&& transactions);
+    /// Build from parts. Returns `error::compact_block_construction_empty` for
+    /// the all-default sentinel (an empty header with no payload).
+    static
+    expect<compact_block> create(chain::header header, uint64_t nonce, short_id_list short_ids, prefilled_transaction::list transactions);
 
     [[nodiscard]]
     friend bool operator==(compact_block const&, compact_block const&) = default;
 
-    chain::header& header();
-
     [[nodiscard]]
     chain::header const& header() const;
-
-    void set_header(chain::header const& value);
 
     [[nodiscard]]
     uint64_t nonce() const;
 
-    void set_nonce(uint64_t value);
-
-    short_id_list& short_ids();
-
     [[nodiscard]]
     short_id_list const& short_ids() const;
-
-    void set_short_ids(short_id_list const& value);
-    void set_short_ids(short_id_list&& value);
-
-    prefilled_transaction::list& transactions();
 
     [[nodiscard]]
     prefilled_transaction::list const& transactions() const;
 
-    void set_transactions(prefilled_transaction::list const& value);
-    void set_transactions(prefilled_transaction::list&& value);
-
     static
     expect<compact_block> from_data(byte_reader& reader, uint32_t version);
 
-    bool from_block(message::block const& block);
-
     [[nodiscard]]
     expect<void> to_data(byte_writer& writer, uint32_t version) const;
-
-    [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
 
     [[nodiscard]]
     size_t serialized_size(uint32_t version) const;
@@ -91,6 +70,11 @@ struct KD_API compact_block {
     uint32_t const version_maximum;
 
 private:
+    // Construction goes through `create` / `from_data` / `factory_from_block`,
+    // which guarantee a non-sentinel value.
+    compact_block(chain::header const& header, uint64_t nonce, short_id_list const& short_ids, prefilled_transaction::list const& transactions);
+    compact_block(chain::header const& header, uint64_t nonce, short_id_list&& short_ids, prefilled_transaction::list&& transactions);
+
     chain::header header_;
     uint64_t nonce_{0};
     short_id_list short_ids_;

--- a/src/domain/include/kth/domain/message/merkle_block.hpp
+++ b/src/domain/include/kth/domain/message/merkle_block.hpp
@@ -25,52 +25,35 @@ struct KD_API merkle_block {
     using ptr = std::shared_ptr<merkle_block>;
     using const_ptr = std::shared_ptr<const merkle_block>;
 
-    merkle_block() = default;
-    merkle_block(chain::header const& header, size_t total_transactions, hash_list const& hashes, data_chunk const& flags);
-    merkle_block(chain::header const& header, size_t total_transactions, hash_list&& hashes, data_chunk&& flags);
+    /// Build from parts. Returns `error::merkle_block_construction_empty` for
+    /// the all-default sentinel (an empty header with no hashes or flags), so
+    /// a constructed `merkle_block` is always a real one.
+    static
+    expect<merkle_block> create(chain::header header, size_t total_transactions, hash_list hashes, data_chunk flags);
+
+    /// Wrap an already-constructed (hence valid) block.
     merkle_block(chain::block const& block);
 
-    bool operator==(merkle_block const& x) const;
-    bool operator!=(merkle_block const& x) const;
-
-    chain::header& header();
+    [[nodiscard]]
+    friend bool operator==(merkle_block const&, merkle_block const&) = default;
 
     [[nodiscard]]
     chain::header const& header() const;
 
-    void set_header(chain::header const& value);
-
     [[nodiscard]]
     size_t total_transactions() const;
-
-    void set_total_transactions(size_t value);
-
-    hash_list& hashes();
 
     [[nodiscard]]
     hash_list const& hashes() const;
 
-    void set_hashes(hash_list const& value);
-    void set_hashes(hash_list&& value);
-
-    data_chunk& flags();
-
     [[nodiscard]]
     data_chunk const& flags() const;
-
-    void set_flags(data_chunk const& value);
-    void set_flags(data_chunk&& value);
 
     static
     expect<merkle_block> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
     expect<void> to_data(byte_writer& writer, uint32_t version) const;
-
-    [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
 
     [[nodiscard]]
     size_t serialized_size(uint32_t version) const;
@@ -87,6 +70,11 @@ struct KD_API merkle_block {
 
 
 private:
+    // Construction goes through `create` / `from_data` / the block-wrapping
+    // ctor, which guarantee a non-sentinel value.
+    merkle_block(chain::header const& header, size_t total_transactions, hash_list&& hashes, data_chunk&& flags);
+    merkle_block(chain::header const& header, size_t total_transactions, hash_list const& hashes, data_chunk const& flags);
+
     chain::header header_;
     size_t total_transactions_{0};
     hash_list hashes_;

--- a/src/domain/src/message/compact_block.cpp
+++ b/src/domain/src/message/compact_block.cpp
@@ -12,7 +12,7 @@
 #include <kth/infrastructure/math/sip_hash.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
-#include <kth/infrastructure/utility/pseudo_random_broken_do_not_use.hpp>
+#include <kth/infrastructure/utility/pseudo_random.hpp>
 
 namespace kth::domain::message {
 
@@ -20,10 +20,39 @@ std::string const compact_block::command = "cmpctblock";
 uint32_t const compact_block::version_minimum = version::level::bip152;
 uint32_t const compact_block::version_maximum = version::level::bip152;
 
-compact_block compact_block::factory_from_block(message::block const& blk) {
-    compact_block instance;
-    instance.from_block(blk);
-    return instance;
+// static
+compact_block compact_block::factory_from_block(message::block const& block) {
+    // BIP152: the nonce salts the SipHash short-id computation, so it must be
+    // unpredictable to an adversary (otherwise short-id collisions can be
+    // ground out to force block-reconstruction failures). Use the CSPRNG.
+    uint64_t nonce = 0;
+    pseudo_random::fill(reinterpret_cast<uint8_t*>(&nonce), sizeof(nonce));
+
+    prefilled_transaction::list prefilled_list{prefilled_transaction{0, block.transactions()[0]}};
+
+    auto header_hash = hash(block, nonce);
+    auto k0 = from_little_endian_unsafe<uint64_t>(header_hash);
+    auto k1 = from_little_endian_unsafe<uint64_t>(std::span{header_hash}.subspan(sizeof(uint64_t)));
+
+    compact_block::short_id_list short_ids_list;
+    short_ids_list.reserve(block.transactions().size() - 1);
+    for (size_t i = 1; i < block.transactions().size(); ++i) {
+        uint64_t shortid = sip_hash_uint256(k0, k1, block.transactions()[i].hash()) & uint64_t(0xffffffffffff);
+        short_ids_list.push_back(shortid);
+    }
+
+    // A block always carries a valid header and a coinbase, so the result is
+    // never the empty sentinel.
+    return compact_block{block.header(), nonce, std::move(short_ids_list), std::move(prefilled_list)};
+}
+
+// static
+expect<compact_block> compact_block::create(chain::header header, uint64_t nonce, short_id_list short_ids, prefilled_transaction::list transactions) {
+    // Reject the all-default sentinel (what the old `is_valid()` guarded).
+    if ( ! header.is_valid() && short_ids.empty() && transactions.empty()) {
+        return std::unexpected(error::compact_block_construction_empty);
+    }
+    return compact_block{header, nonce, std::move(short_ids), std::move(transactions)};
 }
 
 compact_block::compact_block(chain::header const& header, uint64_t nonce, short_id_list const& short_ids, prefilled_transaction::list const& transactions)
@@ -56,51 +85,6 @@ compact_block::compact_block(chain::header const& header, uint64_t nonce, short_
 //     transactions_ = std::move(x.transactions_);
 //     return *this;
 // }
-
-bool compact_block::is_valid() const {
-    //std::println("compact_block::is_valid");
-
-    return header_.is_valid()
-        && ! short_ids_.empty()
-        && ! transactions_.empty();
-}
-
-void compact_block::reset() {
-    //std::println("compact_block::reset");
-
-    header_ = chain::header{};
-    nonce_ = 0;
-    short_ids_.clear();
-    short_ids_.shrink_to_fit();
-    transactions_.clear();
-    transactions_.shrink_to_fit();
-}
-
-bool compact_block::from_block(message::block const& block) {
-    reset();
-
-    header_ = block.header();
-    nonce_ = pseudo_random_broken_do_not_use(1, max_uint64);
-
-    prefilled_transaction::list prefilled_list{prefilled_transaction{0, block.transactions()[0]}};
-
-    auto header_hash = hash(block, nonce_);
-
-    auto k0 = from_little_endian_unsafe<uint64_t>(header_hash);
-    auto k1 = from_little_endian_unsafe<uint64_t>(std::span{header_hash}.subspan(sizeof(uint64_t)));
-
-    compact_block::short_id_list short_ids_list;
-    short_ids_list.reserve(block.transactions().size() - 1);
-    for (size_t i = 1; i < block.transactions().size(); ++i) {
-        uint64_t shortid = sip_hash_uint256(k0, k1, block.transactions()[i].hash()) & uint64_t(0xffffffffffff);
-        short_ids_list.push_back(shortid);
-    }
-
-    short_ids_ = std::move(short_ids_list);
-    transactions_ = std::move(prefilled_list);
-
-    return true;
-}
 
 // Deserialization.
 //-----------------------------------------------------------------------------
@@ -149,7 +133,7 @@ expect<compact_block> compact_block::from_data(byte_reader& reader, uint32_t ver
         return std::unexpected(error::version_too_low);
     }
 
-    return compact_block(*header, *nonce, std::move(short_ids), std::move(*txs));
+    return create(*header, *nonce, std::move(short_ids), std::move(*txs));
 }
 
 // Serialization.
@@ -173,67 +157,20 @@ size_t compact_block::serialized_size(uint32_t version) const {
     return size;
 }
 
-chain::header& compact_block::header() {
-    //std::println("compact_block::header");
-
-    return header_;
-}
-
 chain::header const& compact_block::header() const {
-    //std::println("compact_block::header 2");
-
     return header_;
-}
-
-void compact_block::set_header(chain::header const& value) {
-    //std::println("compact_block::set_header");
-
-    header_ = value;
 }
 
 uint64_t compact_block::nonce() const {
-    //std::println("compact_block::nonce");
-
     return nonce_;
 }
 
-void compact_block::set_nonce(uint64_t value) {
-    //std::println("compact_block::set_nonce");
-    nonce_ = value;
-}
-
-compact_block::short_id_list& compact_block::short_ids() {
-    //std::println("compact_block::short_ids");
-    return short_ids_;
-}
-
 compact_block::short_id_list const& compact_block::short_ids() const {
-    //std::println("compact_block::short_ids 2");
     return short_ids_;
-}
-
-void compact_block::set_short_ids(short_id_list const& value) {
-    short_ids_ = value;
-}
-
-void compact_block::set_short_ids(short_id_list&& value) {
-    short_ids_ = std::move(value);
-}
-
-prefilled_transaction::list& compact_block::transactions() {
-    return transactions_;
 }
 
 prefilled_transaction::list const& compact_block::transactions() const {
     return transactions_;
-}
-
-void compact_block::set_transactions(prefilled_transaction::list const& value) {
-    transactions_ = value;
-}
-
-void compact_block::set_transactions(prefilled_transaction::list&& value) {
-    transactions_ = std::move(value);
 }
 
 hash_digest hash(compact_block const& block) {

--- a/src/domain/src/message/merkle_block.cpp
+++ b/src/domain/src/message/merkle_block.cpp
@@ -34,38 +34,13 @@ merkle_block::merkle_block(chain::block const& block)
                    {}) {
 }
 
-bool merkle_block::operator==(merkle_block const& x) const {
-    auto result = (header_ == x.header_) &&
-                  (hashes_.size() == x.hashes_.size()) &&
-                  (flags_.size() == x.flags_.size());
-
-    for (size_t i = 0; i < hashes_.size() && result; i++) {
-        result = (hashes_[i] == x.hashes_[i]);
+// static
+expect<merkle_block> merkle_block::create(chain::header header, size_t total_transactions, hash_list hashes, data_chunk flags) {
+    // Reject the all-default sentinel (what the old `is_valid()` guarded).
+    if (hashes.empty() && flags.empty() && ! header.is_valid()) {
+        return std::unexpected(error::merkle_block_construction_empty);
     }
-
-    for (size_t i = 0; i < flags_.size() && result; i++) {
-        result = (flags_[i] == x.flags_[i]);
-    }
-
-    return result;
-}
-
-bool merkle_block::operator!=(merkle_block const& x) const {
-    return !(*this == x);
-}
-
-
-bool merkle_block::is_valid() const {
-    return !hashes_.empty() || !flags_.empty() || header_.is_valid();
-}
-
-void merkle_block::reset() {
-    header_ = chain::header{};
-    total_transactions_ = 0;
-    hashes_.clear();
-    hashes_.shrink_to_fit();
-    flags_.clear();
-    flags_.shrink_to_fit();
+    return merkle_block{header, total_transactions, std::move(hashes), std::move(flags)};
 }
 
 // Deserialization.
@@ -116,7 +91,7 @@ expect<merkle_block> merkle_block::from_data(byte_reader& reader, uint32_t versi
         return std::unexpected(error::unsupported_version);
     }
 
-    return merkle_block(
+    return create(
         *header,
         *total_transactions,
         std::move(hashes),
@@ -135,56 +110,20 @@ size_t merkle_block::serialized_size(uint32_t /*version*/) const {
            infrastructure::message::variable_uint_size(flags_.size()) + flags_.size();
 }
 
-chain::header& merkle_block::header() {
-    return header_;
-}
-
 chain::header const& merkle_block::header() const {
     return header_;
-}
-
-void merkle_block::set_header(chain::header const& value) {
-    header_ = value;
 }
 
 size_t merkle_block::total_transactions() const {
     return total_transactions_;
 }
 
-void merkle_block::set_total_transactions(size_t value) {
-    total_transactions_ = value;
-}
-
-hash_list& merkle_block::hashes() {
-    return hashes_;
-}
-
 hash_list const& merkle_block::hashes() const {
     return hashes_;
 }
 
-void merkle_block::set_hashes(hash_list const& value) {
-    hashes_ = value;
-}
-
-void merkle_block::set_hashes(hash_list&& value) {
-    hashes_ = std::move(value);
-}
-
-data_chunk& merkle_block::flags() {
-    return flags_;
-}
-
 data_chunk const& merkle_block::flags() const {
     return flags_;
-}
-
-void merkle_block::set_flags(data_chunk const& value) {
-    flags_ = value;
-}
-
-void merkle_block::set_flags(data_chunk&& value) {
-    flags_ = std::move(value);
 }
 
 expect<void> merkle_block::to_data(byte_writer& writer, uint32_t version) const {

--- a/src/domain/test/message/compact_block.cpp
+++ b/src/domain/test/message/compact_block.cpp
@@ -7,12 +7,7 @@
 using namespace kth;
 using namespace kd;
 
-// Start Test Suite: compact block tests
-
-TEST_CASE("compact block constructor 1 always invalid", "[compact block]") {
-    message::compact_block instance;
-    REQUIRE( ! instance.is_valid());
-}
+namespace {
 
 uint64_t convert_to_uint64t(std::string const& rawdata) {
     uint64_t value;
@@ -21,132 +16,59 @@ uint64_t convert_to_uint64t(std::string const& rawdata) {
     return value;
 }
 
-TEST_CASE("compact block constructor 2 always equals params", "[compact block]") {
-    chain::header const header(10u,
-                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-                               531234u,
-                               6523454u,
-                               68644u);
+chain::header const test_header{10u,
+    "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+    "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
+    531234u,
+    6523454u,
+    68644u};
 
-    uint64_t nonce = 453245u;
+message::compact_block::short_id_list const test_short_ids{
+    convert_to_uint64t("aaaaaaaaaaaa"),
+    convert_to_uint64t("bbbbbbbbbbbb"),
+    convert_to_uint64t("0f0f0f0f0f0f"),
+    convert_to_uint64t("f0f0f0f0f0f0")};
 
-    const message::compact_block::short_id_list& short_ids = {
-        convert_to_uint64t("aaaaaaaaaaaa"),
-        convert_to_uint64t("bbbbbbbbbbbb"),
-        convert_to_uint64t("0f0f0f0f0f0f"),
-        convert_to_uint64t("f0f0f0f0f0f0")};
+message::prefilled_transaction::list const test_transactions{
+    message::prefilled_transaction(10, chain::transaction(1, 48, {}, {})),
+    message::prefilled_transaction(20, chain::transaction(2, 32, {}, {})),
+    message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))};
 
-    const message::prefilled_transaction::list transactions = {
-        message::prefilled_transaction(10, chain::transaction(1, 48, {}, {})),
-        message::prefilled_transaction(20, chain::transaction(2, 32, {}, {})),
-        message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))};
-
-    message::compact_block instance(header, nonce, short_ids, transactions);
-    REQUIRE(instance.is_valid());
-    REQUIRE(header == instance.header());
-    REQUIRE(nonce == instance.nonce());
-    REQUIRE(short_ids == instance.short_ids());
-    REQUIRE(transactions == instance.transactions());
+message::compact_block make_compact_block(uint64_t nonce = 453245u) {
+    return message::compact_block::create(test_header, nonce, test_short_ids, test_transactions).value();
 }
 
-TEST_CASE("compact block constructor 3 always equals params", "[compact block]") {
-    chain::header const header(10u,
-                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-                               531234u,
-                               6523454u,
-                               68644u);
-    chain::header dup_header(header);
+} // namespace
 
-    uint64_t nonce = 453245u;
-    const message::compact_block::short_id_list short_ids = {
-        convert_to_uint64t("aaaaaaaaaaaa"),
-        convert_to_uint64t("bbbbbbbbbbbb"),
-        convert_to_uint64t("0f0f0f0f0f0f"),
-        convert_to_uint64t("f0f0f0f0f0f0")};
-    message::compact_block::short_id_list dup_short_ids = short_ids;
+// Start Test Suite: compact block tests
 
-    const message::prefilled_transaction::list transactions = {
-        message::prefilled_transaction(10, chain::transaction(1, 48, {}, {})),
-        message::prefilled_transaction(20, chain::transaction(2, 32, {}, {})),
-        message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))};
-    message::prefilled_transaction::list dup_transactions = transactions;
-
-    message::compact_block instance(std::move(dup_header), nonce,
-                                    std::move(dup_short_ids), std::move(dup_transactions));
-
-    REQUIRE(instance.is_valid());
-    REQUIRE(header == instance.header());
-    REQUIRE(nonce == instance.nonce());
-    REQUIRE(short_ids == instance.short_ids());
-    REQUIRE(transactions == instance.transactions());
+TEST_CASE("compact block create rejects empty sentinel", "[compact block]") {
+    auto const result = message::compact_block::create(chain::header{}, 0u, {}, {});
+    REQUIRE( ! result);
+    REQUIRE(result.error() == error::compact_block_construction_empty);
 }
 
-TEST_CASE("compact block constructor 4 always equals params", "[compact block]") {
-    chain::header const header(10u,
-                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-                               531234u,
-                               6523454u,
-                               68644u);
+TEST_CASE("compact block create always equals params", "[compact block]") {
+    uint64_t const nonce = 453245u;
+    auto const instance = message::compact_block::create(test_header, nonce, test_short_ids, test_transactions).value();
+    REQUIRE(test_header == instance.header());
+    REQUIRE(nonce == instance.nonce());
+    REQUIRE(test_short_ids == instance.short_ids());
+    REQUIRE(test_transactions == instance.transactions());
+}
 
-    uint64_t nonce = 453245u;
-    const message::compact_block::short_id_list short_ids = {
-        convert_to_uint64t("aaaaaaaaaaaa"),
-        convert_to_uint64t("bbbbbbbbbbbb"),
-        convert_to_uint64t("0f0f0f0f0f0f"),
-        convert_to_uint64t("f0f0f0f0f0f0")};
-
-    const message::prefilled_transaction::list transactions = {
-        message::prefilled_transaction(10, chain::transaction(1, 48, {}, {})),
-        message::prefilled_transaction(20, chain::transaction(2, 32, {}, {})),
-        message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))};
-
-    const message::compact_block value(header, nonce, short_ids, transactions);
-
+TEST_CASE("compact block copy equals params", "[compact block]") {
+    auto const value = make_compact_block();
     message::compact_block instance(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(value == instance);
-    REQUIRE(header == instance.header());
-    REQUIRE(nonce == instance.nonce());
-    REQUIRE(short_ids == instance.short_ids());
-    REQUIRE(transactions == instance.transactions());
-}
-
-TEST_CASE("compact block constructor 5 always equals params", "[compact block]") {
-    chain::header const header(10u,
-                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-                               531234u,
-                               6523454u,
-                               68644u);
-
-    uint64_t nonce = 453245u;
-    const message::compact_block::short_id_list short_ids = {
-        convert_to_uint64t("aaaaaaaaaaaa"),
-        convert_to_uint64t("bbbbbbbbbbbb"),
-        convert_to_uint64t("0f0f0f0f0f0f"),
-        convert_to_uint64t("f0f0f0f0f0f0")};
-
-    const message::prefilled_transaction::list transactions = {
-        message::prefilled_transaction(10, chain::transaction(1, 48, {}, {})),
-        message::prefilled_transaction(20, chain::transaction(2, 32, {}, {})),
-        message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))};
-
-    message::compact_block value(header, nonce, short_ids, transactions);
-
-    message::compact_block instance(std::move(value));
-    REQUIRE(instance.is_valid());
-    REQUIRE(header == instance.header());
-    REQUIRE(nonce == instance.nonce());
-    REQUIRE(short_ids == instance.short_ids());
-    REQUIRE(transactions == instance.transactions());
+    REQUIRE(test_header == instance.header());
+    REQUIRE(453245u == instance.nonce());
+    REQUIRE(test_short_ids == instance.short_ids());
+    REQUIRE(test_transactions == instance.transactions());
 }
 
 TEST_CASE("compact block from data insufficient bytes failure", "[compact block]") {
     data_chunk const raw{0xab, 0xcd};
-    message::compact_block instance{};
     byte_reader reader(raw);
     auto result = message::compact_block::from_data(reader, message::compact_block::version_minimum);
     REQUIRE( ! result);
@@ -156,7 +78,6 @@ TEST_CASE("compact block from data insufficient bytes failure", "[compact block]
 TEST_CASE("compact block from data insufficient bytes mid transaction failure", "[compact block]") {
     auto const raw = to_chunk("0a0000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d61900000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a221b08003e8a6300240c0100d20400000000000004000000121212121212343434343434565656565678789a9a0201000000010000000000000100000001000000"_base16);
 
-    message::compact_block instance{};
     byte_reader reader(raw);
     auto result = message::compact_block::from_data(reader, message::compact_block::version_minimum);
     REQUIRE( ! result);
@@ -192,383 +113,53 @@ TEST_CASE("compact block from data valid input success", "[compact block]") {
     REQUIRE(result_exp2);
     auto const result = std::move(*result_exp2);
 
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
     REQUIRE(data.size() == result.serialized_size(message::compact_block::version_minimum));
     REQUIRE(expected.serialized_size(message::compact_block::version_minimum) == result.serialized_size(message::compact_block::version_minimum));
 }
 
-TEST_CASE("compact block header accessor 1 always returns initialized value", "[compact block]") {
-    chain::header const header(10u,
-                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-                               531234u,
-                               6523454u,
-                               68644u);
-
-    uint64_t nonce = 453245u;
-    const message::compact_block::short_id_list short_ids = {
-        convert_to_uint64t("aaaaaaaaaaaa"),
-        convert_to_uint64t("bbbbbbbbbbbb"),
-        convert_to_uint64t("0f0f0f0f0f0f"),
-        convert_to_uint64t("f0f0f0f0f0f0")};
-
-    const message::prefilled_transaction::list transactions = {
-        message::prefilled_transaction(10, chain::transaction(1, 48, {}, {})),
-        message::prefilled_transaction(20, chain::transaction(2, 32, {}, {})),
-        message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))};
-
-    message::compact_block instance(header, nonce, short_ids, transactions);
-    REQUIRE(header == instance.header());
-}
-
-TEST_CASE("compact block header accessor 2 always returns initialized value", "[compact block]") {
-    chain::header const header(10u,
-                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-                               531234u,
-                               6523454u,
-                               68644u);
-
-    uint64_t nonce = 453245u;
-    const message::compact_block::short_id_list short_ids = {
-        convert_to_uint64t("aaaaaaaaaaaa"),
-        convert_to_uint64t("bbbbbbbbbbbb"),
-        convert_to_uint64t("0f0f0f0f0f0f"),
-        convert_to_uint64t("f0f0f0f0f0f0")};
-
-    const message::prefilled_transaction::list transactions = {
-        message::prefilled_transaction(10, chain::transaction(1, 48, {}, {})),
-        message::prefilled_transaction(20, chain::transaction(2, 32, {}, {})),
-        message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))};
-
-    const message::compact_block instance(header, nonce, short_ids, transactions);
-    REQUIRE(header == instance.header());
-}
-
-TEST_CASE("compact block header setter 1 roundtrip success", "[compact block]") {
-    chain::header const value(10u,
-                              "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-                              "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-                              531234u,
-                              6523454u,
-                              68644u);
-
-    message::compact_block instance;
-    REQUIRE(value != instance.header());
-    instance.set_header(value);
-    REQUIRE(value == instance.header());
-}
-
-TEST_CASE("compact block header setter 2 roundtrip success", "[compact block]") {
-    chain::header const value(10u,
-                              "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-                              "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-                              531234u,
-                              6523454u,
-                              68644u);
-    chain::header dup(value);
-
-    message::compact_block instance;
-    REQUIRE(value != instance.header());
-    instance.set_header(std::move(dup));
-    REQUIRE(value == instance.header());
+TEST_CASE("compact block header accessor always returns initialized value", "[compact block]") {
+    auto const instance = make_compact_block();
+    REQUIRE(test_header == instance.header());
 }
 
 TEST_CASE("compact block nonce accessor always returns initialized value", "[compact block]") {
-    chain::header const header(10u,
-                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-                               531234u,
-                               6523454u,
-                               68644u);
-
-    uint64_t nonce = 453245u;
-    const message::compact_block::short_id_list short_ids = {
-        convert_to_uint64t("aaaaaaaaaaaa"),
-        convert_to_uint64t("bbbbbbbbbbbb"),
-        convert_to_uint64t("0f0f0f0f0f0f"),
-        convert_to_uint64t("f0f0f0f0f0f0")};
-
-    const message::prefilled_transaction::list transactions = {
-        message::prefilled_transaction(10, chain::transaction(1, 48, {}, {})),
-        message::prefilled_transaction(20, chain::transaction(2, 32, {}, {})),
-        message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))};
-
-    message::compact_block instance(header, nonce, short_ids, transactions);
+    uint64_t const nonce = 453245u;
+    auto const instance = make_compact_block(nonce);
     REQUIRE(nonce == instance.nonce());
 }
 
-TEST_CASE("compact block nonce setter roundtrip success", "[compact block]") {
-    uint64_t value = 123356u;
-
-    message::compact_block instance;
-    REQUIRE(value != instance.nonce());
-    instance.set_nonce(value);
-    REQUIRE(value == instance.nonce());
+TEST_CASE("compact block short ids accessor always returns initialized value", "[compact block]") {
+    auto const instance = make_compact_block();
+    REQUIRE(test_short_ids == instance.short_ids());
 }
 
-TEST_CASE("compact block short ids accessor 1 always returns initialized value", "[compact block]") {
-    chain::header const header(10u,
-                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-                               531234u,
-                               6523454u,
-                               68644u);
-
-    uint64_t nonce = 453245u;
-    const message::compact_block::short_id_list short_ids = {
-        convert_to_uint64t("aaaaaaaaaaaa"),
-        convert_to_uint64t("bbbbbbbbbbbb"),
-        convert_to_uint64t("0f0f0f0f0f0f"),
-        convert_to_uint64t("f0f0f0f0f0f0")};
-
-    const message::prefilled_transaction::list transactions = {
-        message::prefilled_transaction(10, chain::transaction(1, 48, {}, {})),
-        message::prefilled_transaction(20, chain::transaction(2, 32, {}, {})),
-        message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))};
-
-    message::compact_block instance(header, nonce, short_ids, transactions);
-    REQUIRE(short_ids == instance.short_ids());
-}
-
-TEST_CASE("compact block short ids accessor 2 always returns initialized value", "[compact block]") {
-    chain::header const header(10u,
-                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-                               531234u,
-                               6523454u,
-                               68644u);
-
-    uint64_t nonce = 453245u;
-    const message::compact_block::short_id_list short_ids = {
-        convert_to_uint64t("aaaaaaaaaaaa"),
-        convert_to_uint64t("bbbbbbbbbbbb"),
-        convert_to_uint64t("0f0f0f0f0f0f"),
-        convert_to_uint64t("f0f0f0f0f0f0")};
-
-    const message::prefilled_transaction::list transactions = {
-        message::prefilled_transaction(10, chain::transaction(1, 48, {}, {})),
-        message::prefilled_transaction(20, chain::transaction(2, 32, {}, {})),
-        message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))};
-
-    const message::compact_block instance(header, nonce, short_ids, transactions);
-    REQUIRE(short_ids == instance.short_ids());
-}
-
-TEST_CASE("compact block short ids setter 1 roundtrip success", "[compact block]") {
-    const message::compact_block::short_id_list value = {
-        convert_to_uint64t("aaaaaaaaaaaa"),
-        convert_to_uint64t("bbbbbbbbbbbb"),
-        convert_to_uint64t("0f0f0f0f0f0f"),
-        convert_to_uint64t("f0f0f0f0f0f0")};
-
-    message::compact_block instance;
-    REQUIRE(value != instance.short_ids());
-    instance.set_short_ids(value);
-    REQUIRE(value == instance.short_ids());
-}
-
-TEST_CASE("compact block short ids setter 2 roundtrip success", "[compact block]") {
-    const message::compact_block::short_id_list value = {
-        convert_to_uint64t("aaaaaaaaaaaa"),
-        convert_to_uint64t("bbbbbbbbbbbb"),
-        convert_to_uint64t("0f0f0f0f0f0f"),
-        convert_to_uint64t("f0f0f0f0f0f0")};
-    message::compact_block::short_id_list dup(value);
-
-    message::compact_block instance;
-    REQUIRE(value != instance.short_ids());
-    instance.set_short_ids(std::move(dup));
-    REQUIRE(value == instance.short_ids());
-}
-
-TEST_CASE("compact block transactions accessor 1 always returns initialized value", "[compact block]") {
-    chain::header const header(10u,
-                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-                               531234u,
-                               6523454u,
-                               68644u);
-
-    uint64_t nonce = 453245u;
-    const message::compact_block::short_id_list short_ids = {
-        convert_to_uint64t("aaaaaaaaaaaa"),
-        convert_to_uint64t("bbbbbbbbbbbb"),
-        convert_to_uint64t("0f0f0f0f0f0f"),
-        convert_to_uint64t("f0f0f0f0f0f0")};
-
-    const message::prefilled_transaction::list transactions = {
-        message::prefilled_transaction(10, chain::transaction(1, 48, {}, {})),
-        message::prefilled_transaction(20, chain::transaction(2, 32, {}, {})),
-        message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))};
-
-    message::compact_block instance(header, nonce, short_ids, transactions);
-    REQUIRE(transactions == instance.transactions());
-}
-
-TEST_CASE("compact block transactions accessor 2 always returns initialized value", "[compact block]") {
-    chain::header const header(10u,
-                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-                               531234u,
-                               6523454u,
-                               68644u);
-
-    uint64_t nonce = 453245u;
-    const message::compact_block::short_id_list short_ids = {
-        convert_to_uint64t("aaaaaaaaaaaa"),
-        convert_to_uint64t("bbbbbbbbbbbb"),
-        convert_to_uint64t("0f0f0f0f0f0f"),
-        convert_to_uint64t("f0f0f0f0f0f0")};
-
-    const message::prefilled_transaction::list transactions = {
-        message::prefilled_transaction(10, chain::transaction(1, 48, {}, {})),
-        message::prefilled_transaction(20, chain::transaction(2, 32, {}, {})),
-        message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))};
-
-    const message::compact_block instance(header, nonce, short_ids, transactions);
-    REQUIRE(transactions == instance.transactions());
-}
-
-TEST_CASE("compact block transactions setter 1 roundtrip success", "[compact block]") {
-    const message::prefilled_transaction::list value = {
-        message::prefilled_transaction(10, chain::transaction(1, 48, {}, {})),
-        message::prefilled_transaction(20, chain::transaction(2, 32, {}, {})),
-        message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))};
-
-    message::compact_block instance;
-    REQUIRE(value != instance.transactions());
-    instance.set_transactions(value);
-    REQUIRE(value == instance.transactions());
-}
-
-TEST_CASE("compact block transactions setter 2 roundtrip success", "[compact block]") {
-    const message::prefilled_transaction::list value = {
-        message::prefilled_transaction(10, chain::transaction(1, 48, {}, {})),
-        message::prefilled_transaction(20, chain::transaction(2, 32, {}, {})),
-        message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))};
-    message::prefilled_transaction::list dup(value);
-
-    message::compact_block instance;
-    REQUIRE(value != instance.transactions());
-    instance.set_transactions(std::move(dup));
-    REQUIRE(value == instance.transactions());
-}
-
-TEST_CASE("compact block operator assign equals always matches equivalent", "[compact block]") {
-    chain::header const header(10u,
-                               "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-                               "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-                               531234u,
-                               6523454u,
-                               68644u);
-
-    uint64_t nonce = 453245u;
-    const message::compact_block::short_id_list short_ids = {
-        convert_to_uint64t("aaaaaaaaaaaa"),
-        convert_to_uint64t("bbbbbbbbbbbb"),
-        convert_to_uint64t("0f0f0f0f0f0f"),
-        convert_to_uint64t("f0f0f0f0f0f0")};
-
-    const message::prefilled_transaction::list transactions = {
-        message::prefilled_transaction(10, chain::transaction(1, 48, {}, {})),
-        message::prefilled_transaction(20, chain::transaction(2, 32, {}, {})),
-        message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))};
-
-    message::compact_block value(header, nonce, short_ids, transactions);
-    REQUIRE(value.is_valid());
-    message::compact_block instance;
-    REQUIRE( ! instance.is_valid());
-    instance = std::move(value);
-    REQUIRE(instance.is_valid());
-    REQUIRE(header == instance.header());
-    REQUIRE(nonce == instance.nonce());
-    REQUIRE(short_ids == instance.short_ids());
-    REQUIRE(transactions == instance.transactions());
+TEST_CASE("compact block transactions accessor always returns initialized value", "[compact block]") {
+    auto const instance = make_compact_block();
+    REQUIRE(test_transactions == instance.transactions());
 }
 
 TEST_CASE("compact block operator boolean equals duplicates returns true", "[compact block]") {
-    const message::compact_block expected(
-        chain::header(10u,
-                      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-                      "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-                      531234u,
-                      6523454u,
-                      68644u),
-        12334u,
-        {convert_to_uint64t("aaaaaaaaaaaa"),
-         convert_to_uint64t("bbbbbbbbbbbb"),
-         convert_to_uint64t("0f0f0f0f0f0f"),
-         convert_to_uint64t("f0f0f0f0f0f0")},
-        {message::prefilled_transaction(10, chain::transaction(1, 48, {}, {})),
-         message::prefilled_transaction(20, chain::transaction(2, 32, {}, {})),
-         message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))});
-
+    auto const expected = make_compact_block(12334u);
     message::compact_block instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("compact block operator boolean equals differs returns false", "[compact block]") {
-    const message::compact_block expected(
-        chain::header(10u,
-                      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-                      "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-                      531234u,
-                      6523454u,
-                      68644u),
-        12334u,
-        {convert_to_uint64t("aaaaaaaaaaaa"),
-         convert_to_uint64t("bbbbbbbbbbbb"),
-         convert_to_uint64t("0f0f0f0f0f0f"),
-         convert_to_uint64t("f0f0f0f0f0f0")},
-        {message::prefilled_transaction(10, chain::transaction(1, 48, {}, {})),
-         message::prefilled_transaction(20, chain::transaction(2, 32, {}, {})),
-         message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))});
-
-    message::compact_block instance;
+    auto const expected = make_compact_block(12334u);
+    auto const instance = message::compact_block::create(test_header, 99999u, test_short_ids, test_transactions).value();
     REQUIRE(instance != expected);
 }
 
 TEST_CASE("compact block operator boolean not equals duplicates returns false", "[compact block]") {
-    const message::compact_block expected(
-        chain::header(10u,
-                      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-                      "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-                      531234u,
-                      6523454u,
-                      68644u),
-        12334u,
-        {convert_to_uint64t("aaaaaaaaaaaa"),
-         convert_to_uint64t("bbbbbbbbbbbb"),
-         convert_to_uint64t("0f0f0f0f0f0f"),
-         convert_to_uint64t("f0f0f0f0f0f0")},
-        {message::prefilled_transaction(10, chain::transaction(1, 48, {}, {})),
-         message::prefilled_transaction(20, chain::transaction(2, 32, {}, {})),
-         message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))});
-
+    auto const expected = make_compact_block(12334u);
     message::compact_block instance(expected);
-    REQUIRE(instance == expected);
+    REQUIRE( ! (instance != expected));
 }
 
 TEST_CASE("compact block operator boolean not equals differs returns true", "[compact block]") {
-    const message::compact_block expected(
-        chain::header(10u,
-                      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-                      "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-                      531234u,
-                      6523454u,
-                      68644u),
-        12334u,
-        {convert_to_uint64t("aaaaaaaaaaaa"),
-         convert_to_uint64t("bbbbbbbbbbbb"),
-         convert_to_uint64t("0f0f0f0f0f0f"),
-         convert_to_uint64t("f0f0f0f0f0f0")},
-        {message::prefilled_transaction(10, chain::transaction(1, 48, {}, {})),
-         message::prefilled_transaction(20, chain::transaction(2, 32, {}, {})),
-         message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))});
-
-    message::compact_block instance;
+    auto const expected = make_compact_block(12334u);
+    auto const instance = message::compact_block::create(test_header, 99999u, test_short_ids, test_transactions).value();
     REQUIRE(instance != expected);
 }
 

--- a/src/domain/test/message/merkle_block.cpp
+++ b/src/domain/test/message/merkle_block.cpp
@@ -7,150 +7,81 @@
 using namespace kth;
 using namespace kd;
 
+namespace {
+
+chain::header const test_header{
+    10,
+    "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
+    "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
+    531234,
+    6523454,
+    68644};
+
+hash_list const test_hashes{
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
+    "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
+};
+
+data_chunk const test_flags{0xae, 0x56, 0x0f};
+
+message::merkle_block make_merkle_block(size_t count = 1234u) {
+    return message::merkle_block::create(test_header, count, test_hashes, test_flags).value();
+}
+
+} // namespace
+
 // Start Test Suite: merkle block tests
 
-TEST_CASE("merkle block constructor 1 always invalid", "[merkle block]") {
-    const message::merkle_block instance;
-    REQUIRE( ! instance.is_valid());
+TEST_CASE("merkle block create rejects empty sentinel", "[merkle block]") {
+    auto const result = message::merkle_block::create(chain::header{}, 0u, {}, {});
+    REQUIRE( ! result);
+    REQUIRE(result.error() == error::merkle_block_construction_empty);
 }
 
-TEST_CASE("merkle block constructor 2 always equals params", "[merkle block]") {
-    chain::header const header(
-        10,
-        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-        531234,
-        6523454,
-        68644);
-
+TEST_CASE("merkle block create always equals params", "[merkle block]") {
     size_t const count = 1234u;
-
-    hash_list const hashes{
-        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
-        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
-        "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
-    };
-    data_chunk const flags{0xae, 0x56, 0x0f};
-
-    message::merkle_block instance(header, count, hashes, flags);
-    REQUIRE(instance.is_valid());
-    REQUIRE(header == instance.header());
+    auto const instance = message::merkle_block::create(test_header, count, test_hashes, test_flags).value();
+    REQUIRE(test_header == instance.header());
     REQUIRE(instance.total_transactions() == count);
-    REQUIRE(hashes == instance.hashes());
-    REQUIRE(flags == instance.flags());
+    REQUIRE(test_hashes == instance.hashes());
+    REQUIRE(test_flags == instance.flags());
 }
 
-TEST_CASE("merkle block constructor 3 always equals params", "[merkle block]") {
-    const message::merkle_block instance(
-        chain::header{
-            10,
-            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-            531234,
-            6523454,
-            68644},
-        1234u,
-        {
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
-            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
-            "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
-        },
-        {0xae, 0x56, 0x0f});
-
-    REQUIRE(instance.is_valid());
-}
-
-TEST_CASE("merkle block constructor 4 always equals params", "[merkle block]") {
-    const message::merkle_block expected(
-        chain::header{
-            10,
-            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-            531234,
-            6523454,
-            68644},
-        4321234u,
-        {
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
-            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
-            "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
-        },
-        {0xae, 0x56, 0x0f});
-
+TEST_CASE("merkle block wrap block equals params", "[merkle block]") {
+    auto const expected = make_merkle_block(4321234u);
     message::merkle_block instance(expected);
-    REQUIRE(instance.is_valid());
     REQUIRE(expected == instance);
-}
-
-TEST_CASE("merkle block constructor 5 always equals params", "[merkle block]") {
-    chain::header const header(
-        10,
-        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-        531234,
-        6523454,
-        68644);
-
-    size_t const count = 654576u;
-
-    hash_list const hashes{
-        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
-        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
-        "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
-    };
-    data_chunk const flags{0xae, 0x56, 0x0f};
-
-    message::merkle_block expected(header, count, hashes, flags);
-    message::merkle_block instance(std::move(expected));
-    REQUIRE(instance.is_valid());
-    REQUIRE(header == instance.header());
-    REQUIRE(instance.total_transactions() == count);
-    REQUIRE(hashes == instance.hashes());
-    REQUIRE(flags == instance.flags());
 }
 
 TEST_CASE("from data insufficient data fails", "[merkle block]") {
     data_chunk const data{10};
-    message::merkle_block instance{};
 
     byte_reader reader(data);
     auto result = message::merkle_block::from_data(reader, message::version::level::maximum);
     REQUIRE( ! result);
-    REQUIRE( ! instance.is_valid());
 }
 
 TEST_CASE("from data insufficient version fails", "[merkle block]") {
-    const message::merkle_block expected{
-        {10,
-         "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-         "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-         531234,
-         6523454,
-         68644},
+    auto const expected = message::merkle_block::create(
+        test_header,
         34523u,
         {"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash},
-        {0x00}};
+        {0x00}).value();
 
     auto const data = kth::to_data_chunk(expected, message::version::level::maximum);
-    message::merkle_block instance{};
 
     byte_reader reader(data);
     auto result = message::merkle_block::from_data(reader, message::merkle_block::version_minimum - 1);
     REQUIRE( ! result);
-    REQUIRE( ! instance.is_valid());
 }
 
 TEST_CASE("merkle block - roundtrip to data factory from data chunk", "[merkle block]") {
-    const message::merkle_block expected{
-        {10,
-         "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-         "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-         531234,
-         6523454,
-         68644},
+    auto const expected = message::merkle_block::create(
+        test_header,
         45633u,
         {"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash},
-        {0x00}};
+        {0x00}).value();
 
     auto const data = kth::to_data_chunk(expected, message::version::level::maximum);
     byte_reader reader(data);
@@ -158,321 +89,45 @@ TEST_CASE("merkle block - roundtrip to data factory from data chunk", "[merkle b
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
 
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
 }
 
-
-
-TEST_CASE("merkle block header accessor 1 always returns initialized value", "[merkle block]") {
-    chain::header const expected{
-        10,
-        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-        531234,
-        6523454,
-        68644};
-
-    const message::merkle_block instance(
-        expected,
-        753u,
-        {
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
-            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
-            "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
-        },
-        {0xae, 0x56, 0x0f});
-
-    REQUIRE(expected == instance.header());
+TEST_CASE("merkle block header accessor always returns initialized value", "[merkle block]") {
+    auto const instance = make_merkle_block(753u);
+    REQUIRE(test_header == instance.header());
 }
 
-TEST_CASE("merkle block header accessor 2 always returns initialized value", "[merkle block]") {
-    chain::header const expected{
-        10,
-        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-        531234,
-        6523454,
-        68644};
-
-    const message::merkle_block instance(
-        expected,
-        9542u,
-        {
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
-            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
-            "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
-        },
-        {0xae, 0x56, 0x0f});
-
-    REQUIRE(expected == instance.header());
+TEST_CASE("merkle block hashes accessor always returns initialized value", "[merkle block]") {
+    auto const instance = make_merkle_block(2456u);
+    REQUIRE(test_hashes == instance.hashes());
 }
 
-TEST_CASE("merkle block header setter 1 roundtrip success", "[merkle block]") {
-    chain::header const expected{
-        10,
-        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-        531234,
-        6523454,
-        68644};
-
-    message::merkle_block instance;
-    REQUIRE(expected != instance.header());
-    instance.set_header(expected);
-    REQUIRE(expected == instance.header());
-}
-
-TEST_CASE("merkle block header setter 2 roundtrip success", "[merkle block]") {
-    message::merkle_block instance;
-    REQUIRE( ! instance.header().is_valid());
-    instance.set_header(
-        chain::header{
-            10,
-            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-            531234,
-            6523454,
-            68644});
-
-    REQUIRE(instance.header().is_valid());
-}
-
-TEST_CASE("merkle block hashes accessor 1 always returns initialized value", "[merkle block]") {
-    hash_list const expected{
-        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
-        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
-        "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
-    };
-
-    const message::merkle_block instance(
-        chain::header{
-            10,
-            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-            531234,
-            6523454,
-            68644},
-        2456u,
-        expected,
-        {0xae, 0x56, 0x0f});
-
-    REQUIRE(expected == instance.hashes());
-}
-
-TEST_CASE("merkle block hashes accessor 2 always returns initialized value", "[merkle block]") {
-    hash_list const expected{
-        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
-        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
-        "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
-    };
-
-    const message::merkle_block instance(
-        chain::header{
-            10,
-            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-            531234,
-            6523454,
-            68644},
-        9137u,
-        expected,
-        {0xae, 0x56, 0x0f});
-
-    REQUIRE(expected == instance.hashes());
-}
-
-TEST_CASE("merkle block hashes setter 1 roundtrip success", "[merkle block]") {
-    hash_list const expected{
-        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
-        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
-        "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
-    };
-
-    message::merkle_block instance;
-    REQUIRE(expected != instance.hashes());
-    instance.set_hashes(expected);
-    REQUIRE(expected == instance.hashes());
-}
-
-TEST_CASE("merkle block hashes setter 2 roundtrip success", "[merkle block]") {
-    message::merkle_block instance;
-    REQUIRE(instance.hashes().empty());
-    instance.set_hashes(hash_list{
-        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
-        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
-        "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
-    });
-
-    REQUIRE( ! instance.hashes().empty());
-}
-
-TEST_CASE("merkle block flags accessor 1 always returns initialized value", "[merkle block]") {
-    data_chunk const expected{0xae, 0x56, 0x0f};
-
-    const message::merkle_block instance(
-        chain::header{
-            10,
-            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-            531234,
-            6523454,
-            68644},
-        8264u,
-        {
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
-            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
-            "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
-        },
-        expected);
-
-    REQUIRE(expected == instance.flags());
-}
-
-TEST_CASE("merkle block flags accessor 2 always returns initialized value", "[merkle block]") {
-    data_chunk const expected{0xae, 0x56, 0x0f};
-
-    const message::merkle_block instance(
-        chain::header{
-            10,
-            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-            531234,
-            6523454,
-            68644},
-        6428u,
-        {
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
-            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
-            "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
-        },
-        expected);
-
-    REQUIRE(expected == instance.flags());
-}
-
-TEST_CASE("merkle block flags setter 1 roundtrip success", "[merkle block]") {
-    data_chunk const expected{0xae, 0x56, 0x0f};
-    message::merkle_block instance;
-    REQUIRE(expected != instance.flags());
-    instance.set_flags(expected);
-    REQUIRE(expected == instance.flags());
-}
-
-TEST_CASE("merkle block flags setter 2 roundtrip success", "[merkle block]") {
-    message::merkle_block instance;
-    REQUIRE(instance.flags().empty());
-    instance.set_flags(data_chunk{0xae, 0x56, 0x0f});
-    REQUIRE( ! instance.flags().empty());
-}
-
-TEST_CASE("merkle block operator assign equals always matches equivalent", "[merkle block]") {
-    message::merkle_block value(
-        chain::header{
-            10,
-            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-            531234,
-            6523454,
-            68644},
-        3197u,
-        {
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
-            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
-            "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
-        },
-        {0xae, 0x56, 0x0f});
-
-    REQUIRE(value.is_valid());
-
-    message::merkle_block instance;
-    REQUIRE( ! instance.is_valid());
-
-    instance = std::move(value);
-    REQUIRE(instance.is_valid());
+TEST_CASE("merkle block flags accessor always returns initialized value", "[merkle block]") {
+    auto const instance = make_merkle_block(8264u);
+    REQUIRE(test_flags == instance.flags());
 }
 
 TEST_CASE("merkle block operator boolean equals duplicates returns true", "[merkle block]") {
-    const message::merkle_block expected(
-        chain::header{
-            10,
-            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-            531234,
-            6523454,
-            68644},
-        9821u,
-        {
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
-            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
-            "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
-        },
-        {0xae, 0x56, 0x0f});
-
+    auto const expected = make_merkle_block(9821u);
     message::merkle_block instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("merkle block operator boolean equals differs returns false", "[merkle block]") {
-    const message::merkle_block expected(
-        chain::header{
-            10,
-            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-            531234,
-            6523454,
-            68644},
-        1469u,
-        {
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
-            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
-            "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
-        },
-        {0xae, 0x56, 0x0f});
-
-    message::merkle_block instance;
+    auto const expected = make_merkle_block(1469u);
+    auto const instance = message::merkle_block::create(test_header, 1470u, {}, test_flags).value();
     REQUIRE( ! (instance == expected));
 }
 
 TEST_CASE("merkle block operator boolean not equals duplicates returns false", "[merkle block]") {
-    const message::merkle_block expected(
-        chain::header{
-            10,
-            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-            531234,
-            6523454,
-            68644},
-        3524u,
-        {
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
-            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
-            "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
-        },
-        {0xae, 0x56, 0x0f});
-
+    auto const expected = make_merkle_block(3524u);
     message::merkle_block instance(expected);
     REQUIRE( ! (instance != expected));
 }
 
 TEST_CASE("merkle block operator boolean not equals differs returns true", "[merkle block]") {
-    const message::merkle_block expected(
-        chain::header{
-            10,
-            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
-            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-            531234,
-            6523454,
-            68644},
-        8642u,
-        {
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaffffffffffffffffffffffffffffffff"_hash,
-            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"_hash,
-            "ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"_hash,
-        },
-        {0xae, 0x56, 0x0f});
-
-    message::merkle_block instance;
+    auto const expected = make_merkle_block(8642u);
+    auto const instance = message::merkle_block::create(test_header, 8642u, {}, test_flags).value();
     REQUIRE(instance != expected);
 }
 

--- a/src/infrastructure/include/kth/infrastructure/error.hpp
+++ b/src/infrastructure/include/kth/infrastructure/error.hpp
@@ -288,6 +288,12 @@ enum error_code_t {
     // from the consensus `empty_block` check performed during validation.
     block_construction_empty,
 
+    // Valid-by-construction guards for the message wrappers: `create` was
+    // given parts that would be the all-default sentinel (an all-zero header
+    // and no payload).
+    merkle_block_construction_empty,
+    compact_block_construction_empty,
+
     // Database cache
     height_not_found,
     hash_not_found,

--- a/src/infrastructure/src/error.cpp
+++ b/src/infrastructure/src/error.cpp
@@ -263,7 +263,9 @@ std::string error_category_impl::message(int ev) const noexcept {
         { error::write_past_end_of_buffer, "write past end of buffer" },
 
         // Valid-by-construction
-        { error::block_construction_empty, "cannot construct a block with no transactions and an empty header" }
+        { error::block_construction_empty, "cannot construct a block with no transactions and an empty header" },
+        { error::merkle_block_construction_empty, "cannot construct a merkle_block from an empty header with no payload" },
+        { error::compact_block_construction_empty, "cannot construct a compact_block from an empty header with no payload" }
     };
 
     auto const message = messages.find(ev);


### PR DESCRIPTION
Applies the valid-by-construction pattern to the two remaining block message wrappers, mirroring `chain::block` (#459).

## Changes

- **`create` factories** returning `expect<>` for both types, rejecting the all-default sentinel (empty header, no payload) with two new error codes: `merkle_block_construction_empty` / `compact_block_construction_empty`.
- **Private field constructors** — construction goes through `create`, `from_data`, the block-wrapping ctor, or `compact_block::factory_from_block`.
- Removed the default constructor, all setters, non-const accessors, `is_valid()` and `reset()`.
- **Defaulted `merkle_block::operator==`** — the hand-written one silently ignored `total_transactions`; both wrappers now compare all members (consistent with `compact_block`).
- `transaction_pool::fetch_template` (an unimplemented stub) now returns `error::not_implemented` rather than a default-constructed `merkle_block`.
- Regenerated C-API bindings + error enum and rewrote domain and C-API tests against the factory surface.

## Testing

Local build green across domain, database, blockchain and c-api. Domain and C-API test suites pass (`[merkle block]`, `[compact block]`, `[C-API MerkleBlock]`, `[C-API CompactBlock]`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added clear validation messages for empty Merkle block and compact block construction attempts.
  * Improved error reporting when these message wrappers receive an empty or default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->