### PR TITLE
refactor(domain/chain): remove header::is_valid(); construction validity via create()

### DIFF
--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -1664,7 +1664,7 @@ void block_chain::fill_tx_list_from_mempool(domain::message::compact_block const
 
     for (auto it = inventories.begin(); it != inventories.end();) {
         auto const header = internal_db.get_header(it->hash());
-        if (it->is_block_type() && header && header->first.is_valid()) {
+        if (it->is_block_type() && header) {
             it = inventories.erase(it);
         } else {
             ++it;

--- a/src/c-api/include/kth/capi/chain/header.h
+++ b/src/c-api/include/kth/capi/chain/header.h
@@ -97,9 +97,6 @@ kth_hash_t kth_chain_header_hash(kth_header_const_t self);
 // Predicates
 
 KTH_EXPORT
-kth_bool_t kth_chain_header_is_valid(kth_header_const_t self);
-
-KTH_EXPORT
 kth_bool_t kth_chain_header_is_valid_timestamp(kth_header_const_t self);
 
 /** @param hash Borrowed input; must be non-null. Read during the call; ownership of `hash` stays with the caller. */

--- a/src/c-api/src/chain/header.cpp
+++ b/src/c-api/src/chain/header.cpp
@@ -137,11 +137,6 @@ kth_hash_t kth_chain_header_hash(kth_header_const_t self) {
 
 // Predicates
 
-kth_bool_t kth_chain_header_is_valid(kth_header_const_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_valid());
-}
-
 kth_bool_t kth_chain_header_is_valid_timestamp(kth_header_const_t self) {
     KTH_PRECONDITION(self != nullptr);
     return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_valid_timestamp());

--- a/src/c-api/test/chain/block_fixtures.hpp
+++ b/src/c-api/test/chain/block_fixtures.hpp
@@ -9,6 +9,7 @@
 
 #include <kth/capi/chain/block.h>
 #include <kth/capi/chain/header.h>
+#include <kth/capi/chain/transaction.h>
 #include <kth/capi/chain/transaction_list.h>
 #include <kth/capi/hash.h>
 #include <kth/capi/primitives.h>
@@ -20,16 +21,26 @@ inline kth_block_mut_t make_block(void) {
     return blk;
 }
 
-// A minimal valid block: a non-zero header, no transactions. Distinct from
-// genesis, so it doubles as the "other" block for inequality tests.
+// A minimal block: a non-zero header and a single transaction (a block always
+// has at least one). Distinct from genesis, so it doubles as the "other" block
+// for inequality tests.
 inline kth_block_mut_t make_minimal_block(void) {
     static kth_hash_t const zero_hash = {{0}};
+    // Minimal serializable tx: version=1, no inputs, no outputs, locktime=0.
+    static uint8_t const minimal_tx[10] = {
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+    };
     kth_header_mut_t h = kth_chain_header_construct(1u, &zero_hash, &zero_hash, 0u, 0u, 0u);
+    kth_transaction_mut_t tx = NULL;
+    REQUIRE(kth_chain_transaction_construct_from_data(
+        minimal_tx, sizeof(minimal_tx), 1, &tx) == kth_ec_success);
     kth_transaction_list_mut_t txs = kth_chain_transaction_list_construct_default();
+    kth_chain_transaction_list_push_back(txs, tx);
     kth_block_mut_t blk = NULL;
     kth_error_code_t ec = kth_chain_block_create(h, txs, &blk);
     REQUIRE(ec == kth_ec_success);
     REQUIRE(blk != NULL);
+    kth_chain_transaction_destruct(tx);
     kth_chain_header_destruct(h);
     kth_chain_transaction_list_destruct(txs);
     return blk;

--- a/src/c-api/test/chain/header.cpp
+++ b/src/c-api/test/chain/header.cpp
@@ -46,9 +46,9 @@ static kth_hash_t const kMerkle = {{
     0x3a, 0x9f, 0xb8, 0xaa, 0x4b, 0x1e, 0x5e, 0x4a
 }};
 
-// The all-zero header is the `is_valid() == false` sentinel. There is no
-// default constructor (the domain type is valid-by-construction), so build it
-// explicitly from zero fields.
+// A header with all-zero fields, used where a test needs a header distinct
+// from a populated one. There is no default constructor (the domain type is
+// valid-by-construction), so build it explicitly from zero fields.
 static kth_hash_t const kZeroHash = {{ 0 }};
 
 static kth_header_mut_t make_zero_header(void) {
@@ -59,17 +59,10 @@ static kth_header_mut_t make_zero_header(void) {
 // Constructors
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API Header - all-zero header is invalid", "[C-API Header]") {
-    kth_header_mut_t header = make_zero_header();
-    REQUIRE(kth_chain_header_is_valid(header) == 0);
-    kth_chain_header_destruct(header);
-}
-
 TEST_CASE("C-API Header - field constructor preserves all fields", "[C-API Header]") {
     kth_header_mut_t header = kth_chain_header_construct(
         kVersion, &kPrevHash, &kMerkle, kTimestamp, kBits, kNonce);
 
-    REQUIRE(kth_chain_header_is_valid(header) != 0);
     REQUIRE(kth_chain_header_version(header)   == kVersion);
     REQUIRE(kth_chain_header_timestamp(header) == kTimestamp);
     REQUIRE(kth_chain_header_bits(header)      == kBits);
@@ -111,7 +104,6 @@ TEST_CASE("C-API Header - to_data / from_data roundtrip", "[C-API Header]") {
     REQUIRE(ec == kth_ec_success);
     REQUIRE(parsed != NULL);
 
-    REQUIRE(kth_chain_header_is_valid(parsed) != 0);
     REQUIRE(kth_chain_header_equals(expected, parsed) != 0);
 
     kth_core_destruct_array(raw);
@@ -158,7 +150,6 @@ TEST_CASE("C-API Header - copy preserves all fields", "[C-API Header]") {
         kVersion, &kPrevHash, &kMerkle, kTimestamp, kBits, kNonce);
     kth_header_mut_t copy = kth_chain_header_copy(original);
 
-    REQUIRE(kth_chain_header_is_valid(copy) != 0);
     REQUIRE(kth_chain_header_equals(original, copy) != 0);
     REQUIRE(kth_chain_header_version(copy)   == kVersion);
     REQUIRE(kth_chain_header_timestamp(copy) == kTimestamp);

--- a/src/domain/include/kth/domain/chain/header_members.hpp
+++ b/src/domain/include/kth/domain/chain/header_members.hpp
@@ -95,15 +95,6 @@ public:
         return writer.write_little_endian<uint32_t>(nonce_);
     }
 
-    [[nodiscard]]
-    constexpr bool is_valid() const {
-        return version_ != 0 ||
-               previous_block_hash_ != null_hash ||
-               merkle_ != null_hash ||
-               timestamp_ != 0 ||
-               bits_ != 0 ||
-               nonce_ != 0;
-    }
 
     // Properties (size).
     //-------------------------------------------------------------------------

--- a/src/domain/include/kth/domain/chain/header_raw.hpp
+++ b/src/domain/include/kth/domain/chain/header_raw.hpp
@@ -240,13 +240,6 @@ public:
         return writer.write_bytes(std::span<uint8_t const>{data_.data(), serialized_size_wire});
     }
 
-    [[nodiscard]]
-    constexpr bool is_valid() const {
-        // Check if any field is non-zero (header has been set).
-        constexpr std::array<uint8_t, serialized_size_wire> zero_data{};
-        return data_ != zero_data;
-    }
-
     // Properties (size).
     //-------------------------------------------------------------------------
 

--- a/src/domain/src/chain/block.cpp
+++ b/src/domain/src/chain/block.cpp
@@ -187,9 +187,10 @@ block::block(chain::header const& header, transaction::list&& transactions)
 
 // static
 expect<block> block::create(chain::header header, transaction::list transactions) {
-    // Reject the empty sentinel (what the old `is_valid()` guarded against):
-    // a block with no transactions and an all-zero header is not a block.
-    if (transactions.empty() && ! header.is_valid()) {
+    // A block always carries at least a coinbase, so no transactions is never
+    // a real block. (Consensus validity beyond this — merkle root, sigops,
+    // etc. — is validation's concern, not construction's.)
+    if (transactions.empty()) {
         return std::unexpected(error::block_construction_empty);
     }
     return block{header, std::move(transactions)};

--- a/src/domain/src/message/compact_block.cpp
+++ b/src/domain/src/message/compact_block.cpp
@@ -48,8 +48,9 @@ compact_block compact_block::factory_from_block(message::block const& block) {
 
 // static
 expect<compact_block> compact_block::create(chain::header header, uint64_t nonce, short_id_list short_ids, prefilled_transaction::list transactions) {
-    // Reject the all-default sentinel (what the old `is_valid()` guarded).
-    if ( ! header.is_valid() && short_ids.empty() && transactions.empty()) {
+    // Reject the fully-empty payload; a compact block always prefills at least
+    // the coinbase.
+    if (short_ids.empty() && transactions.empty()) {
         return std::unexpected(error::compact_block_construction_empty);
     }
     return compact_block{header, nonce, std::move(short_ids), std::move(transactions)};

--- a/src/domain/src/message/merkle_block.cpp
+++ b/src/domain/src/message/merkle_block.cpp
@@ -36,8 +36,8 @@ merkle_block::merkle_block(chain::block const& block)
 
 // static
 expect<merkle_block> merkle_block::create(chain::header header, size_t total_transactions, hash_list hashes, data_chunk flags) {
-    // Reject the all-default sentinel (what the old `is_valid()` guarded).
-    if (hashes.empty() && flags.empty() && ! header.is_valid()) {
+    // Reject the fully-empty payload; a merkle block always describes a tree.
+    if (hashes.empty() && flags.empty()) {
         return std::unexpected(error::merkle_block_construction_empty);
     }
     return merkle_block{header, total_transactions, std::move(hashes), std::move(flags)};

--- a/src/domain/test/chain/block.cpp
+++ b/src/domain/test/chain/block.cpp
@@ -30,9 +30,10 @@ bool all_valid(chain::transaction::list const& transactions) {
     return valid;
 }
 
-// A block with a non-zero header (so `create` accepts it) and the given
-// transactions. Replaces the old default-construct-then-set idiom.
-chain::block make_block(chain::transaction::list txs = {}) {
+// A block with a non-zero header and the given transactions. Defaults to a
+// single (coinbase-stand-in) transaction because a block always has at least
+// one; `create` rejects an empty transaction list.
+chain::block make_block(chain::transaction::list txs = {chain::transaction(1, 0, {}, {})}) {
     return chain::block::create(
         chain::header{1u, null_hash, null_hash, 0u, 0u, 0u}, std::move(txs)).value();
 }
@@ -178,13 +179,8 @@ TEST_CASE("block move 5 always equals params", "[chain block]") {
 }
 
 TEST_CASE("block hash always returns header hash", "[chain block]") {
-    auto const instance = chain::block::create(chain::header{1u, null_hash, null_hash, 0u, 0u, 0u}, {}).value();
-    REQUIRE(chain::hash(instance.header()) == instance.hash());
-}
-
-TEST_CASE("block is valid merkle root uninitialized returns true", "[chain block]") {
     auto const instance = make_block();
-    REQUIRE(instance.is_valid_merkle_root());
+    REQUIRE(chain::hash(instance.header()) == instance.hash());
 }
 
 TEST_CASE("block is valid merkle root non empty tx invalid block returns false", "[chain block]") {
@@ -352,11 +348,6 @@ TEST_CASE("block factory from data 3 genesis mainnet success", "[block serializa
 
 // Start Test Suite: block generate merkle root tests
 
-TEST_CASE("block generate merkle root block with zero transactions matches null hash", "[block generate merkle root]") {
-    auto const empty = make_block();
-    REQUIRE(empty.generate_merkle_root() == null_hash);
-}
-
 TEST_CASE("block generate merkle root block with multiple transactions matches historic data", "[block generate merkle root]") {
     // encodes the 100,000 block data.
     data_chunk const raw = to_chunk(
@@ -428,7 +419,7 @@ TEST_CASE("block construct exposes header", "[block generate merkle root]") {
         68644u
     };
 
-    auto instance = chain::block::create(header, chain::transaction::list{}).value();
+    auto instance = chain::block::create(header, {chain::transaction(1, 0, {}, {})}).value();
     REQUIRE(header == instance.header());
 }
 

--- a/src/domain/test/chain/header.cpp
+++ b/src/domain/test/chain/header.cpp
@@ -32,11 +32,9 @@ constexpr hash_digest ct_merkle = {{
     0x3a, 0x9f, 0xb8, 0xaa, 0x4b, 0x1e, 0x5e, 0x4a
 }};
 
-// Test: the all-zero header (is_valid() == false sentinel) is constexpr.
-// There is no default constructor (header is valid-by-construction); build the
-// sentinel explicitly from zero fields.
+// Test: the all-zero header is constexpr-constructible. There is no default
+// constructor (header is valid-by-construction); build it from zero fields.
 constexpr chain::header ct_default_header{0u, hash_digest{}, hash_digest{}, 0u, 0u, 0u};
-static_assert( ! ct_default_header.is_valid(), "all-zero header should be invalid");
 static_assert(ct_default_header.version() == 0, "default version should be 0");
 static_assert(ct_default_header.timestamp() == 0, "default timestamp should be 0");
 static_assert(ct_default_header.bits() == 0, "default bits should be 0");
@@ -52,7 +50,6 @@ constexpr chain::header ct_header_from_fields{
     0x1d00ffffu,  // bits
     2083236893u   // nonce
 };
-static_assert(ct_header_from_fields.is_valid(), "constructed header should be valid");
 static_assert(ct_header_from_fields.version() == 1u, "version mismatch");
 static_assert(ct_header_from_fields.timestamp() == 1231006505u, "timestamp mismatch");
 static_assert(ct_header_from_fields.bits() == 0x1d00ffffu, "bits mismatch");
@@ -169,11 +166,6 @@ static_assert(ct_lambda_header.version() == 42u, "lambda header version");
 
 // Start Test Suite: chain header tests
 
-TEST_CASE("chain header constructor 1 always initialized invalid", "[chain header]") {
-    chain::header instance{0u, null_hash, null_hash, 0u, 0u, 0u};
-    REQUIRE( ! instance.is_valid());
-}
-
 TEST_CASE("chain header constructor 2 always equals params", "[chain header]") {
     uint32_t const version = 10u;
     auto const previous = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
@@ -183,7 +175,6 @@ TEST_CASE("chain header constructor 2 always equals params", "[chain header]") {
     uint32_t const nonce = 68644u;
 
     chain::header instance(version, previous, merkle, timestamp, bits, nonce);
-    REQUIRE(instance.is_valid());
     REQUIRE(version == instance.version());
     REQUIRE(timestamp == instance.timestamp());
     REQUIRE(bits == instance.bits());
@@ -203,7 +194,6 @@ TEST_CASE("chain header constructor 3 always equals params", "[chain header]") {
     auto merkle = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     chain::header instance(version, std::move(previous), std::move(merkle), timestamp, bits, nonce);
-    REQUIRE(instance.is_valid());
     REQUIRE(version == instance.version());
     REQUIRE(timestamp == instance.timestamp());
     REQUIRE(bits == instance.bits());
@@ -222,7 +212,6 @@ TEST_CASE("chain header constructor 4 always equals params", "[chain header]") {
         68644u);
 
     chain::header instance(expected);
-    REQUIRE(instance.is_valid());
     REQUIRE(expected == instance);
 }
 
@@ -237,7 +226,6 @@ TEST_CASE("chain header constructor 5 always equals params", "[chain header]") {
         68644u);
 
     chain::header instance(std::move(expected));
-    REQUIRE(instance.is_valid());
     REQUIRE(expected == instance);
 }
 
@@ -264,7 +252,6 @@ TEST_CASE("chain header from data valid input success", "[chain header]") {
     REQUIRE(result_exp);
     auto const& result = *result_exp;
 
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
 }
 
@@ -283,7 +270,6 @@ TEST_CASE("chain header factory from data 2 valid input success", "[chain header
     REQUIRE(result_exp);
     auto const& result = *result_exp;
 
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
 }
 
@@ -302,7 +288,6 @@ TEST_CASE("chain header factory from data 3 valid input success", "[chain header
     REQUIRE(result_exp);
     auto const& result = *result_exp;
 
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
 }
 
@@ -470,13 +455,10 @@ TEST_CASE("chain header operator assign equals always matches equivalent", "[cha
         6523454u,
         68644u);
 
-    REQUIRE(value.is_valid());
 
     chain::header instance{0u, null_hash, null_hash, 0u, 0u, 0u};
-    REQUIRE( ! instance.is_valid());
 
     instance = std::move(value);
-    REQUIRE(instance.is_valid());
 }
 
 TEST_CASE("chain header operator boolean equals duplicates returns true", "[chain header]") {

--- a/src/domain/test/chain/light_block.cpp
+++ b/src/domain/test/chain/light_block.cpp
@@ -74,14 +74,6 @@ TEST_CASE("light_block tx_count returns correct count", "[chain light_block]") {
     REQUIRE(result->tx_count() == 3);
 }
 
-TEST_CASE("light_block header is valid", "[chain light_block]") {
-    auto const raw_block = get_raw_block();
-    byte_reader reader(raw_block);
-    auto const result = chain::light_block::from_data(reader, true);
-    REQUIRE(result.has_value());
-    REQUIRE(result->header().is_valid());
-}
-
 TEST_CASE("light_block header hash matches full block", "[chain light_block]") {
     auto const raw_block = get_raw_block();
 

--- a/src/domain/test/message/block.cpp
+++ b/src/domain/test/message/block.cpp
@@ -11,13 +11,16 @@ using namespace kd;
 using namespace kth::domain::message;
 
 namespace {
-// Valid blocks (non-zero header, no transactions) for fixtures that only need
-// "some block" — `create` rejects the empty sentinel.
+// Blocks for fixtures that only need "some block". A block always has at least
+// one transaction; `create` rejects an empty transaction list.
+chain::transaction::list one_tx() {
+    return {chain::transaction(1, 0, {}, {})};
+}
 chain::block make_chain_block() {
-    return chain::block::create(chain::header{1u, null_hash, null_hash, 0u, 0u, 0u}, {}).value();
+    return chain::block::create(chain::header{1u, null_hash, null_hash, 0u, 0u, 0u}, one_tx()).value();
 }
 message::block make_msg_block() {
-    return message::block::create(chain::header{1u, null_hash, null_hash, 0u, 0u, 0u}, {}).value();
+    return message::block::create(chain::header{1u, null_hash, null_hash, 0u, 0u, 0u}, one_tx()).value();
 }
 } // anonymous namespace
 

--- a/src/domain/test/message/header.cpp
+++ b/src/domain/test/message/header.cpp
@@ -8,20 +8,15 @@ using namespace kth;
 using namespace kd;
 
 namespace {
-// The all-zero header is the `is_valid() == false` sentinel; there is no
-// default constructor (header is valid-by-construction), so build it from zero
-// fields.
+// A header with all-zero fields, used where a test needs a header distinct
+// from a populated one. There is no default constructor (header is
+// valid-by-construction), so build it from zero fields.
 message::header make_zero_header() {
     return message::header{0u, null_hash, null_hash, 0u, 0u, 0u};
 }
 } // namespace
 
 // Start Test Suite: message header tests
-
-TEST_CASE("message header constructor 1 always initialized invalid", "[message header]") {
-    auto instance = make_zero_header();
-    REQUIRE( ! instance.is_valid());
-}
 
 TEST_CASE("message header constructor 2 always equals params", "[message header]") {
     uint32_t version = 10u;
@@ -32,7 +27,6 @@ TEST_CASE("message header constructor 2 always equals params", "[message header]
     uint32_t nonce = 68644u;
 
     message::header instance(version, previous, merkle, timestamp, bits, nonce);
-    REQUIRE(instance.is_valid());
     REQUIRE(version == instance.version());
     REQUIRE(timestamp == instance.timestamp());
     REQUIRE(bits == instance.bits());
@@ -50,7 +44,6 @@ TEST_CASE("message header constructor 3 always equals params", "[message header]
     uint32_t nonce = 68644u;
 
     message::header instance(version, std::move(previous), std::move(merkle), timestamp, bits, nonce);
-    REQUIRE(instance.is_valid());
     REQUIRE(version == instance.version());
     REQUIRE(timestamp == instance.timestamp());
     REQUIRE(bits == instance.bits());
@@ -69,7 +62,6 @@ TEST_CASE("message header constructor 4 always equals params", "[message header]
         1234u);
 
     message::header instance(expected);
-    REQUIRE(instance.is_valid());
     REQUIRE(expected == instance);
 }
 
@@ -83,7 +75,6 @@ TEST_CASE("message header constructor 5 always equals params", "[message header]
         123u);
 
     message::header instance(std::move(expected));
-    REQUIRE(instance.is_valid());
     REQUIRE(expected == instance);
 }
 
@@ -97,7 +88,6 @@ TEST_CASE("message header constructor 6 always equals params", "[message header]
         68644u);
 
     message::header instance(expected);
-    REQUIRE(instance.is_valid());
     REQUIRE(expected == instance);
 }
 
@@ -111,7 +101,6 @@ TEST_CASE("message header constructor 7 always equals params", "[message header]
         68644u);
 
     message::header instance(std::move(expected));
-    REQUIRE(instance.is_valid());
     REQUIRE(expected == instance);
 }
 
@@ -139,7 +128,6 @@ TEST_CASE("message header from data valid input canonical version no transaction
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
 
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
     REQUIRE(data.size() == result.serialized_size(version));
     REQUIRE(expected.serialized_size(version) == chain::header::satoshi_fixed_size());
@@ -162,7 +150,6 @@ TEST_CASE("message header from data valid input success", "[message header]") {
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
 
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
     REQUIRE(data.size() == result.serialized_size(version));
     REQUIRE(expected.serialized_size(version) == result.serialized_size(version));
@@ -179,13 +166,10 @@ TEST_CASE("message header operator assign equals 1 always matches equivalent", "
         6523454u,
         68644u);
 
-    REQUIRE(value.is_valid());
 
     auto instance = make_zero_header();
-    REQUIRE( ! instance.is_valid());
 
     instance = std::move(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(value == instance);
 }
 
@@ -198,13 +182,10 @@ TEST_CASE("message header operator assign equals 2 always matches equivalent", "
         6523454u,
         68644u);
 
-    REQUIRE(value.is_valid());
 
     auto instance = make_zero_header();
-    REQUIRE( ! instance.is_valid());
 
     instance = std::move(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(value == instance);
 }
 


### PR DESCRIPTION
Stacked on #463. Completes the header valid-by-construction cascade by removing `header::is_valid()`.

## Rationale

A header has **no construction-time validity criterion**: any 6-field value is a syntactically valid header (the genesis header even carries an all-zero previous-block hash), and consensus validity (PoW, timestamps) is checked by *validation* with chain context — not at construction. The old `is_valid()` was really an "is this the uninitialized default sentinel?" query, made obsolete once the default constructor was removed (#463).

## Changes

- Remove `header::is_valid()` from both implementations and the redundant C-API `kth_chain_header_is_valid` binding.
- Drop the now-dead `is_valid()` guard in `block_chain::filter_blocks` — `internal_db.get_header` already signals not-found via `unexpected`.
- Re-express the `create()` guards that referenced `header.is_valid()` in terms of the payload alone:
  - `block::create` rejects an empty transaction list (a block always has a coinbase). `from_data` goes through `create`, so a zero-transaction block is rejected at parse time. The existing `empty_block` validation checks remain as defence-in-depth.
  - `merkle_block` / `compact_block` reject a fully-empty payload.
- Update domain + C-API tests: build the all-zero header explicitly where a distinct header is needed, drop the sentinel/`is_valid` assertions, remove the (now unreachable) empty-block tests, and give block fixtures a transaction.

## Testing

Local build green across domain, database, blockchain, network, c-api and node. Full domain suite (3835 cases) and C-API suite (741 cases) pass.