### PR TITLE
refactor(domain/chain): domain construction is syntactic-only, never fails

### DIFF
--- a/src/c-api/include/kth/capi/chain/block.h
+++ b/src/c-api/include/kth/capi/chain/block.h
@@ -44,9 +44,9 @@ kth_block_mut_t kth_chain_block_genesis_scalenet(void);
 KTH_EXPORT KTH_OWNED
 kth_block_mut_t kth_chain_block_genesis_chipnet(void);
 
-/** @param[out] out Must point to a null `kth_block_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_block_destruct`. Untouched on error. */
-KTH_EXPORT
-kth_error_code_t kth_chain_block_create(kth_header_const_t header, kth_transaction_list_const_t transactions, KTH_OUT_OWNED kth_block_mut_t* out);
+/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_block_mut_t kth_chain_block_create(kth_header_const_t header, kth_transaction_list_const_t transactions);
 
 
 // Destructor

--- a/src/c-api/include/kth/capi/chain/compact_block.h
+++ b/src/c-api/include/kth/capi/chain/compact_block.h
@@ -20,9 +20,9 @@ extern "C" {
 KTH_EXPORT
 kth_error_code_t kth_chain_compact_block_construct_from_data(uint8_t const* data, kth_size_t n, uint32_t version, KTH_OUT_OWNED kth_compact_block_mut_t* out);
 
-/** @param[out] out Must point to a null `kth_compact_block_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_compact_block_destruct`. Untouched on error. */
-KTH_EXPORT
-kth_error_code_t kth_chain_compact_block_create(kth_header_const_t header, uint64_t nonce, kth_u64_list_const_t short_ids, kth_prefilled_transaction_list_const_t transactions, KTH_OUT_OWNED kth_compact_block_mut_t* out);
+/** @return Owned `kth_compact_block_mut_t`. Caller must release with `kth_chain_compact_block_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_compact_block_mut_t kth_chain_compact_block_create(kth_header_const_t header, uint64_t nonce, kth_u64_list_const_t short_ids, kth_prefilled_transaction_list_const_t transactions);
 
 
 // Destructor

--- a/src/c-api/include/kth/capi/chain/merkle_block.h
+++ b/src/c-api/include/kth/capi/chain/merkle_block.h
@@ -27,9 +27,9 @@ kth_error_code_t kth_chain_merkle_block_construct_from_data(uint8_t const* data,
 KTH_EXPORT KTH_OWNED
 kth_merkle_block_mut_t kth_chain_merkle_block_construct(kth_block_const_t block);
 
-/** @param[out] out Must point to a null `kth_merkle_block_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_merkle_block_destruct`. Untouched on error. */
-KTH_EXPORT
-kth_error_code_t kth_chain_merkle_block_create(kth_header_const_t header, kth_size_t total_transactions, kth_hash_list_const_t hashes, uint8_t const* flags, kth_size_t n, KTH_OUT_OWNED kth_merkle_block_mut_t* out);
+/** @return Owned `kth_merkle_block_mut_t`. Caller must release with `kth_chain_merkle_block_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_merkle_block_mut_t kth_chain_merkle_block_create(kth_header_const_t header, kth_size_t total_transactions, kth_hash_list_const_t hashes, uint8_t const* flags, kth_size_t n);
 
 
 // Destructor

--- a/src/c-api/include/kth/capi/error.h
+++ b/src/c-api/include/kth/capi/error.h
@@ -252,17 +252,6 @@ typedef enum kth_error_code {
     kth_ec_bad_merkle_block_count,
     kth_ec_illegal_value,
 
-    // Valid-by-construction guard: `block::create` was given parts that would
-    // be the empty sentinel (no transactions and an all-zero header). Distinct
-    // from the consensus `empty_block` check performed during validation.
-    kth_ec_block_construction_empty,
-
-    // Valid-by-construction guards for the message wrappers: `create` was
-    // given parts that would be the all-default sentinel (an all-zero header
-    // and no payload).
-    kth_ec_merkle_block_construction_empty,
-    kth_ec_compact_block_construction_empty,
-
     // Database cache
     kth_ec_height_not_found,
     kth_ec_hash_not_found,

--- a/src/c-api/src/chain/block.cpp
+++ b/src/c-api/src/chain/block.cpp
@@ -57,17 +57,12 @@ kth_block_mut_t kth_chain_block_genesis_chipnet(void) {
     return kth::leak(cpp_t::genesis_chipnet());
 }
 
-kth_error_code_t kth_chain_block_create(kth_header_const_t header, kth_transaction_list_const_t transactions, KTH_OUT_OWNED kth_block_mut_t* out) {
+kth_block_mut_t kth_chain_block_create(kth_header_const_t header, kth_transaction_list_const_t transactions) {
     KTH_PRECONDITION(header != nullptr);
     KTH_PRECONDITION(transactions != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
     auto const& header_cpp = kth::cpp_ref<kth::domain::chain::header>(header);
     auto const& transactions_cpp = kth::cpp_ref<kth::domain::chain::transaction::list>(transactions);
-    auto result = cpp_t::create(header_cpp, transactions_cpp);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
+    return kth::leak(cpp_t::create(header_cpp, transactions_cpp));
 }
 
 

--- a/src/c-api/src/chain/compact_block.cpp
+++ b/src/c-api/src/chain/compact_block.cpp
@@ -33,19 +33,14 @@ kth_error_code_t kth_chain_compact_block_construct_from_data(uint8_t const* data
     return kth_ec_success;
 }
 
-kth_error_code_t kth_chain_compact_block_create(kth_header_const_t header, uint64_t nonce, kth_u64_list_const_t short_ids, kth_prefilled_transaction_list_const_t transactions, KTH_OUT_OWNED kth_compact_block_mut_t* out) {
+kth_compact_block_mut_t kth_chain_compact_block_create(kth_header_const_t header, uint64_t nonce, kth_u64_list_const_t short_ids, kth_prefilled_transaction_list_const_t transactions) {
     KTH_PRECONDITION(header != nullptr);
     KTH_PRECONDITION(short_ids != nullptr);
     KTH_PRECONDITION(transactions != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
     auto const& header_cpp = kth::cpp_ref<kth::domain::chain::header>(header);
     auto const& short_ids_cpp = kth::cpp_ref<std::vector<uint64_t>>(short_ids);
     auto const& transactions_cpp = kth::cpp_ref<kth::domain::message::prefilled_transaction::list>(transactions);
-    auto result = cpp_t::create(header_cpp, nonce, short_ids_cpp, transactions_cpp);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
+    return kth::leak(cpp_t::create(header_cpp, nonce, short_ids_cpp, transactions_cpp));
 }
 
 

--- a/src/c-api/src/chain/merkle_block.cpp
+++ b/src/c-api/src/chain/merkle_block.cpp
@@ -39,20 +39,15 @@ kth_merkle_block_mut_t kth_chain_merkle_block_construct(kth_block_const_t block)
     return kth::leak<cpp_t>(block_cpp);
 }
 
-kth_error_code_t kth_chain_merkle_block_create(kth_header_const_t header, kth_size_t total_transactions, kth_hash_list_const_t hashes, uint8_t const* flags, kth_size_t n, KTH_OUT_OWNED kth_merkle_block_mut_t* out) {
+kth_merkle_block_mut_t kth_chain_merkle_block_create(kth_header_const_t header, kth_size_t total_transactions, kth_hash_list_const_t hashes, uint8_t const* flags, kth_size_t n) {
     KTH_PRECONDITION(header != nullptr);
     KTH_PRECONDITION(hashes != nullptr);
     KTH_PRECONDITION(flags != nullptr || n == 0);
-    KTH_PRECONDITION(out != nullptr);
-    KTH_PRECONDITION(*out == nullptr);
     auto const& header_cpp = kth::cpp_ref<kth::domain::chain::header>(header);
     auto const total_transactions_cpp = kth::sz(total_transactions);
     auto const& hashes_cpp = kth::cpp_ref<kth::hash_list>(hashes);
     auto const flags_cpp = n != 0 ? kth::data_chunk(flags, flags + n) : kth::data_chunk{};
-    auto result = cpp_t::create(header_cpp, total_transactions_cpp, hashes_cpp, flags_cpp);
-    if ( ! result) return kth::to_c_err(result.error());
-    *out = kth::leak(std::move(*result));
-    return kth_ec_success;
+    return kth::leak(cpp_t::create(header_cpp, total_transactions_cpp, hashes_cpp, flags_cpp));
 }
 
 

--- a/src/c-api/test/chain/block.cpp
+++ b/src/c-api/test/chain/block.cpp
@@ -27,15 +27,16 @@
 // Constructors / lifecycle
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API Block - create rejects the empty sentinel",
+TEST_CASE("C-API Block - create accepts a block with no transactions",
           "[C-API Block]") {
+    // A domain block does no consensus checks: an empty block is syntactically
+    // valid and construction cannot fail.
     kth_hash_t const zero = {{ 0 }};
     kth_header_mut_t h = kth_chain_header_construct(0u, &zero, &zero, 0u, 0u, 0u);
     kth_transaction_list_mut_t txs = kth_chain_transaction_list_construct_default();
-    kth_block_mut_t blk = NULL;
-    kth_error_code_t ec = kth_chain_block_create(h, txs, &blk);
-    REQUIRE(ec != kth_ec_success);
-    REQUIRE(blk == NULL);
+    kth_block_mut_t blk = kth_chain_block_create(h, txs);
+    REQUIRE(blk != NULL);
+    kth_chain_block_destruct(blk);
     kth_chain_header_destruct(h);
     kth_chain_transaction_list_destruct(txs);
 }

--- a/src/c-api/test/chain/block_fixtures.hpp
+++ b/src/c-api/test/chain/block_fixtures.hpp
@@ -21,26 +21,14 @@ inline kth_block_mut_t make_block(void) {
     return blk;
 }
 
-// A minimal block: a non-zero header and a single transaction (a block always
-// has at least one). Distinct from genesis, so it doubles as the "other" block
-// for inequality tests.
+// A minimal block: a non-zero header, no transactions. Distinct from genesis,
+// so it doubles as the "other" block for inequality tests.
 inline kth_block_mut_t make_minimal_block(void) {
     static kth_hash_t const zero_hash = {{0}};
-    // Minimal serializable tx: version=1, no inputs, no outputs, locktime=0.
-    static uint8_t const minimal_tx[10] = {
-        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
-    };
     kth_header_mut_t h = kth_chain_header_construct(1u, &zero_hash, &zero_hash, 0u, 0u, 0u);
-    kth_transaction_mut_t tx = NULL;
-    REQUIRE(kth_chain_transaction_construct_from_data(
-        minimal_tx, sizeof(minimal_tx), 1, &tx) == kth_ec_success);
     kth_transaction_list_mut_t txs = kth_chain_transaction_list_construct_default();
-    kth_chain_transaction_list_push_back(txs, tx);
-    kth_block_mut_t blk = NULL;
-    kth_error_code_t ec = kth_chain_block_create(h, txs, &blk);
-    REQUIRE(ec == kth_ec_success);
+    kth_block_mut_t blk = kth_chain_block_create(h, txs);
     REQUIRE(blk != NULL);
-    kth_chain_transaction_destruct(tx);
     kth_chain_header_destruct(h);
     kth_chain_transaction_list_destruct(txs);
     return blk;

--- a/src/c-api/test/chain/compact_block.cpp
+++ b/src/c-api/test/chain/compact_block.cpp
@@ -94,10 +94,8 @@ static kth_compact_block_mut_t make_fixture(void) {
     kth_transaction_mut_t tx = make_tx();
     kth_prefilled_transaction_list_mut_t txs = make_prefilled_list(tx);
 
-    kth_compact_block_mut_t cb = NULL;
-    kth_error_code_t ec = kth_chain_compact_block_create(
-        header, 0xCAFEBABEu, short_ids, txs, &cb);
-    REQUIRE(ec == kth_ec_success);
+    kth_compact_block_mut_t cb = kth_chain_compact_block_create(
+        header, 0xCAFEBABEu, short_ids, txs);
     REQUIRE(cb != NULL);
 
     kth_chain_prefilled_transaction_list_destruct(txs);
@@ -111,18 +109,18 @@ static kth_compact_block_mut_t make_fixture(void) {
 // Constructors / lifecycle
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API CompactBlock - create rejects the empty sentinel",
+TEST_CASE("C-API CompactBlock - create accepts an empty payload",
           "[C-API CompactBlock]") {
+    // A domain compact_block does no consensus checks; construction cannot fail.
     kth_hash_t const zero = {{ 0 }};
     kth_header_mut_t header = kth_chain_header_construct(0u, &zero, &zero, 0u, 0u, 0u);
     kth_u64_list_mut_t short_ids = kth_core_u64_list_construct_default();
     kth_prefilled_transaction_list_mut_t txs =
         kth_chain_prefilled_transaction_list_construct_default();
-    kth_compact_block_mut_t cb = NULL;
-    kth_error_code_t ec = kth_chain_compact_block_create(
-        header, 0u, short_ids, txs, &cb);
-    REQUIRE(ec != kth_ec_success);
-    REQUIRE(cb == NULL);
+    kth_compact_block_mut_t cb = kth_chain_compact_block_create(
+        header, 0u, short_ids, txs);
+    REQUIRE(cb != NULL);
+    kth_chain_compact_block_destruct(cb);
     kth_chain_prefilled_transaction_list_destruct(txs);
     kth_core_u64_list_destruct(short_ids);
     kth_chain_header_destruct(header);
@@ -251,9 +249,8 @@ TEST_CASE("C-API CompactBlock - create null header aborts",
     kth_u64_list_mut_t short_ids = make_short_ids();
     kth_transaction_mut_t tx = make_tx();
     kth_prefilled_transaction_list_mut_t txs = make_prefilled_list(tx);
-    kth_compact_block_mut_t out = NULL;
     KTH_EXPECT_ABORT(
-        kth_chain_compact_block_create(NULL, 0u, short_ids, txs, &out));
+        kth_chain_compact_block_create(NULL, 0u, short_ids, txs));
     kth_chain_prefilled_transaction_list_destruct(txs);
     kth_chain_transaction_destruct(tx);
     kth_core_u64_list_destruct(short_ids);
@@ -264,9 +261,8 @@ TEST_CASE("C-API CompactBlock - create null short_ids aborts",
     kth_header_mut_t header = make_header();
     kth_transaction_mut_t tx = make_tx();
     kth_prefilled_transaction_list_mut_t txs = make_prefilled_list(tx);
-    kth_compact_block_mut_t out = NULL;
     KTH_EXPECT_ABORT(
-        kth_chain_compact_block_create(header, 0u, NULL, txs, &out));
+        kth_chain_compact_block_create(header, 0u, NULL, txs));
     kth_chain_prefilled_transaction_list_destruct(txs);
     kth_chain_transaction_destruct(tx);
     kth_chain_header_destruct(header);
@@ -276,9 +272,8 @@ TEST_CASE("C-API CompactBlock - create null transactions aborts",
           "[C-API CompactBlock][precondition]") {
     kth_header_mut_t header = make_header();
     kth_u64_list_mut_t short_ids = make_short_ids();
-    kth_compact_block_mut_t out = NULL;
     KTH_EXPECT_ABORT(
-        kth_chain_compact_block_create(header, 0u, short_ids, NULL, &out));
+        kth_chain_compact_block_create(header, 0u, short_ids, NULL));
     kth_core_u64_list_destruct(short_ids);
     kth_chain_header_destruct(header);
 }

--- a/src/c-api/test/chain/merkle_block.cpp
+++ b/src/c-api/test/chain/merkle_block.cpp
@@ -78,10 +78,8 @@ static kth_hash_list_mut_t make_two_hashes(void) {
 static kth_merkle_block_mut_t make_fixture(void) {
     kth_header_mut_t header = make_header();
     kth_hash_list_mut_t hashes = make_two_hashes();
-    kth_merkle_block_mut_t mb = NULL;
-    kth_error_code_t ec = kth_chain_merkle_block_create(
-        header, 2u, hashes, kFlags, sizeof(kFlags), &mb);
-    REQUIRE(ec == kth_ec_success);
+    kth_merkle_block_mut_t mb = kth_chain_merkle_block_create(
+        header, 2u, hashes, kFlags, sizeof(kFlags));
     REQUIRE(mb != NULL);
     kth_core_hash_list_destruct(hashes);
     kth_chain_header_destruct(header);
@@ -92,16 +90,16 @@ static kth_merkle_block_mut_t make_fixture(void) {
 // Constructors / lifecycle
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API MerkleBlock - create rejects the empty sentinel",
+TEST_CASE("C-API MerkleBlock - create accepts an empty payload",
           "[C-API MerkleBlock]") {
+    // A domain merkle_block does no consensus checks; construction cannot fail.
     kth_hash_t const zero = {{ 0 }};
     kth_header_mut_t header = kth_chain_header_construct(0u, &zero, &zero, 0u, 0u, 0u);
     kth_hash_list_mut_t hashes = kth_core_hash_list_construct_default();
-    kth_merkle_block_mut_t mb = NULL;
-    kth_error_code_t ec = kth_chain_merkle_block_create(
-        header, 0u, hashes, NULL, 0, &mb);
-    REQUIRE(ec != kth_ec_success);
-    REQUIRE(mb == NULL);
+    kth_merkle_block_mut_t mb = kth_chain_merkle_block_create(
+        header, 0u, hashes, NULL, 0);
+    REQUIRE(mb != NULL);
+    kth_chain_merkle_block_destruct(mb);
     kth_core_hash_list_destruct(hashes);
     kth_chain_header_destruct(header);
 }
@@ -251,9 +249,8 @@ TEST_CASE("C-API MerkleBlock - construct_from_data non-null out slot aborts",
 TEST_CASE("C-API MerkleBlock - create null header aborts",
           "[C-API MerkleBlock][precondition]") {
     kth_hash_list_mut_t hashes = make_two_hashes();
-    kth_merkle_block_mut_t out = NULL;
     KTH_EXPECT_ABORT(kth_chain_merkle_block_create(
-        NULL, 2u, hashes, kFlags, sizeof(kFlags), &out));
+        NULL, 2u, hashes, kFlags, sizeof(kFlags)));
     kth_core_hash_list_destruct(hashes);
 }
 

--- a/src/domain/include/kth/domain/chain/block.hpp
+++ b/src/domain/include/kth/domain/chain/block.hpp
@@ -63,11 +63,12 @@ public:
     // Constructors.
     //-------------------------------------------------------------------------
 
-    /// The only way to build a block from parts. Returns `error::empty_block`
-    /// when the result would be the empty sentinel (no transactions and an
-    /// all-zero header), so a constructed `block` is always a real block.
+    /// Build a block from parts. Construction cannot fail: a domain block is a
+    /// pure structural aggregate of a header and its transactions and performs
+    /// no consensus checks. An empty block is syntactically valid; consensus
+    /// validity (empty block, merkle root, etc.) is validation's concern.
     static
-    expect<block> create(chain::header header, transaction::list transactions);
+    block create(chain::header header, transaction::list transactions);
 
     // Operators.
     //-------------------------------------------------------------------------

--- a/src/domain/include/kth/domain/message/block.hpp
+++ b/src/domain/include/kth/domain/message/block.hpp
@@ -36,10 +36,10 @@ public:
     block(chain::block const& x);
     block(chain::block&& x);
 
-    /// Build from parts. Mirrors `chain::block::create`: returns
-    /// `error::block_construction_empty` for the empty sentinel.
+    /// Build from parts. Mirrors `chain::block::create`; construction cannot
+    /// fail (a domain block does no consensus checks).
     static
-    expect<block> create(chain::header header, chain::transaction::list transactions);
+    block create(chain::header header, chain::transaction::list transactions);
 
     block& operator=(chain::block&& x);
 

--- a/src/domain/include/kth/domain/message/compact_block.hpp
+++ b/src/domain/include/kth/domain/message/compact_block.hpp
@@ -31,10 +31,9 @@ struct KD_API compact_block {
     static
     compact_block factory_from_block(message::block const& blk);
 
-    /// Build from parts. Returns `error::compact_block_construction_empty` for
-    /// the all-default sentinel (an empty header with no payload).
+    /// Build from parts. Construction cannot fail (no consensus checks).
     static
-    expect<compact_block> create(chain::header header, uint64_t nonce, short_id_list short_ids, prefilled_transaction::list transactions);
+    compact_block create(chain::header header, uint64_t nonce, short_id_list short_ids, prefilled_transaction::list transactions);
 
     [[nodiscard]]
     friend bool operator==(compact_block const&, compact_block const&) = default;

--- a/src/domain/include/kth/domain/message/merkle_block.hpp
+++ b/src/domain/include/kth/domain/message/merkle_block.hpp
@@ -25,11 +25,9 @@ struct KD_API merkle_block {
     using ptr = std::shared_ptr<merkle_block>;
     using const_ptr = std::shared_ptr<const merkle_block>;
 
-    /// Build from parts. Returns `error::merkle_block_construction_empty` for
-    /// the all-default sentinel (an empty header with no hashes or flags), so
-    /// a constructed `merkle_block` is always a real one.
+    /// Build from parts. Construction cannot fail (no consensus checks).
     static
-    expect<merkle_block> create(chain::header header, size_t total_transactions, hash_list hashes, data_chunk flags);
+    merkle_block create(chain::header header, size_t total_transactions, hash_list hashes, data_chunk flags);
 
     /// Wrap an already-constructed (hence valid) block.
     merkle_block(chain::block const& block);

--- a/src/domain/src/chain/block.cpp
+++ b/src/domain/src/chain/block.cpp
@@ -186,13 +186,7 @@ block::block(chain::header const& header, transaction::list&& transactions)
 {}
 
 // static
-expect<block> block::create(chain::header header, transaction::list transactions) {
-    // A block always carries at least a coinbase, so no transactions is never
-    // a real block. (Consensus validity beyond this — merkle root, sigops,
-    // etc. — is validation's concern, not construction's.)
-    if (transactions.empty()) {
-        return std::unexpected(error::block_construction_empty);
-    }
+block block::create(chain::header header, transaction::list transactions) {
     return block{header, std::move(transactions)};
 }
 
@@ -219,11 +213,8 @@ expect<block> block::from_data(byte_reader& reader) {
     }
     auto const end_deserialize = asio::steady_clock::now();
     auto res = create(*hdr, std::move(*txs));
-    if ( ! res) {
-        return std::unexpected(res.error());
-    }
-    res->validation.start_deserialize = start_deserialize;
-    res->validation.end_deserialize = end_deserialize;
+    res.validation.start_deserialize = start_deserialize;
+    res.validation.end_deserialize = end_deserialize;
     return res;
 }
 

--- a/src/domain/src/message/block.cpp
+++ b/src/domain/src/message/block.cpp
@@ -29,12 +29,8 @@ block::block(chain::block const& x)
 {}
 
 // static
-expect<block> block::create(chain::header header, chain::transaction::list transactions) {
-    auto base = chain::block::create(std::move(header), std::move(transactions));
-    if ( ! base) {
-        return std::unexpected(base.error());
-    }
-    return block{std::move(*base)};
+block block::create(chain::header header, chain::transaction::list transactions) {
+    return block{chain::block::create(std::move(header), std::move(transactions))};
 }
 
 // block::block(block&& x) noexcept

--- a/src/domain/src/message/compact_block.cpp
+++ b/src/domain/src/message/compact_block.cpp
@@ -47,12 +47,7 @@ compact_block compact_block::factory_from_block(message::block const& block) {
 }
 
 // static
-expect<compact_block> compact_block::create(chain::header header, uint64_t nonce, short_id_list short_ids, prefilled_transaction::list transactions) {
-    // Reject the fully-empty payload; a compact block always prefills at least
-    // the coinbase.
-    if (short_ids.empty() && transactions.empty()) {
-        return std::unexpected(error::compact_block_construction_empty);
-    }
+compact_block compact_block::create(chain::header header, uint64_t nonce, short_id_list short_ids, prefilled_transaction::list transactions) {
     return compact_block{header, nonce, std::move(short_ids), std::move(transactions)};
 }
 

--- a/src/domain/src/message/merkle_block.cpp
+++ b/src/domain/src/message/merkle_block.cpp
@@ -35,11 +35,7 @@ merkle_block::merkle_block(chain::block const& block)
 }
 
 // static
-expect<merkle_block> merkle_block::create(chain::header header, size_t total_transactions, hash_list hashes, data_chunk flags) {
-    // Reject the fully-empty payload; a merkle block always describes a tree.
-    if (hashes.empty() && flags.empty()) {
-        return std::unexpected(error::merkle_block_construction_empty);
-    }
+merkle_block merkle_block::create(chain::header header, size_t total_transactions, hash_list hashes, data_chunk flags) {
     return merkle_block{header, total_transactions, std::move(hashes), std::move(flags)};
 }
 

--- a/src/domain/test/chain/block.cpp
+++ b/src/domain/test/chain/block.cpp
@@ -35,7 +35,7 @@ bool all_valid(chain::transaction::list const& transactions) {
 // one; `create` rejects an empty transaction list.
 chain::block make_block(chain::transaction::list txs = {chain::transaction(1, 0, {}, {})}) {
     return chain::block::create(
-        chain::header{1u, null_hash, null_hash, 0u, 0u, 0u}, std::move(txs)).value();
+        chain::header{1u, null_hash, null_hash, 0u, 0u, 0u}, std::move(txs));
 }
 
 } // anonymous namespace
@@ -77,12 +77,6 @@ TEST_CASE("block locator heights positive backoff returns top plus log offset to
     REQUIRE(expected == result);
 }
 
-TEST_CASE("block create rejects the empty sentinel", "[chain block]") {
-    // No transactions and an all-zero header is not a block.
-    REQUIRE( ! chain::block::create(chain::header{0u, null_hash, null_hash, 0u, 0u, 0u}, {}));
-    REQUIRE(chain::block::create(chain::header{0u, null_hash, null_hash, 0u, 0u, 0u}, {}).error() == error::block_construction_empty);
-}
-
 TEST_CASE("block create 2 always equals params", "[chain block]") {
     chain::header const header {
         10u,
@@ -99,7 +93,7 @@ TEST_CASE("block create 2 always equals params", "[chain block]") {
         chain::transaction(4, 16, {}, {})
     };
 
-    auto const instance = chain::block::create(header, transactions).value();
+    auto const instance = chain::block::create(header, transactions);
     REQUIRE(header == instance.header());
     REQUIRE(transactions == instance.transactions());
 }
@@ -124,7 +118,7 @@ TEST_CASE("block create 3 always equals params", "[chain block]") {
     chain::header dup_header(header);
     chain::transaction::list dup_transactions(transactions);
 
-    auto const instance = chain::block::create(std::move(dup_header), std::move(dup_transactions)).value();
+    auto const instance = chain::block::create(std::move(dup_header), std::move(dup_transactions));
 
     REQUIRE(header == instance.header());
     REQUIRE(transactions == instance.transactions());
@@ -146,7 +140,7 @@ TEST_CASE("block copy 4 always equals params", "[chain block]") {
         chain::transaction(4, 16, {}, {})
     };
 
-    auto const value = chain::block::create(header, transactions).value();
+    auto const value = chain::block::create(header, transactions);
     chain::block const instance(value);
     REQUIRE(value == instance);
     REQUIRE(header == instance.header());
@@ -170,7 +164,7 @@ TEST_CASE("block move 5 always equals params", "[chain block]") {
     };
 
     // This must be non-const.
-    auto value = chain::block::create(header, transactions).value();
+    auto value = chain::block::create(header, transactions);
 
     chain::block const instance(std::move(value));
 
@@ -405,7 +399,7 @@ TEST_CASE("block header accessor always returns initialized value", "[block gene
         chain::transaction(4, 16, {}, {})
     };
 
-    auto const instance = chain::block::create(header, transactions).value();
+    auto const instance = chain::block::create(header, transactions);
     REQUIRE(header == instance.header());
 }
 
@@ -419,7 +413,7 @@ TEST_CASE("block construct exposes header", "[block generate merkle root]") {
         68644u
     };
 
-    auto instance = chain::block::create(header, {chain::transaction(1, 0, {}, {})}).value();
+    auto instance = chain::block::create(header, {chain::transaction(1, 0, {}, {})});
     REQUIRE(header == instance.header());
 }
 
@@ -439,7 +433,7 @@ TEST_CASE("block transactions accessor always returns initialized value", "[bloc
         chain::transaction(4, 16, {}, {})
     };
 
-    auto const instance = chain::block::create(header, transactions).value();
+    auto const instance = chain::block::create(header, transactions);
     REQUIRE(transactions == instance.transactions());
 }
 
@@ -489,7 +483,7 @@ TEST_CASE("block operator assign equals always matches equivalent", "[block gene
     };
 
     // This must be non-const.
-    auto value = chain::block::create(header, transactions).value();
+    auto value = chain::block::create(header, transactions);
 
     auto instance = make_block();
     instance = std::move(value);
@@ -512,7 +506,7 @@ TEST_CASE("block operator boolean equals duplicates returns true", "[block gener
             chain::transaction(2, 32, {}, {}),
             chain::transaction(4, 16, {}, {})
         }
-    ).value();
+    );
 
     chain::block const instance(expected);
     REQUIRE(instance == expected);
@@ -533,7 +527,7 @@ TEST_CASE("block operator boolean equals differs returns false", "[block generat
             chain::transaction(2, 32, {}, {}),
             chain::transaction(4, 16, {}, {})
         }
-    ).value();
+    );
 
     auto const instance = make_block();
     REQUIRE( ! (instance == expected));
@@ -554,7 +548,7 @@ TEST_CASE("block operator boolean not equals duplicates returns false", "[block 
             chain::transaction(2, 32, {}, {}),
             chain::transaction(4, 16, {}, {})
         }
-    ).value();
+    );
 
     chain::block const instance(expected);
     REQUIRE( ! (instance != expected));
@@ -575,7 +569,7 @@ TEST_CASE("block operator boolean not equals differs returns true", "[block gene
             chain::transaction(2, 32, {}, {}),
             chain::transaction(4, 16, {}, {})
         }
-    ).value();
+    );
 
     auto const instance = make_block();
     REQUIRE(instance != expected);

--- a/src/domain/test/message/block.cpp
+++ b/src/domain/test/message/block.cpp
@@ -17,18 +17,14 @@ chain::transaction::list one_tx() {
     return {chain::transaction(1, 0, {}, {})};
 }
 chain::block make_chain_block() {
-    return chain::block::create(chain::header{1u, null_hash, null_hash, 0u, 0u, 0u}, one_tx()).value();
+    return chain::block::create(chain::header{1u, null_hash, null_hash, 0u, 0u, 0u}, one_tx());
 }
 message::block make_msg_block() {
-    return message::block::create(chain::header{1u, null_hash, null_hash, 0u, 0u, 0u}, one_tx()).value();
+    return message::block::create(chain::header{1u, null_hash, null_hash, 0u, 0u, 0u}, one_tx());
 }
 } // anonymous namespace
 
 // Start Test Suite: message block tests
-
-TEST_CASE("block create rejects the empty sentinel", "[message block]") {
-    REQUIRE( ! block::create(chain::header{0u, null_hash, null_hash, 0u, 0u, 0u}, {}));
-}
 
 TEST_CASE("block constructor 2 always equals params", "[message block]") {
     chain::header const header(10u,
@@ -43,7 +39,7 @@ TEST_CASE("block constructor 2 always equals params", "[message block]") {
         chain::transaction(2, 32, {}, {}),
         chain::transaction(4, 16, {}, {})};
 
-    auto instance = block::create(header, transactions).value();
+    auto instance = block::create(header, transactions);
     REQUIRE(header == instance.header());
     REQUIRE(transactions == instance.transactions());
 }
@@ -63,7 +59,7 @@ TEST_CASE("block constructor 3 always equals params", "[message block]") {
 
     chain::header dup_header(header);
     chain::transaction::list dup_transactions = transactions;
-    auto instance = block::create(std::move(dup_header), std::move(dup_transactions)).value();
+    auto instance = block::create(std::move(dup_header), std::move(dup_transactions));
     REQUIRE(header == instance.header());
     REQUIRE(transactions == instance.transactions());
 }
@@ -81,7 +77,7 @@ TEST_CASE("block constructor 4 always equals params", "[message block]") {
         chain::transaction(2, 32, {}, {}),
         chain::transaction(4, 16, {}, {})};
 
-    auto value = chain::block::create(header, transactions).value();
+    auto value = chain::block::create(header, transactions);
     block instance(value);
     REQUIRE(instance == value);
     REQUIRE(header == instance.header());
@@ -101,7 +97,7 @@ TEST_CASE("block constructor 5 always equals params", "[message block]") {
         chain::transaction(2, 32, {}, {}),
         chain::transaction(4, 16, {}, {})};
 
-    auto value = chain::block::create(header, transactions).value();
+    auto value = chain::block::create(header, transactions);
     block instance(std::move(value));
     REQUIRE(header == instance.header());
     REQUIRE(transactions == instance.transactions());
@@ -120,7 +116,7 @@ TEST_CASE("block constructor 6 always equals params", "[message block]") {
         chain::transaction(2, 32, {}, {}),
         chain::transaction(4, 16, {}, {})};
 
-    auto value = block::create(header, transactions).value();
+    auto value = block::create(header, transactions);
     block instance(value);
     REQUIRE(value == instance);
     REQUIRE(header == instance.header());
@@ -140,7 +136,7 @@ TEST_CASE("block constructor 7 always equals params", "[message block]") {
         chain::transaction(2, 32, {}, {}),
         chain::transaction(4, 16, {}, {})};
 
-    auto value = block::create(header, transactions).value();
+    auto value = block::create(header, transactions);
     block instance(std::move(value));
     REQUIRE(header == instance.header());
     REQUIRE(transactions == instance.transactions());
@@ -186,7 +182,7 @@ TEST_CASE("block operator assign equals 1 always matches equivalent", "[message 
         chain::transaction(2, 32, {}, {}),
         chain::transaction(4, 16, {}, {})};
 
-    auto value = chain::block::create(header, transactions).value();
+    auto value = chain::block::create(header, transactions);
 
     auto instance = make_msg_block();
 
@@ -208,7 +204,7 @@ TEST_CASE("block operator assign equals 2 always matches equivalent", "[message 
         chain::transaction(2, 32, {}, {}),
         chain::transaction(4, 16, {}, {})};
 
-    auto value = message::block::create(header, transactions).value();
+    auto value = message::block::create(header, transactions);
 
 
     auto instance = make_msg_block();
@@ -228,7 +224,7 @@ TEST_CASE("block operator boolean equals 1 duplicates returns true", "[message b
                       68644u),
         {chain::transaction(1, 48, {}, {}),
          chain::transaction(2, 32, {}, {}),
-         chain::transaction(4, 16, {}, {})}).value();
+         chain::transaction(4, 16, {}, {})});
 
     message::block instance(expected);
     REQUIRE(instance == expected);
@@ -244,7 +240,7 @@ TEST_CASE("block operator boolean equals 1 differs returns false", "[message blo
                       68644u),
         {chain::transaction(1, 48, {}, {}),
          chain::transaction(2, 32, {}, {}),
-         chain::transaction(4, 16, {}, {})}).value();
+         chain::transaction(4, 16, {}, {})});
 
     auto instance = make_msg_block();
     REQUIRE(instance != expected);
@@ -260,7 +256,7 @@ TEST_CASE("block operator boolean not equals 1 duplicates returns false", "[mess
                       68644u),
         {chain::transaction(1, 48, {}, {}),
          chain::transaction(2, 32, {}, {}),
-         chain::transaction(4, 16, {}, {})}).value();
+         chain::transaction(4, 16, {}, {})});
 
     message::block instance(expected);
     REQUIRE(instance == expected);
@@ -276,7 +272,7 @@ TEST_CASE("block operator boolean not equals 1 differs returns true", "[message 
                       68644u),
         {chain::transaction(1, 48, {}, {}),
          chain::transaction(2, 32, {}, {}),
-         chain::transaction(4, 16, {}, {})}).value();
+         chain::transaction(4, 16, {}, {})});
 
     auto instance = make_chain_block();
     REQUIRE(instance != expected);
@@ -292,7 +288,7 @@ TEST_CASE("block operator boolean equals 2 duplicates returns true", "[message b
                       68644u),
         {chain::transaction(1, 48, {}, {}),
          chain::transaction(2, 32, {}, {}),
-         chain::transaction(4, 16, {}, {})}).value();
+         chain::transaction(4, 16, {}, {})});
 
     message::block instance(expected);
     REQUIRE(instance == expected);
@@ -308,7 +304,7 @@ TEST_CASE("block operator boolean equals 2 differs returns false", "[message blo
                       68644u),
         {chain::transaction(1, 48, {}, {}),
          chain::transaction(2, 32, {}, {}),
-         chain::transaction(4, 16, {}, {})}).value();
+         chain::transaction(4, 16, {}, {})});
 
     auto instance = make_msg_block();
     REQUIRE(instance != expected);
@@ -324,7 +320,7 @@ TEST_CASE("block operator boolean not equals 2 duplicates returns false", "[mess
                       68644u),
         {chain::transaction(1, 48, {}, {}),
          chain::transaction(2, 32, {}, {}),
-         chain::transaction(4, 16, {}, {})}).value();
+         chain::transaction(4, 16, {}, {})});
 
     message::block instance(expected);
     REQUIRE(instance == expected);
@@ -340,7 +336,7 @@ TEST_CASE("block operator boolean not equals 2 differs returns true", "[message 
                       68644u),
         {chain::transaction(1, 48, {}, {}),
          chain::transaction(2, 32, {}, {}),
-         chain::transaction(4, 16, {}, {})}).value();
+         chain::transaction(4, 16, {}, {})});
 
     auto instance = make_msg_block();
     REQUIRE(instance != expected);

--- a/src/domain/test/message/compact_block.cpp
+++ b/src/domain/test/message/compact_block.cpp
@@ -35,22 +35,16 @@ message::prefilled_transaction::list const test_transactions{
     message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))};
 
 message::compact_block make_compact_block(uint64_t nonce = 453245u) {
-    return message::compact_block::create(test_header, nonce, test_short_ids, test_transactions).value();
+    return message::compact_block::create(test_header, nonce, test_short_ids, test_transactions);
 }
 
 } // namespace
 
 // Start Test Suite: compact block tests
 
-TEST_CASE("compact block create rejects empty sentinel", "[compact block]") {
-    auto const result = message::compact_block::create(chain::header{0u, null_hash, null_hash, 0u, 0u, 0u}, 0u, {}, {});
-    REQUIRE( ! result);
-    REQUIRE(result.error() == error::compact_block_construction_empty);
-}
-
 TEST_CASE("compact block create always equals params", "[compact block]") {
     uint64_t const nonce = 453245u;
-    auto const instance = message::compact_block::create(test_header, nonce, test_short_ids, test_transactions).value();
+    auto const instance = message::compact_block::create(test_header, nonce, test_short_ids, test_transactions);
     REQUIRE(test_header == instance.header());
     REQUIRE(nonce == instance.nonce());
     REQUIRE(test_short_ids == instance.short_ids());
@@ -147,7 +141,7 @@ TEST_CASE("compact block operator boolean equals duplicates returns true", "[com
 
 TEST_CASE("compact block operator boolean equals differs returns false", "[compact block]") {
     auto const expected = make_compact_block(12334u);
-    auto const instance = message::compact_block::create(test_header, 99999u, test_short_ids, test_transactions).value();
+    auto const instance = message::compact_block::create(test_header, 99999u, test_short_ids, test_transactions);
     REQUIRE(instance != expected);
 }
 
@@ -159,7 +153,7 @@ TEST_CASE("compact block operator boolean not equals duplicates returns false", 
 
 TEST_CASE("compact block operator boolean not equals differs returns true", "[compact block]") {
     auto const expected = make_compact_block(12334u);
-    auto const instance = message::compact_block::create(test_header, 99999u, test_short_ids, test_transactions).value();
+    auto const instance = message::compact_block::create(test_header, 99999u, test_short_ids, test_transactions);
     REQUIRE(instance != expected);
 }
 

--- a/src/domain/test/message/merkle_block.cpp
+++ b/src/domain/test/message/merkle_block.cpp
@@ -26,22 +26,16 @@ hash_list const test_hashes{
 data_chunk const test_flags{0xae, 0x56, 0x0f};
 
 message::merkle_block make_merkle_block(size_t count = 1234u) {
-    return message::merkle_block::create(test_header, count, test_hashes, test_flags).value();
+    return message::merkle_block::create(test_header, count, test_hashes, test_flags);
 }
 
 } // namespace
 
 // Start Test Suite: merkle block tests
 
-TEST_CASE("merkle block create rejects empty sentinel", "[merkle block]") {
-    auto const result = message::merkle_block::create(chain::header{0u, null_hash, null_hash, 0u, 0u, 0u}, 0u, {}, {});
-    REQUIRE( ! result);
-    REQUIRE(result.error() == error::merkle_block_construction_empty);
-}
-
 TEST_CASE("merkle block create always equals params", "[merkle block]") {
     size_t const count = 1234u;
-    auto const instance = message::merkle_block::create(test_header, count, test_hashes, test_flags).value();
+    auto const instance = message::merkle_block::create(test_header, count, test_hashes, test_flags);
     REQUIRE(test_header == instance.header());
     REQUIRE(instance.total_transactions() == count);
     REQUIRE(test_hashes == instance.hashes());
@@ -67,7 +61,7 @@ TEST_CASE("from data insufficient version fails", "[merkle block]") {
         test_header,
         34523u,
         {"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash},
-        {0x00}).value();
+        {0x00});
 
     auto const data = kth::to_data_chunk(expected, message::version::level::maximum);
 
@@ -81,7 +75,7 @@ TEST_CASE("merkle block - roundtrip to data factory from data chunk", "[merkle b
         test_header,
         45633u,
         {"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash},
-        {0x00}).value();
+        {0x00});
 
     auto const data = kth::to_data_chunk(expected, message::version::level::maximum);
     byte_reader reader(data);
@@ -115,7 +109,7 @@ TEST_CASE("merkle block operator boolean equals duplicates returns true", "[merk
 
 TEST_CASE("merkle block operator boolean equals differs returns false", "[merkle block]") {
     auto const expected = make_merkle_block(1469u);
-    auto const instance = message::merkle_block::create(test_header, 1470u, {}, test_flags).value();
+    auto const instance = message::merkle_block::create(test_header, 1470u, {}, test_flags);
     REQUIRE( ! (instance == expected));
 }
 
@@ -127,7 +121,7 @@ TEST_CASE("merkle block operator boolean not equals duplicates returns false", "
 
 TEST_CASE("merkle block operator boolean not equals differs returns true", "[merkle block]") {
     auto const expected = make_merkle_block(8642u);
-    auto const instance = message::merkle_block::create(test_header, 8642u, {}, test_flags).value();
+    auto const instance = message::merkle_block::create(test_header, 8642u, {}, test_flags);
     REQUIRE(instance != expected);
 }
 

--- a/src/infrastructure/include/kth/infrastructure/error.hpp
+++ b/src/infrastructure/include/kth/infrastructure/error.hpp
@@ -283,17 +283,6 @@ enum error_code_t {
     bad_merkle_block_count,
     illegal_value,
 
-    // Valid-by-construction guard: `block::create` was given parts that would
-    // be the empty sentinel (no transactions and an all-zero header). Distinct
-    // from the consensus `empty_block` check performed during validation.
-    block_construction_empty,
-
-    // Valid-by-construction guards for the message wrappers: `create` was
-    // given parts that would be the all-default sentinel (an all-zero header
-    // and no payload).
-    merkle_block_construction_empty,
-    compact_block_construction_empty,
-
     // Database cache
     height_not_found,
     hash_not_found,

--- a/src/infrastructure/src/error.cpp
+++ b/src/infrastructure/src/error.cpp
@@ -261,11 +261,6 @@ std::string error_category_impl::message(int ev) const noexcept {
         { error::read_past_end_of_buffer, "read past end of buffer" },
         { error::skip_past_end_of_buffer, "skip past end of buffer" },
         { error::write_past_end_of_buffer, "write past end of buffer" },
-
-        // Valid-by-construction
-        { error::block_construction_empty, "cannot construct a block with no transactions and an empty header" },
-        { error::merkle_block_construction_empty, "cannot construct a merkle_block from an empty header with no payload" },
-        { error::compact_block_construction_empty, "cannot construct a compact_block from an empty header with no payload" }
     };
 
     auto const message = messages.find(ev);


### PR DESCRIPTION
Establishes the rule that **domain value types perform no consensus checks**. A header is always valid; a block is a header plus a list of transactions and is always valid — even if the list is empty; likewise for the message wrappers. The only way construction can fail is deserialization from a malformed byte array, which `from_data` already reports via `expect<>`.

This drops the empty-payload guards added with the block family (#459/#460/#464), which were consensus checks (`empty_block`) leaking into construction.

## Changes

- `block::create`, `message::block::create`, `merkle_block::create` and `compact_block::create` no longer return `expect<>` — they return the value and cannot fail. `from_data` keeps returning `expect<>` (bad bytes); an empty block now parses and is rejected later by validation, as it was before.
- Remove the `block_construction_empty`, `merkle_block_construction_empty` and `compact_block_construction_empty` error codes. The consensus `empty_block` / `empty_transaction` checks in validation are the authority and are reachable again.
- Regenerate the C-API bindings and error enum: the three `_create` entry points now return an owned handle instead of an error code.
- Update domain + C-API tests: drop the `.value()` unwrapping and turn the "create rejects the empty sentinel" cases into coverage that an empty payload is accepted.

## Testing

Local build green across domain, database, blockchain, network, c-api and node. Full domain suite (3831 cases) and C-API suite (741 cases) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for invalid Merkle block counts and other illegal values.
  * Removed obsolete errors related to constructing empty blocks and messages.
  * Updated displayed error messages to reflect the revised validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->