### PR TITLE
refactor(domain/chain): drop header default constructor (valid-by-construction)

### DIFF
--- a/src/c-api/include/kth/capi/chain/header.h
+++ b/src/c-api/include/kth/capi/chain/header.h
@@ -16,10 +16,6 @@ extern "C" {
 
 // Constructors
 
-/** @return Owned `kth_header_mut_t`. Caller must release with `kth_chain_header_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_header_mut_t kth_chain_header_construct_default(void);
-
 /** @param[out] out Must point to a null `kth_header_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_header_destruct`. Untouched on error. */
 KTH_EXPORT
 kth_error_code_t kth_chain_header_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_header_mut_t* out);
@@ -59,6 +55,9 @@ kth_header_mut_t kth_chain_header_copy(kth_header_const_t self);
 
 KTH_EXPORT
 kth_bool_t kth_chain_header_equals(kth_header_const_t self, kth_header_const_t other);
+
+KTH_EXPORT
+kth_bool_t kth_chain_header_not_equal(kth_header_const_t self, kth_header_const_t other);
 
 
 // Serialization

--- a/src/c-api/src/chain/header.cpp
+++ b/src/c-api/src/chain/header.cpp
@@ -22,10 +22,6 @@ extern "C" {
 
 // Constructors
 
-kth_header_mut_t kth_chain_header_construct_default(void) {
-    return kth::leak<cpp_t>();
-}
-
 kth_error_code_t kth_chain_header_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_header_mut_t* out) {
     KTH_PRECONDITION(data != nullptr || n == 0);
     KTH_PRECONDITION(out != nullptr);
@@ -76,6 +72,12 @@ kth_bool_t kth_chain_header_equals(kth_header_const_t self, kth_header_const_t o
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(other != nullptr);
     return kth::eq<cpp_t>(self, other);
+}
+
+kth_bool_t kth_chain_header_not_equal(kth_header_const_t self, kth_header_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::ne<cpp_t>(self, other);
 }
 
 

--- a/src/c-api/test/chain/block.cpp
+++ b/src/c-api/test/chain/block.cpp
@@ -29,7 +29,8 @@
 
 TEST_CASE("C-API Block - create rejects the empty sentinel",
           "[C-API Block]") {
-    kth_header_mut_t h = kth_chain_header_construct_default();
+    kth_hash_t const zero = {{ 0 }};
+    kth_header_mut_t h = kth_chain_header_construct(0u, &zero, &zero, 0u, 0u, 0u);
     kth_transaction_list_mut_t txs = kth_chain_transaction_list_construct_default();
     kth_block_mut_t blk = NULL;
     kth_error_code_t ec = kth_chain_block_create(h, txs, &blk);

--- a/src/c-api/test/chain/compact_block.cpp
+++ b/src/c-api/test/chain/compact_block.cpp
@@ -113,7 +113,8 @@ static kth_compact_block_mut_t make_fixture(void) {
 
 TEST_CASE("C-API CompactBlock - create rejects the empty sentinel",
           "[C-API CompactBlock]") {
-    kth_header_mut_t header = kth_chain_header_construct_default();
+    kth_hash_t const zero = {{ 0 }};
+    kth_header_mut_t header = kth_chain_header_construct(0u, &zero, &zero, 0u, 0u, 0u);
     kth_u64_list_mut_t short_ids = kth_core_u64_list_construct_default();
     kth_prefilled_transaction_list_mut_t txs =
         kth_chain_prefilled_transaction_list_construct_default();

--- a/src/c-api/test/chain/header.cpp
+++ b/src/c-api/test/chain/header.cpp
@@ -46,12 +46,21 @@ static kth_hash_t const kMerkle = {{
     0x3a, 0x9f, 0xb8, 0xaa, 0x4b, 0x1e, 0x5e, 0x4a
 }};
 
+// The all-zero header is the `is_valid() == false` sentinel. There is no
+// default constructor (the domain type is valid-by-construction), so build it
+// explicitly from zero fields.
+static kth_hash_t const kZeroHash = {{ 0 }};
+
+static kth_header_mut_t make_zero_header(void) {
+    return kth_chain_header_construct(0u, &kZeroHash, &kZeroHash, 0u, 0u, 0u);
+}
+
 // ---------------------------------------------------------------------------
 // Constructors
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API Header - default construct is invalid", "[C-API Header]") {
-    kth_header_mut_t header = kth_chain_header_construct_default();
+TEST_CASE("C-API Header - all-zero header is invalid", "[C-API Header]") {
+    kth_header_mut_t header = make_zero_header();
     REQUIRE(kth_chain_header_is_valid(header) == 0);
     kth_chain_header_destruct(header);
 }
@@ -165,7 +174,7 @@ TEST_CASE("C-API Header - equals duplicates", "[C-API Header]") {
         kVersion, &kPrevHash, &kMerkle, kTimestamp, kBits, kNonce);
     kth_header_mut_t b = kth_chain_header_construct(
         kVersion, &kPrevHash, &kMerkle, kTimestamp, kBits, kNonce);
-    kth_header_mut_t c = kth_chain_header_construct_default();
+    kth_header_mut_t c = make_zero_header();
 
     REQUIRE(kth_chain_header_equals(a, b) != 0);
     REQUIRE(kth_chain_header_equals(a, c) == 0);
@@ -239,7 +248,8 @@ TEST_CASE("C-API Header - construct_unsafe null merkle aborts",
 
 TEST_CASE("C-API Header - to_data null out_size aborts",
           "[C-API Header][precondition]") {
-    kth_header_mut_t header = kth_chain_header_construct_default();
+    kth_header_mut_t header = kth_chain_header_construct(
+        kVersion, &kPrevHash, &kMerkle, kTimestamp, kBits, kNonce);
     KTH_EXPECT_ABORT(kth_chain_header_to_data(header, 1, NULL));
     kth_chain_header_destruct(header);
 }

--- a/src/c-api/test/chain/merkle_block.cpp
+++ b/src/c-api/test/chain/merkle_block.cpp
@@ -94,7 +94,8 @@ static kth_merkle_block_mut_t make_fixture(void) {
 
 TEST_CASE("C-API MerkleBlock - create rejects the empty sentinel",
           "[C-API MerkleBlock]") {
-    kth_header_mut_t header = kth_chain_header_construct_default();
+    kth_hash_t const zero = {{ 0 }};
+    kth_header_mut_t header = kth_chain_header_construct(0u, &zero, &zero, 0u, 0u, 0u);
     kth_hash_list_mut_t hashes = kth_core_hash_list_construct_default();
     kth_merkle_block_mut_t mb = NULL;
     kth_error_code_t ec = kth_chain_merkle_block_create(

--- a/src/domain/include/kth/domain/chain/header_members.hpp
+++ b/src/domain/include/kth/domain/chain/header_members.hpp
@@ -46,8 +46,6 @@ public:
     // Constructors.
     //-------------------------------------------------------------------------
 
-    constexpr header() = default;
-
     constexpr header(uint32_t version, hash_digest const& previous_block_hash,
                      hash_digest const& merkle, uint32_t timestamp,
                      uint32_t bits, uint32_t nonce)

--- a/src/domain/include/kth/domain/chain/header_raw.hpp
+++ b/src/domain/include/kth/domain/chain/header_raw.hpp
@@ -90,8 +90,6 @@ public:
     // Constructors.
     //-------------------------------------------------------------------------
 
-    constexpr header() = default;
-
     // Construct from raw bytes (must be exactly 80 bytes).
     explicit constexpr header(std::span<uint8_t const, serialized_size_wire> raw_data)
         : data_{}
@@ -227,13 +225,6 @@ public:
     [[nodiscard]]
     constexpr std::span<uint8_t const, serialized_size_wire> raw_data() const {
         return std::span<uint8_t const, serialized_size_wire>(data_);
-    }
-
-    // Mutable raw data access (for direct deserialization).
-    // Use with caution - allows modifying internal state.
-    [[nodiscard]]
-    constexpr std::array<uint8_t, serialized_size_wire>& raw_data_mutable() {
-        return data_;
     }
 
     // Serialization.

--- a/src/domain/include/kth/domain/message/header.hpp
+++ b/src/domain/include/kth/domain/message/header.hpp
@@ -32,8 +32,6 @@ struct KD_API header : chain::header {
     // Inherit constructors
     using chain::header::header;
 
-    header() = default;
-
     header(chain::header const& x)
         : chain::header(x)
     {}

--- a/src/domain/src/chain/header_raw.cpp
+++ b/src/domain/src/chain/header_raw.cpp
@@ -36,12 +36,12 @@ using wall_clock = std::chrono::system_clock;
 
 //TODO: qué hacemos con el parametro wire?
 expect<header> header::from_data(byte_reader& reader, bool _wire) {
-    header res;
-    auto const read = reader.read_bytes_to(std::span<uint8_t>{res.raw_data_mutable()});
+    std::array<uint8_t, serialized_size_wire> data{};
+    auto const read = reader.read_bytes_to(std::span<uint8_t>{data});
     if ( ! read) {
         return std::unexpected(read.error());
     }
-    return res;
+    return header{data};
 }
 
 // expect<header> header::from_data(byte_reader& reader, bool /*wire*/) {

--- a/src/domain/test/chain/block.cpp
+++ b/src/domain/test/chain/block.cpp
@@ -78,8 +78,8 @@ TEST_CASE("block locator heights positive backoff returns top plus log offset to
 
 TEST_CASE("block create rejects the empty sentinel", "[chain block]") {
     // No transactions and an all-zero header is not a block.
-    REQUIRE( ! chain::block::create(chain::header{}, {}));
-    REQUIRE(chain::block::create(chain::header{}, {}).error() == error::block_construction_empty);
+    REQUIRE( ! chain::block::create(chain::header{0u, null_hash, null_hash, 0u, 0u, 0u}, {}));
+    REQUIRE(chain::block::create(chain::header{0u, null_hash, null_hash, 0u, 0u, 0u}, {}).error() == error::block_construction_empty);
 }
 
 TEST_CASE("block create 2 always equals params", "[chain block]") {

--- a/src/domain/test/chain/header.cpp
+++ b/src/domain/test/chain/header.cpp
@@ -32,9 +32,11 @@ constexpr hash_digest ct_merkle = {{
     0x3a, 0x9f, 0xb8, 0xaa, 0x4b, 0x1e, 0x5e, 0x4a
 }};
 
-// Test: Default constructor is constexpr
-constexpr chain::header ct_default_header{};
-static_assert( ! ct_default_header.is_valid(), "default header should be invalid");
+// Test: the all-zero header (is_valid() == false sentinel) is constexpr.
+// There is no default constructor (header is valid-by-construction); build the
+// sentinel explicitly from zero fields.
+constexpr chain::header ct_default_header{0u, hash_digest{}, hash_digest{}, 0u, 0u, 0u};
+static_assert( ! ct_default_header.is_valid(), "all-zero header should be invalid");
 static_assert(ct_default_header.version() == 0, "default version should be 0");
 static_assert(ct_default_header.timestamp() == 0, "default timestamp should be 0");
 static_assert(ct_default_header.bits() == 0, "default bits should be 0");
@@ -168,7 +170,7 @@ static_assert(ct_lambda_header.version() == 42u, "lambda header version");
 // Start Test Suite: chain header tests
 
 TEST_CASE("chain header constructor 1 always initialized invalid", "[chain header]") {
-    chain::header instance;
+    chain::header instance{0u, null_hash, null_hash, 0u, 0u, 0u};
     REQUIRE( ! instance.is_valid());
 }
 
@@ -470,7 +472,7 @@ TEST_CASE("chain header operator assign equals always matches equivalent", "[cha
 
     REQUIRE(value.is_valid());
 
-    chain::header instance;
+    chain::header instance{0u, null_hash, null_hash, 0u, 0u, 0u};
     REQUIRE( ! instance.is_valid());
 
     instance = std::move(value);
@@ -499,7 +501,7 @@ TEST_CASE("chain header operator boolean equals differs returns false", "[chain 
         6523454u,
         68644u);
 
-    chain::header instance;
+    chain::header instance{0u, null_hash, null_hash, 0u, 0u, 0u};
     REQUIRE(instance != expected);
 }
 
@@ -525,7 +527,7 @@ TEST_CASE("chain header operator boolean not equals differs returns true", "[cha
         6523454u,
         68644u);
 
-    chain::header instance;
+    chain::header instance{0u, null_hash, null_hash, 0u, 0u, 0u};
     REQUIRE(instance != expected);
 }
 

--- a/src/domain/test/message/block.cpp
+++ b/src/domain/test/message/block.cpp
@@ -24,7 +24,7 @@ message::block make_msg_block() {
 // Start Test Suite: message block tests
 
 TEST_CASE("block create rejects the empty sentinel", "[message block]") {
-    REQUIRE( ! block::create(chain::header{}, {}));
+    REQUIRE( ! block::create(chain::header{0u, null_hash, null_hash, 0u, 0u, 0u}, {}));
 }
 
 TEST_CASE("block constructor 2 always equals params", "[message block]") {

--- a/src/domain/test/message/compact_block.cpp
+++ b/src/domain/test/message/compact_block.cpp
@@ -43,7 +43,7 @@ message::compact_block make_compact_block(uint64_t nonce = 453245u) {
 // Start Test Suite: compact block tests
 
 TEST_CASE("compact block create rejects empty sentinel", "[compact block]") {
-    auto const result = message::compact_block::create(chain::header{}, 0u, {}, {});
+    auto const result = message::compact_block::create(chain::header{0u, null_hash, null_hash, 0u, 0u, 0u}, 0u, {}, {});
     REQUIRE( ! result);
     REQUIRE(result.error() == error::compact_block_construction_empty);
 }

--- a/src/domain/test/message/header.cpp
+++ b/src/domain/test/message/header.cpp
@@ -7,10 +7,19 @@
 using namespace kth;
 using namespace kd;
 
+namespace {
+// The all-zero header is the `is_valid() == false` sentinel; there is no
+// default constructor (header is valid-by-construction), so build it from zero
+// fields.
+message::header make_zero_header() {
+    return message::header{0u, null_hash, null_hash, 0u, 0u, 0u};
+}
+} // namespace
+
 // Start Test Suite: message header tests
 
 TEST_CASE("message header constructor 1 always initialized invalid", "[message header]") {
-    message::header instance;
+    auto instance = make_zero_header();
     REQUIRE( ! instance.is_valid());
 }
 
@@ -108,11 +117,9 @@ TEST_CASE("message header constructor 7 always equals params", "[message header]
 
 TEST_CASE("message header from data insufficient bytes failure", "[message header]") {
     data_chunk data(10);
-    message::header header;
     byte_reader reader(data);
     auto result = message::header::from_data(reader, message::header::version_maximum);
     REQUIRE( ! result);
-    REQUIRE( ! header.is_valid());
 }
 
 TEST_CASE("message header from data valid input canonical version no transaction count", "[message header]") {
@@ -174,7 +181,7 @@ TEST_CASE("message header operator assign equals 1 always matches equivalent", "
 
     REQUIRE(value.is_valid());
 
-    message::header instance;
+    auto instance = make_zero_header();
     REQUIRE( ! instance.is_valid());
 
     instance = std::move(value);
@@ -193,7 +200,7 @@ TEST_CASE("message header operator assign equals 2 always matches equivalent", "
 
     REQUIRE(value.is_valid());
 
-    message::header instance;
+    auto instance = make_zero_header();
     REQUIRE( ! instance.is_valid());
 
     instance = std::move(value);
@@ -223,7 +230,7 @@ TEST_CASE("message header operator boolean equals 1 differs returns false", "[me
         68644u,
         4453u);
 
-    message::header instance;
+    auto instance = make_zero_header();
     REQUIRE(instance != expected);
 }
 
@@ -249,7 +256,7 @@ TEST_CASE("message header operator boolean not equals 1 differs returns true", "
         68644u,
         47476u);
 
-    message::header instance;
+    auto instance = make_zero_header();
     REQUIRE(instance != expected);
 }
 
@@ -275,7 +282,7 @@ TEST_CASE("message header operator boolean equals 2 differs returns false", "[me
         6523454u,
         68644u);
 
-    message::header instance;
+    auto instance = make_zero_header();
     REQUIRE(instance != expected);
 }
 
@@ -301,7 +308,7 @@ TEST_CASE("message header operator boolean not equals 2 differs returns true", "
         6523454u,
         68644u);
 
-    message::header instance;
+    auto instance = make_zero_header();
     REQUIRE(instance != expected);
 }
 

--- a/src/domain/test/message/merkle_block.cpp
+++ b/src/domain/test/message/merkle_block.cpp
@@ -34,7 +34,7 @@ message::merkle_block make_merkle_block(size_t count = 1234u) {
 // Start Test Suite: merkle block tests
 
 TEST_CASE("merkle block create rejects empty sentinel", "[merkle block]") {
-    auto const result = message::merkle_block::create(chain::header{}, 0u, {}, {});
+    auto const result = message::merkle_block::create(chain::header{0u, null_hash, null_hash, 0u, 0u, 0u}, 0u, {}, {});
     REQUIRE( ! result);
     REQUIRE(result.error() == error::merkle_block_construction_empty);
 }


### PR DESCRIPTION
Removes `chain::header`'s default constructor so a header can only be built from real fields, raw bytes, or `from_data`. This is the header-cascade step that was blocked until `merkle_block` / `compact_block` stopped default-constructing headers (#460).

## Changes

- Remove `header() = default` from both the raw and member-based implementations, plus the redundant one on `message::header`.
- Rewrite `header::from_data` to read into a local buffer and construct via the byte-array constructor (drops the default-then-fill pattern); remove the now-unused `raw_data_mutable()` backdoor.
- Regenerate the C-API header binding: `kth_chain_header_construct_default` is gone; callers build the all-zero sentinel from zero fields.
- Update domain + C-API tests to construct the all-zero header explicitly.

The all-zero state (the `is_valid() == false` sentinel) is still representable via zero fields, and `is_valid()` is retained for now — dropping it is a later cascade step.

## Testing

Local build green across domain, database, blockchain, network, c-api and node. Full domain suite (3840 cases) and C-API suite (742 cases) pass.