### PR TITLE
refactor(domain/chain): restore public constructors; drop the create() factories

### DIFF
--- a/src/c-api/include/kth/capi/chain/block.h
+++ b/src/c-api/include/kth/capi/chain/block.h
@@ -22,6 +22,18 @@ kth_error_code_t kth_chain_block_construct_from_data(uint8_t const* data, kth_si
 
 /** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
 KTH_EXPORT KTH_OWNED
+kth_block_mut_t kth_chain_block_construct_default(void);
+
+/**
+ * @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`.
+ * @param header Borrowed input. Copied by value into the resulting object; ownership of `header` stays with the caller.
+ * @param transactions Borrowed input. Copied by value into the resulting object; ownership of `transactions` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_block_mut_t kth_chain_block_construct(kth_header_const_t header, kth_transaction_list_const_t transactions);
+
+/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
+KTH_EXPORT KTH_OWNED
 kth_block_mut_t kth_chain_block_genesis_mainnet(void);
 
 /** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
@@ -43,10 +55,6 @@ kth_block_mut_t kth_chain_block_genesis_scalenet(void);
 /** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_block_mut_t kth_chain_block_genesis_chipnet(void);
-
-/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_block_mut_t kth_chain_block_create(kth_header_const_t header, kth_transaction_list_const_t transactions);
 
 
 // Destructor

--- a/src/c-api/include/kth/capi/chain/compact_block.h
+++ b/src/c-api/include/kth/capi/chain/compact_block.h
@@ -22,7 +22,16 @@ kth_error_code_t kth_chain_compact_block_construct_from_data(uint8_t const* data
 
 /** @return Owned `kth_compact_block_mut_t`. Caller must release with `kth_chain_compact_block_destruct`. */
 KTH_EXPORT KTH_OWNED
-kth_compact_block_mut_t kth_chain_compact_block_create(kth_header_const_t header, uint64_t nonce, kth_u64_list_const_t short_ids, kth_prefilled_transaction_list_const_t transactions);
+kth_compact_block_mut_t kth_chain_compact_block_construct_default(void);
+
+/**
+ * @return Owned `kth_compact_block_mut_t`. Caller must release with `kth_chain_compact_block_destruct`.
+ * @param header Borrowed input. Copied by value into the resulting object; ownership of `header` stays with the caller.
+ * @param short_ids Borrowed input. Copied by value into the resulting object; ownership of `short_ids` stays with the caller.
+ * @param transactions Borrowed input. Copied by value into the resulting object; ownership of `transactions` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_compact_block_mut_t kth_chain_compact_block_construct(kth_header_const_t header, uint64_t nonce, kth_u64_list_const_t short_ids, kth_prefilled_transaction_list_const_t transactions);
 
 
 // Destructor

--- a/src/c-api/include/kth/capi/chain/merkle_block.h
+++ b/src/c-api/include/kth/capi/chain/merkle_block.h
@@ -20,16 +20,24 @@ extern "C" {
 KTH_EXPORT
 kth_error_code_t kth_chain_merkle_block_construct_from_data(uint8_t const* data, kth_size_t n, uint32_t version, KTH_OUT_OWNED kth_merkle_block_mut_t* out);
 
+/** @return Owned `kth_merkle_block_mut_t`. Caller must release with `kth_chain_merkle_block_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_merkle_block_mut_t kth_chain_merkle_block_construct_default(void);
+
+/**
+ * @return Owned `kth_merkle_block_mut_t`. Caller must release with `kth_chain_merkle_block_destruct`.
+ * @param header Borrowed input. Copied by value into the resulting object; ownership of `header` stays with the caller.
+ * @param hashes Borrowed input. Copied by value into the resulting object; ownership of `hashes` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_merkle_block_mut_t kth_chain_merkle_block_construct_from_header_total_transactions_hashes_flags(kth_header_const_t header, kth_size_t total_transactions, kth_hash_list_const_t hashes, uint8_t const* flags, kth_size_t n);
+
 /**
  * @return Owned `kth_merkle_block_mut_t`. Caller must release with `kth_chain_merkle_block_destruct`.
  * @param block Borrowed input. Copied by value into the resulting object; ownership of `block` stays with the caller.
  */
 KTH_EXPORT KTH_OWNED
-kth_merkle_block_mut_t kth_chain_merkle_block_construct(kth_block_const_t block);
-
-/** @return Owned `kth_merkle_block_mut_t`. Caller must release with `kth_chain_merkle_block_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_merkle_block_mut_t kth_chain_merkle_block_create(kth_header_const_t header, kth_size_t total_transactions, kth_hash_list_const_t hashes, uint8_t const* flags, kth_size_t n);
+kth_merkle_block_mut_t kth_chain_merkle_block_construct_from_block(kth_block_const_t block);
 
 
 // Destructor

--- a/src/c-api/src/chain/block.cpp
+++ b/src/c-api/src/chain/block.cpp
@@ -33,6 +33,18 @@ kth_error_code_t kth_chain_block_construct_from_data(uint8_t const* data, kth_si
     return kth_ec_success;
 }
 
+kth_block_mut_t kth_chain_block_construct_default(void) {
+    return kth::leak<cpp_t>();
+}
+
+kth_block_mut_t kth_chain_block_construct(kth_header_const_t header, kth_transaction_list_const_t transactions) {
+    KTH_PRECONDITION(header != nullptr);
+    KTH_PRECONDITION(transactions != nullptr);
+    auto const& header_cpp = kth::cpp_ref<kth::domain::chain::header>(header);
+    auto const& transactions_cpp = kth::cpp_ref<kth::domain::chain::transaction::list>(transactions);
+    return kth::leak<cpp_t>(header_cpp, transactions_cpp);
+}
+
 kth_block_mut_t kth_chain_block_genesis_mainnet(void) {
     return kth::leak(cpp_t::genesis_mainnet());
 }
@@ -55,14 +67,6 @@ kth_block_mut_t kth_chain_block_genesis_scalenet(void) {
 
 kth_block_mut_t kth_chain_block_genesis_chipnet(void) {
     return kth::leak(cpp_t::genesis_chipnet());
-}
-
-kth_block_mut_t kth_chain_block_create(kth_header_const_t header, kth_transaction_list_const_t transactions) {
-    KTH_PRECONDITION(header != nullptr);
-    KTH_PRECONDITION(transactions != nullptr);
-    auto const& header_cpp = kth::cpp_ref<kth::domain::chain::header>(header);
-    auto const& transactions_cpp = kth::cpp_ref<kth::domain::chain::transaction::list>(transactions);
-    return kth::leak(cpp_t::create(header_cpp, transactions_cpp));
 }
 
 

--- a/src/c-api/src/chain/compact_block.cpp
+++ b/src/c-api/src/chain/compact_block.cpp
@@ -33,14 +33,18 @@ kth_error_code_t kth_chain_compact_block_construct_from_data(uint8_t const* data
     return kth_ec_success;
 }
 
-kth_compact_block_mut_t kth_chain_compact_block_create(kth_header_const_t header, uint64_t nonce, kth_u64_list_const_t short_ids, kth_prefilled_transaction_list_const_t transactions) {
+kth_compact_block_mut_t kth_chain_compact_block_construct_default(void) {
+    return kth::leak<cpp_t>();
+}
+
+kth_compact_block_mut_t kth_chain_compact_block_construct(kth_header_const_t header, uint64_t nonce, kth_u64_list_const_t short_ids, kth_prefilled_transaction_list_const_t transactions) {
     KTH_PRECONDITION(header != nullptr);
     KTH_PRECONDITION(short_ids != nullptr);
     KTH_PRECONDITION(transactions != nullptr);
     auto const& header_cpp = kth::cpp_ref<kth::domain::chain::header>(header);
     auto const& short_ids_cpp = kth::cpp_ref<std::vector<uint64_t>>(short_ids);
     auto const& transactions_cpp = kth::cpp_ref<kth::domain::message::prefilled_transaction::list>(transactions);
-    return kth::leak(cpp_t::create(header_cpp, nonce, short_ids_cpp, transactions_cpp));
+    return kth::leak<cpp_t>(header_cpp, nonce, short_ids_cpp, transactions_cpp);
 }
 
 

--- a/src/c-api/src/chain/merkle_block.cpp
+++ b/src/c-api/src/chain/merkle_block.cpp
@@ -33,13 +33,11 @@ kth_error_code_t kth_chain_merkle_block_construct_from_data(uint8_t const* data,
     return kth_ec_success;
 }
 
-kth_merkle_block_mut_t kth_chain_merkle_block_construct(kth_block_const_t block) {
-    KTH_PRECONDITION(block != nullptr);
-    auto const& block_cpp = kth::cpp_ref<kth::domain::chain::block>(block);
-    return kth::leak<cpp_t>(block_cpp);
+kth_merkle_block_mut_t kth_chain_merkle_block_construct_default(void) {
+    return kth::leak<cpp_t>();
 }
 
-kth_merkle_block_mut_t kth_chain_merkle_block_create(kth_header_const_t header, kth_size_t total_transactions, kth_hash_list_const_t hashes, uint8_t const* flags, kth_size_t n) {
+kth_merkle_block_mut_t kth_chain_merkle_block_construct_from_header_total_transactions_hashes_flags(kth_header_const_t header, kth_size_t total_transactions, kth_hash_list_const_t hashes, uint8_t const* flags, kth_size_t n) {
     KTH_PRECONDITION(header != nullptr);
     KTH_PRECONDITION(hashes != nullptr);
     KTH_PRECONDITION(flags != nullptr || n == 0);
@@ -47,7 +45,13 @@ kth_merkle_block_mut_t kth_chain_merkle_block_create(kth_header_const_t header, 
     auto const total_transactions_cpp = kth::sz(total_transactions);
     auto const& hashes_cpp = kth::cpp_ref<kth::hash_list>(hashes);
     auto const flags_cpp = n != 0 ? kth::data_chunk(flags, flags + n) : kth::data_chunk{};
-    return kth::leak(cpp_t::create(header_cpp, total_transactions_cpp, hashes_cpp, flags_cpp));
+    return kth::leak<cpp_t>(header_cpp, total_transactions_cpp, hashes_cpp, flags_cpp);
+}
+
+kth_merkle_block_mut_t kth_chain_merkle_block_construct_from_block(kth_block_const_t block) {
+    KTH_PRECONDITION(block != nullptr);
+    auto const& block_cpp = kth::cpp_ref<kth::domain::chain::block>(block);
+    return kth::leak<cpp_t>(block_cpp);
 }
 
 

--- a/src/c-api/test/chain/block.cpp
+++ b/src/c-api/test/chain/block.cpp
@@ -34,7 +34,7 @@ TEST_CASE("C-API Block - create accepts a block with no transactions",
     kth_hash_t const zero = {{ 0 }};
     kth_header_mut_t h = kth_chain_header_construct(0u, &zero, &zero, 0u, 0u, 0u);
     kth_transaction_list_mut_t txs = kth_chain_transaction_list_construct_default();
-    kth_block_mut_t blk = kth_chain_block_create(h, txs);
+    kth_block_mut_t blk = kth_chain_block_construct(h, txs);
     REQUIRE(blk != NULL);
     kth_chain_block_destruct(blk);
     kth_chain_header_destruct(h);

--- a/src/c-api/test/chain/block_fixtures.hpp
+++ b/src/c-api/test/chain/block_fixtures.hpp
@@ -27,7 +27,7 @@ inline kth_block_mut_t make_minimal_block(void) {
     static kth_hash_t const zero_hash = {{0}};
     kth_header_mut_t h = kth_chain_header_construct(1u, &zero_hash, &zero_hash, 0u, 0u, 0u);
     kth_transaction_list_mut_t txs = kth_chain_transaction_list_construct_default();
-    kth_block_mut_t blk = kth_chain_block_create(h, txs);
+    kth_block_mut_t blk = kth_chain_block_construct(h, txs);
     REQUIRE(blk != NULL);
     kth_chain_header_destruct(h);
     kth_chain_transaction_list_destruct(txs);

--- a/src/c-api/test/chain/compact_block.cpp
+++ b/src/c-api/test/chain/compact_block.cpp
@@ -94,7 +94,7 @@ static kth_compact_block_mut_t make_fixture(void) {
     kth_transaction_mut_t tx = make_tx();
     kth_prefilled_transaction_list_mut_t txs = make_prefilled_list(tx);
 
-    kth_compact_block_mut_t cb = kth_chain_compact_block_create(
+    kth_compact_block_mut_t cb = kth_chain_compact_block_construct(
         header, 0xCAFEBABEu, short_ids, txs);
     REQUIRE(cb != NULL);
 
@@ -117,7 +117,7 @@ TEST_CASE("C-API CompactBlock - create accepts an empty payload",
     kth_u64_list_mut_t short_ids = kth_core_u64_list_construct_default();
     kth_prefilled_transaction_list_mut_t txs =
         kth_chain_prefilled_transaction_list_construct_default();
-    kth_compact_block_mut_t cb = kth_chain_compact_block_create(
+    kth_compact_block_mut_t cb = kth_chain_compact_block_construct(
         header, 0u, short_ids, txs);
     REQUIRE(cb != NULL);
     kth_chain_compact_block_destruct(cb);
@@ -250,7 +250,7 @@ TEST_CASE("C-API CompactBlock - create null header aborts",
     kth_transaction_mut_t tx = make_tx();
     kth_prefilled_transaction_list_mut_t txs = make_prefilled_list(tx);
     KTH_EXPECT_ABORT(
-        kth_chain_compact_block_create(NULL, 0u, short_ids, txs));
+        kth_chain_compact_block_construct(NULL, 0u, short_ids, txs));
     kth_chain_prefilled_transaction_list_destruct(txs);
     kth_chain_transaction_destruct(tx);
     kth_core_u64_list_destruct(short_ids);
@@ -262,7 +262,7 @@ TEST_CASE("C-API CompactBlock - create null short_ids aborts",
     kth_transaction_mut_t tx = make_tx();
     kth_prefilled_transaction_list_mut_t txs = make_prefilled_list(tx);
     KTH_EXPECT_ABORT(
-        kth_chain_compact_block_create(header, 0u, NULL, txs));
+        kth_chain_compact_block_construct(header, 0u, NULL, txs));
     kth_chain_prefilled_transaction_list_destruct(txs);
     kth_chain_transaction_destruct(tx);
     kth_chain_header_destruct(header);
@@ -273,7 +273,7 @@ TEST_CASE("C-API CompactBlock - create null transactions aborts",
     kth_header_mut_t header = make_header();
     kth_u64_list_mut_t short_ids = make_short_ids();
     KTH_EXPECT_ABORT(
-        kth_chain_compact_block_create(header, 0u, short_ids, NULL));
+        kth_chain_compact_block_construct(header, 0u, short_ids, NULL));
     kth_core_u64_list_destruct(short_ids);
     kth_chain_header_destruct(header);
 }

--- a/src/c-api/test/chain/merkle_block.cpp
+++ b/src/c-api/test/chain/merkle_block.cpp
@@ -78,7 +78,7 @@ static kth_hash_list_mut_t make_two_hashes(void) {
 static kth_merkle_block_mut_t make_fixture(void) {
     kth_header_mut_t header = make_header();
     kth_hash_list_mut_t hashes = make_two_hashes();
-    kth_merkle_block_mut_t mb = kth_chain_merkle_block_create(
+    kth_merkle_block_mut_t mb = kth_chain_merkle_block_construct_from_header_total_transactions_hashes_flags(
         header, 2u, hashes, kFlags, sizeof(kFlags));
     REQUIRE(mb != NULL);
     kth_core_hash_list_destruct(hashes);
@@ -96,7 +96,7 @@ TEST_CASE("C-API MerkleBlock - create accepts an empty payload",
     kth_hash_t const zero = {{ 0 }};
     kth_header_mut_t header = kth_chain_header_construct(0u, &zero, &zero, 0u, 0u, 0u);
     kth_hash_list_mut_t hashes = kth_core_hash_list_construct_default();
-    kth_merkle_block_mut_t mb = kth_chain_merkle_block_create(
+    kth_merkle_block_mut_t mb = kth_chain_merkle_block_construct_from_header_total_transactions_hashes_flags(
         header, 0u, hashes, NULL, 0);
     REQUIRE(mb != NULL);
     kth_chain_merkle_block_destruct(mb);
@@ -249,14 +249,14 @@ TEST_CASE("C-API MerkleBlock - construct_from_data non-null out slot aborts",
 TEST_CASE("C-API MerkleBlock - create null header aborts",
           "[C-API MerkleBlock][precondition]") {
     kth_hash_list_mut_t hashes = make_two_hashes();
-    KTH_EXPECT_ABORT(kth_chain_merkle_block_create(
+    KTH_EXPECT_ABORT(kth_chain_merkle_block_construct_from_header_total_transactions_hashes_flags(
         NULL, 2u, hashes, kFlags, sizeof(kFlags)));
     kth_core_hash_list_destruct(hashes);
 }
 
 TEST_CASE("C-API MerkleBlock - construct null block aborts",
           "[C-API MerkleBlock][precondition]") {
-    KTH_EXPECT_ABORT(kth_chain_merkle_block_construct(NULL));
+    KTH_EXPECT_ABORT(kth_chain_merkle_block_construct_from_block(NULL));
 }
 
 TEST_CASE("C-API MerkleBlock - to_data null out_size aborts",

--- a/src/domain/include/kth/domain/chain/block.hpp
+++ b/src/domain/include/kth/domain/chain/block.hpp
@@ -63,12 +63,12 @@ public:
     // Constructors.
     //-------------------------------------------------------------------------
 
-    /// Build a block from parts. Construction cannot fail: a domain block is a
-    /// pure structural aggregate of a header and its transactions and performs
-    /// no consensus checks. An empty block is syntactically valid; consensus
-    /// validity (empty block, merkle root, etc.) is validation's concern.
-    static
-    block create(chain::header header, transaction::list transactions);
+    // A block is a pure structural aggregate of a header and its transactions
+    // and performs no consensus checks, so construction cannot fail and every
+    // state is syntactically valid — including the all-default one and the
+    // empty block. Consensus validity is validation's concern.
+    block() = default;
+    block(chain::header header, transaction::list transactions);
 
     // Operators.
     //-------------------------------------------------------------------------
@@ -217,11 +217,6 @@ public:
     size_t non_coinbase_input_count() const;
 
 private:
-    // Construction goes through `create` / `from_data` / `genesis_*`, which
-    // guarantee a non-sentinel block; these do the actual member init.
-    block(chain::header const& header, transaction::list&& transactions);
-    block(chain::header const& header, transaction::list const& transactions);
-
     chain::header header_;
     transaction::list transactions_;
 };

--- a/src/domain/include/kth/domain/chain/header_members.hpp
+++ b/src/domain/include/kth/domain/chain/header_members.hpp
@@ -46,6 +46,10 @@ public:
     // Constructors.
     //-------------------------------------------------------------------------
 
+    // Every field combination is a syntactically valid header, so the
+    // all-default state is a valid value.
+    constexpr header() = default;
+
     constexpr header(uint32_t version, hash_digest const& previous_block_hash,
                      hash_digest const& merkle, uint32_t timestamp,
                      uint32_t bits, uint32_t nonce)

--- a/src/domain/include/kth/domain/chain/header_raw.hpp
+++ b/src/domain/include/kth/domain/chain/header_raw.hpp
@@ -90,6 +90,11 @@ public:
     // Constructors.
     //-------------------------------------------------------------------------
 
+    // Every field combination is a syntactically valid header (the genesis
+    // header even carries an all-zero previous-block hash), so construction
+    // cannot fail and the all-default state is a valid value.
+    constexpr header() = default;
+
     // Construct from raw bytes (must be exactly 80 bytes).
     explicit constexpr header(std::span<uint8_t const, serialized_size_wire> raw_data)
         : data_{}

--- a/src/domain/include/kth/domain/message/block.hpp
+++ b/src/domain/include/kth/domain/message/block.hpp
@@ -32,14 +32,14 @@ public:
     using const_ptr_list_ptr = std::shared_ptr<const_ptr_list>;
     using const_ptr_list_const_ptr = std::shared_ptr<const const_ptr_list>;
 
-    // Wrapping an already-constructed (hence valid) chain::block.
+    block() = default;
+
+    // Wrapping an already-constructed chain::block.
     block(chain::block const& x);
     block(chain::block&& x);
 
-    /// Build from parts. Mirrors `chain::block::create`; construction cannot
-    /// fail (a domain block does no consensus checks).
-    static
-    block create(chain::header header, chain::transaction::list transactions);
+    // Construction cannot fail (a domain block does no consensus checks).
+    block(chain::header header, chain::transaction::list transactions);
 
     block& operator=(chain::block&& x);
 

--- a/src/domain/include/kth/domain/message/compact_block.hpp
+++ b/src/domain/include/kth/domain/message/compact_block.hpp
@@ -31,9 +31,10 @@ struct KD_API compact_block {
     static
     compact_block factory_from_block(message::block const& blk);
 
-    /// Build from parts. Construction cannot fail (no consensus checks).
-    static
-    compact_block create(chain::header header, uint64_t nonce, short_id_list short_ids, prefilled_transaction::list transactions);
+    // Construction cannot fail (no consensus checks); every state, including
+    // the all-default one, is syntactically valid.
+    compact_block() = default;
+    compact_block(chain::header header, uint64_t nonce, short_id_list short_ids, prefilled_transaction::list transactions);
 
     [[nodiscard]]
     friend bool operator==(compact_block const&, compact_block const&) = default;
@@ -69,11 +70,6 @@ struct KD_API compact_block {
     uint32_t const version_maximum;
 
 private:
-    // Construction goes through `create` / `from_data` / `factory_from_block`,
-    // which guarantee a non-sentinel value.
-    compact_block(chain::header const& header, uint64_t nonce, short_id_list const& short_ids, prefilled_transaction::list const& transactions);
-    compact_block(chain::header const& header, uint64_t nonce, short_id_list&& short_ids, prefilled_transaction::list&& transactions);
-
     chain::header header_;
     uint64_t nonce_{0};
     short_id_list short_ids_;

--- a/src/domain/include/kth/domain/message/header.hpp
+++ b/src/domain/include/kth/domain/message/header.hpp
@@ -32,6 +32,8 @@ struct KD_API header : chain::header {
     // Inherit constructors
     using chain::header::header;
 
+    header() = default;
+
     header(chain::header const& x)
         : chain::header(x)
     {}

--- a/src/domain/include/kth/domain/message/merkle_block.hpp
+++ b/src/domain/include/kth/domain/message/merkle_block.hpp
@@ -25,9 +25,10 @@ struct KD_API merkle_block {
     using ptr = std::shared_ptr<merkle_block>;
     using const_ptr = std::shared_ptr<const merkle_block>;
 
-    /// Build from parts. Construction cannot fail (no consensus checks).
-    static
-    merkle_block create(chain::header header, size_t total_transactions, hash_list hashes, data_chunk flags);
+    // Construction cannot fail (no consensus checks); every state, including
+    // the all-default one, is syntactically valid.
+    merkle_block() = default;
+    merkle_block(chain::header header, size_t total_transactions, hash_list hashes, data_chunk flags);
 
     /// Wrap an already-constructed (hence valid) block.
     merkle_block(chain::block const& block);
@@ -68,11 +69,6 @@ struct KD_API merkle_block {
 
 
 private:
-    // Construction goes through `create` / `from_data` / the block-wrapping
-    // ctor, which guarantee a non-sentinel value.
-    merkle_block(chain::header const& header, size_t total_transactions, hash_list&& hashes, data_chunk&& flags);
-    merkle_block(chain::header const& header, size_t total_transactions, hash_list const& hashes, data_chunk const& flags);
-
     chain::header header_;
     size_t total_transactions_{0};
     hash_list hashes_;

--- a/src/domain/src/chain/block.cpp
+++ b/src/domain/src/chain/block.cpp
@@ -174,21 +174,11 @@ std::string const encoded_regtest_genesis_block =
 //-----------------------------------------------------------------------------
 
 // TODO(legacy): deal with possibility of inconsistent merkle root in relation to txs.
-block::block(chain::header const& header, transaction::list const& transactions)
-    : header_(header)
-    , transactions_(transactions)
-{}
-
-// TODO(legacy): deal with possibility of inconsistent merkle root in relation to txs.
-block::block(chain::header const& header, transaction::list&& transactions)
+block::block(chain::header header, transaction::list transactions)
     : header_(header)
     , transactions_(std::move(transactions))
 {}
 
-// static
-block block::create(chain::header header, transaction::list transactions) {
-    return block{header, std::move(transactions)};
-}
 
 // Operators.
 //-----------------------------------------------------------------------------
@@ -212,7 +202,7 @@ expect<block> block::from_data(byte_reader& reader) {
         return std::unexpected(txs.error());
     }
     auto const end_deserialize = asio::steady_clock::now();
-    auto res = create(*hdr, std::move(*txs));
+    auto res = block(*hdr, std::move(*txs));
     res.validation.start_deserialize = start_deserialize;
     res.validation.end_deserialize = end_deserialize;
     return res;

--- a/src/domain/src/message/block.cpp
+++ b/src/domain/src/message/block.cpp
@@ -29,9 +29,9 @@ block::block(chain::block const& x)
 {}
 
 // static
-block block::create(chain::header header, chain::transaction::list transactions) {
-    return block{chain::block::create(std::move(header), std::move(transactions))};
-}
+block::block(chain::header header, chain::transaction::list transactions)
+    : chain::block(std::move(header), std::move(transactions))
+{}
 
 // block::block(block&& x) noexcept
 //     : chain::block(std::move(x))

--- a/src/domain/src/message/compact_block.cpp
+++ b/src/domain/src/message/compact_block.cpp
@@ -47,18 +47,9 @@ compact_block compact_block::factory_from_block(message::block const& block) {
 }
 
 // static
-compact_block compact_block::create(chain::header header, uint64_t nonce, short_id_list short_ids, prefilled_transaction::list transactions) {
-    return compact_block{header, nonce, std::move(short_ids), std::move(transactions)};
-}
 
-compact_block::compact_block(chain::header const& header, uint64_t nonce, short_id_list const& short_ids, prefilled_transaction::list const& transactions)
-    : header_(header)
-    , nonce_(nonce)
-    , short_ids_(short_ids)
-    , transactions_(transactions)
-{}
 
-compact_block::compact_block(chain::header const& header, uint64_t nonce, short_id_list&& short_ids, prefilled_transaction::list&& transactions)
+compact_block::compact_block(chain::header header, uint64_t nonce, short_id_list short_ids, prefilled_transaction::list transactions)
     : header_(header)
     , nonce_(nonce)
     , short_ids_(std::move(short_ids))
@@ -129,7 +120,7 @@ expect<compact_block> compact_block::from_data(byte_reader& reader, uint32_t ver
         return std::unexpected(error::version_too_low);
     }
 
-    return create(*header, *nonce, std::move(short_ids), std::move(*txs));
+    return compact_block(*header, *nonce, std::move(short_ids), std::move(*txs));
 }
 
 // Serialization.

--- a/src/domain/src/message/merkle_block.cpp
+++ b/src/domain/src/message/merkle_block.cpp
@@ -17,11 +17,7 @@ std::string const merkle_block::command = "merkleblock";
 uint32_t const merkle_block::version_minimum = version::level::bip37;
 uint32_t const merkle_block::version_maximum = version::level::maximum;
 
-merkle_block::merkle_block(chain::header const& header, size_t total_transactions, hash_list const& hashes, data_chunk const& flags)
-    : header_(header), total_transactions_(total_transactions), hashes_(hashes), flags_(flags) {
-}
-
-merkle_block::merkle_block(chain::header const& header, size_t total_transactions, hash_list&& hashes, data_chunk&& flags)
+merkle_block::merkle_block(chain::header header, size_t total_transactions, hash_list hashes, data_chunk flags)
     : header_(header), total_transactions_(total_transactions), hashes_(std::move(hashes)), flags_(std::move(flags)) {
 }
 
@@ -35,9 +31,7 @@ merkle_block::merkle_block(chain::block const& block)
 }
 
 // static
-merkle_block merkle_block::create(chain::header header, size_t total_transactions, hash_list hashes, data_chunk flags) {
-    return merkle_block{header, total_transactions, std::move(hashes), std::move(flags)};
-}
+
 
 // Deserialization.
 //-----------------------------------------------------------------------------
@@ -87,7 +81,7 @@ expect<merkle_block> merkle_block::from_data(byte_reader& reader, uint32_t versi
         return std::unexpected(error::unsupported_version);
     }
 
-    return create(
+    return merkle_block(
         *header,
         *total_transactions,
         std::move(hashes),

--- a/src/domain/test/chain/block.cpp
+++ b/src/domain/test/chain/block.cpp
@@ -34,7 +34,7 @@ bool all_valid(chain::transaction::list const& transactions) {
 // single (coinbase-stand-in) transaction because a block always has at least
 // one; `create` rejects an empty transaction list.
 chain::block make_block(chain::transaction::list txs = {chain::transaction(1, 0, {}, {})}) {
-    return chain::block::create(
+    return chain::block(
         chain::header{1u, null_hash, null_hash, 0u, 0u, 0u}, std::move(txs));
 }
 
@@ -93,7 +93,7 @@ TEST_CASE("block create 2 always equals params", "[chain block]") {
         chain::transaction(4, 16, {}, {})
     };
 
-    auto const instance = chain::block::create(header, transactions);
+    auto const instance = chain::block(header, transactions);
     REQUIRE(header == instance.header());
     REQUIRE(transactions == instance.transactions());
 }
@@ -118,7 +118,7 @@ TEST_CASE("block create 3 always equals params", "[chain block]") {
     chain::header dup_header(header);
     chain::transaction::list dup_transactions(transactions);
 
-    auto const instance = chain::block::create(std::move(dup_header), std::move(dup_transactions));
+    auto const instance = chain::block(std::move(dup_header), std::move(dup_transactions));
 
     REQUIRE(header == instance.header());
     REQUIRE(transactions == instance.transactions());
@@ -140,7 +140,7 @@ TEST_CASE("block copy 4 always equals params", "[chain block]") {
         chain::transaction(4, 16, {}, {})
     };
 
-    auto const value = chain::block::create(header, transactions);
+    auto const value = chain::block(header, transactions);
     chain::block const instance(value);
     REQUIRE(value == instance);
     REQUIRE(header == instance.header());
@@ -164,7 +164,7 @@ TEST_CASE("block move 5 always equals params", "[chain block]") {
     };
 
     // This must be non-const.
-    auto value = chain::block::create(header, transactions);
+    auto value = chain::block(header, transactions);
 
     chain::block const instance(std::move(value));
 
@@ -399,7 +399,7 @@ TEST_CASE("block header accessor always returns initialized value", "[block gene
         chain::transaction(4, 16, {}, {})
     };
 
-    auto const instance = chain::block::create(header, transactions);
+    auto const instance = chain::block(header, transactions);
     REQUIRE(header == instance.header());
 }
 
@@ -413,7 +413,7 @@ TEST_CASE("block construct exposes header", "[block generate merkle root]") {
         68644u
     };
 
-    auto instance = chain::block::create(header, {chain::transaction(1, 0, {}, {})});
+    auto instance = chain::block(header, {chain::transaction(1, 0, {}, {})});
     REQUIRE(header == instance.header());
 }
 
@@ -433,7 +433,7 @@ TEST_CASE("block transactions accessor always returns initialized value", "[bloc
         chain::transaction(4, 16, {}, {})
     };
 
-    auto const instance = chain::block::create(header, transactions);
+    auto const instance = chain::block(header, transactions);
     REQUIRE(transactions == instance.transactions());
 }
 
@@ -483,7 +483,7 @@ TEST_CASE("block operator assign equals always matches equivalent", "[block gene
     };
 
     // This must be non-const.
-    auto value = chain::block::create(header, transactions);
+    auto value = chain::block(header, transactions);
 
     auto instance = make_block();
     instance = std::move(value);
@@ -492,7 +492,7 @@ TEST_CASE("block operator assign equals always matches equivalent", "[block gene
 }
 
 TEST_CASE("block operator boolean equals duplicates returns true", "[block generate merkle root]") {
-    auto const expected = chain::block::create(
+    auto const expected = chain::block(
         chain::header {
             10u,
             "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
@@ -513,7 +513,7 @@ TEST_CASE("block operator boolean equals duplicates returns true", "[block gener
 }
 
 TEST_CASE("block operator boolean equals differs returns false", "[block generate merkle root]") {
-    auto const expected = chain::block::create(
+    auto const expected = chain::block(
         chain::header {
             10u,
             "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
@@ -534,7 +534,7 @@ TEST_CASE("block operator boolean equals differs returns false", "[block generat
 }
 
 TEST_CASE("block operator boolean not equals duplicates returns false", "[block generate merkle root]") {
-    auto const expected = chain::block::create(
+    auto const expected = chain::block(
         chain::header {
             10u,
             "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
@@ -555,7 +555,7 @@ TEST_CASE("block operator boolean not equals duplicates returns false", "[block 
 }
 
 TEST_CASE("block operator boolean not equals differs returns true", "[block generate merkle root]") {
-    auto const expected = chain::block::create(
+    auto const expected = chain::block(
         chain::header {
             10u,
             "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,

--- a/src/domain/test/message/block.cpp
+++ b/src/domain/test/message/block.cpp
@@ -17,10 +17,10 @@ chain::transaction::list one_tx() {
     return {chain::transaction(1, 0, {}, {})};
 }
 chain::block make_chain_block() {
-    return chain::block::create(chain::header{1u, null_hash, null_hash, 0u, 0u, 0u}, one_tx());
+    return chain::block(chain::header{1u, null_hash, null_hash, 0u, 0u, 0u}, one_tx());
 }
 message::block make_msg_block() {
-    return message::block::create(chain::header{1u, null_hash, null_hash, 0u, 0u, 0u}, one_tx());
+    return message::block(chain::header{1u, null_hash, null_hash, 0u, 0u, 0u}, one_tx());
 }
 } // anonymous namespace
 
@@ -39,7 +39,7 @@ TEST_CASE("block constructor 2 always equals params", "[message block]") {
         chain::transaction(2, 32, {}, {}),
         chain::transaction(4, 16, {}, {})};
 
-    auto instance = block::create(header, transactions);
+    auto instance = block(header, transactions);
     REQUIRE(header == instance.header());
     REQUIRE(transactions == instance.transactions());
 }
@@ -59,7 +59,7 @@ TEST_CASE("block constructor 3 always equals params", "[message block]") {
 
     chain::header dup_header(header);
     chain::transaction::list dup_transactions = transactions;
-    auto instance = block::create(std::move(dup_header), std::move(dup_transactions));
+    auto instance = block(std::move(dup_header), std::move(dup_transactions));
     REQUIRE(header == instance.header());
     REQUIRE(transactions == instance.transactions());
 }
@@ -77,7 +77,7 @@ TEST_CASE("block constructor 4 always equals params", "[message block]") {
         chain::transaction(2, 32, {}, {}),
         chain::transaction(4, 16, {}, {})};
 
-    auto value = chain::block::create(header, transactions);
+    auto value = chain::block(header, transactions);
     block instance(value);
     REQUIRE(instance == value);
     REQUIRE(header == instance.header());
@@ -97,7 +97,7 @@ TEST_CASE("block constructor 5 always equals params", "[message block]") {
         chain::transaction(2, 32, {}, {}),
         chain::transaction(4, 16, {}, {})};
 
-    auto value = chain::block::create(header, transactions);
+    auto value = chain::block(header, transactions);
     block instance(std::move(value));
     REQUIRE(header == instance.header());
     REQUIRE(transactions == instance.transactions());
@@ -116,7 +116,7 @@ TEST_CASE("block constructor 6 always equals params", "[message block]") {
         chain::transaction(2, 32, {}, {}),
         chain::transaction(4, 16, {}, {})};
 
-    auto value = block::create(header, transactions);
+    auto value = block(header, transactions);
     block instance(value);
     REQUIRE(value == instance);
     REQUIRE(header == instance.header());
@@ -136,7 +136,7 @@ TEST_CASE("block constructor 7 always equals params", "[message block]") {
         chain::transaction(2, 32, {}, {}),
         chain::transaction(4, 16, {}, {})};
 
-    auto value = block::create(header, transactions);
+    auto value = block(header, transactions);
     block instance(std::move(value));
     REQUIRE(header == instance.header());
     REQUIRE(transactions == instance.transactions());
@@ -182,7 +182,7 @@ TEST_CASE("block operator assign equals 1 always matches equivalent", "[message 
         chain::transaction(2, 32, {}, {}),
         chain::transaction(4, 16, {}, {})};
 
-    auto value = chain::block::create(header, transactions);
+    auto value = chain::block(header, transactions);
 
     auto instance = make_msg_block();
 
@@ -204,7 +204,7 @@ TEST_CASE("block operator assign equals 2 always matches equivalent", "[message 
         chain::transaction(2, 32, {}, {}),
         chain::transaction(4, 16, {}, {})};
 
-    auto value = message::block::create(header, transactions);
+    auto value = message::block(header, transactions);
 
 
     auto instance = make_msg_block();
@@ -215,7 +215,7 @@ TEST_CASE("block operator assign equals 2 always matches equivalent", "[message 
 }
 
 TEST_CASE("block operator boolean equals 1 duplicates returns true", "[message block]") {
-    auto const expected = chain::block::create(
+    auto const expected = chain::block(
         chain::header(10u,
                       "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
                       "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
@@ -231,7 +231,7 @@ TEST_CASE("block operator boolean equals 1 duplicates returns true", "[message b
 }
 
 TEST_CASE("block operator boolean equals 1 differs returns false", "[message block]") {
-    auto const expected = chain::block::create(
+    auto const expected = chain::block(
         chain::header(10u,
                       "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
                       "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
@@ -247,7 +247,7 @@ TEST_CASE("block operator boolean equals 1 differs returns false", "[message blo
 }
 
 TEST_CASE("block operator boolean not equals 1 duplicates returns false", "[message block]") {
-    auto const expected = chain::block::create(
+    auto const expected = chain::block(
         chain::header(10u,
                       "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
                       "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
@@ -263,7 +263,7 @@ TEST_CASE("block operator boolean not equals 1 duplicates returns false", "[mess
 }
 
 TEST_CASE("block operator boolean not equals 1 differs returns true", "[message block]") {
-    auto const expected = chain::block::create(
+    auto const expected = chain::block(
         chain::header(10u,
                       "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
                       "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
@@ -279,7 +279,7 @@ TEST_CASE("block operator boolean not equals 1 differs returns true", "[message 
 }
 
 TEST_CASE("block operator boolean equals 2 duplicates returns true", "[message block]") {
-    auto const expected = message::block::create(
+    auto const expected = message::block(
         chain::header(10u,
                       "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
                       "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
@@ -295,7 +295,7 @@ TEST_CASE("block operator boolean equals 2 duplicates returns true", "[message b
 }
 
 TEST_CASE("block operator boolean equals 2 differs returns false", "[message block]") {
-    auto const expected = message::block::create(
+    auto const expected = message::block(
         chain::header(10u,
                       "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
                       "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
@@ -311,7 +311,7 @@ TEST_CASE("block operator boolean equals 2 differs returns false", "[message blo
 }
 
 TEST_CASE("block operator boolean not equals 2 duplicates returns false", "[message block]") {
-    auto const expected = message::block::create(
+    auto const expected = message::block(
         chain::header(10u,
                       "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
                       "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
@@ -327,7 +327,7 @@ TEST_CASE("block operator boolean not equals 2 duplicates returns false", "[mess
 }
 
 TEST_CASE("block operator boolean not equals 2 differs returns true", "[message block]") {
-    auto const expected = message::block::create(
+    auto const expected = message::block(
         chain::header(10u,
                       "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
                       "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,

--- a/src/domain/test/message/compact_block.cpp
+++ b/src/domain/test/message/compact_block.cpp
@@ -35,7 +35,7 @@ message::prefilled_transaction::list const test_transactions{
     message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))};
 
 message::compact_block make_compact_block(uint64_t nonce = 453245u) {
-    return message::compact_block::create(test_header, nonce, test_short_ids, test_transactions);
+    return message::compact_block(test_header, nonce, test_short_ids, test_transactions);
 }
 
 } // namespace
@@ -44,7 +44,7 @@ message::compact_block make_compact_block(uint64_t nonce = 453245u) {
 
 TEST_CASE("compact block create always equals params", "[compact block]") {
     uint64_t const nonce = 453245u;
-    auto const instance = message::compact_block::create(test_header, nonce, test_short_ids, test_transactions);
+    auto const instance = message::compact_block(test_header, nonce, test_short_ids, test_transactions);
     REQUIRE(test_header == instance.header());
     REQUIRE(nonce == instance.nonce());
     REQUIRE(test_short_ids == instance.short_ids());
@@ -141,7 +141,7 @@ TEST_CASE("compact block operator boolean equals duplicates returns true", "[com
 
 TEST_CASE("compact block operator boolean equals differs returns false", "[compact block]") {
     auto const expected = make_compact_block(12334u);
-    auto const instance = message::compact_block::create(test_header, 99999u, test_short_ids, test_transactions);
+    auto const instance = message::compact_block(test_header, 99999u, test_short_ids, test_transactions);
     REQUIRE(instance != expected);
 }
 
@@ -153,7 +153,7 @@ TEST_CASE("compact block operator boolean not equals duplicates returns false", 
 
 TEST_CASE("compact block operator boolean not equals differs returns true", "[compact block]") {
     auto const expected = make_compact_block(12334u);
-    auto const instance = message::compact_block::create(test_header, 99999u, test_short_ids, test_transactions);
+    auto const instance = message::compact_block(test_header, 99999u, test_short_ids, test_transactions);
     REQUIRE(instance != expected);
 }
 

--- a/src/domain/test/message/merkle_block.cpp
+++ b/src/domain/test/message/merkle_block.cpp
@@ -26,7 +26,7 @@ hash_list const test_hashes{
 data_chunk const test_flags{0xae, 0x56, 0x0f};
 
 message::merkle_block make_merkle_block(size_t count = 1234u) {
-    return message::merkle_block::create(test_header, count, test_hashes, test_flags);
+    return message::merkle_block(test_header, count, test_hashes, test_flags);
 }
 
 } // namespace
@@ -35,7 +35,7 @@ message::merkle_block make_merkle_block(size_t count = 1234u) {
 
 TEST_CASE("merkle block create always equals params", "[merkle block]") {
     size_t const count = 1234u;
-    auto const instance = message::merkle_block::create(test_header, count, test_hashes, test_flags);
+    auto const instance = message::merkle_block(test_header, count, test_hashes, test_flags);
     REQUIRE(test_header == instance.header());
     REQUIRE(instance.total_transactions() == count);
     REQUIRE(test_hashes == instance.hashes());
@@ -57,7 +57,7 @@ TEST_CASE("from data insufficient data fails", "[merkle block]") {
 }
 
 TEST_CASE("from data insufficient version fails", "[merkle block]") {
-    auto const expected = message::merkle_block::create(
+    auto const expected = message::merkle_block(
         test_header,
         34523u,
         {"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash},
@@ -71,7 +71,7 @@ TEST_CASE("from data insufficient version fails", "[merkle block]") {
 }
 
 TEST_CASE("merkle block - roundtrip to data factory from data chunk", "[merkle block]") {
-    auto const expected = message::merkle_block::create(
+    auto const expected = message::merkle_block(
         test_header,
         45633u,
         {"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash},
@@ -109,7 +109,7 @@ TEST_CASE("merkle block operator boolean equals duplicates returns true", "[merk
 
 TEST_CASE("merkle block operator boolean equals differs returns false", "[merkle block]") {
     auto const expected = make_merkle_block(1469u);
-    auto const instance = message::merkle_block::create(test_header, 1470u, {}, test_flags);
+    auto const instance = message::merkle_block(test_header, 1470u, {}, test_flags);
     REQUIRE( ! (instance == expected));
 }
 
@@ -121,7 +121,7 @@ TEST_CASE("merkle block operator boolean not equals duplicates returns false", "
 
 TEST_CASE("merkle block operator boolean not equals differs returns true", "[merkle block]") {
     auto const expected = make_merkle_block(8642u);
-    auto const instance = message::merkle_block::create(test_header, 8642u, {}, test_flags);
+    auto const instance = message::merkle_block(test_header, 8642u, {}, test_flags);
     REQUIRE(instance != expected);
 }
 


### PR DESCRIPTION
Applies the settled rule: **a `::create` factory returning `expect<>` is only warranted when construction could yield a syntactically invalid object. Otherwise, plain constructors.**

For the block family it cannot: a header is always valid, and a block is a header plus a list of transactions and is always valid too — the all-default state included. Deserialization from a malformed byte array remains the only failure, and `from_data` already reports it via `expect<>`.

This reverts the construction side of #459/#460/#463/#464/#465 while keeping the rest of the sweep (no `is_valid()`, no setters, immutable value types).

## Changes

- Restore the default constructor on `chain::header` (both implementations), `message::header`, `chain::block`, `message::block`, `merkle_block` and `compact_block` — their all-default state is a valid domain value.
- Make the field constructors public again and collapse each const-ref/rvalue overload pair into a single **by-value** constructor that moves into the members.
- Drop the `create()` factories; `from_data` and `factory_from_block` construct directly.
- Regenerate the C-API bindings: the `_create` entry points are back to `_construct` / `_construct_default`.
- Update domain + C-API tests to construct directly.

## Fixes CI

Also fixes the currently-broken build of the benchmark targets on master:

```
src/domain/bench/to_data/benchmarks.cpp:127:51: error:
  'chain::block::block(header const&, transaction::list&&)' is private within this context
```

The bench constructs blocks through the constructor, which #459 made private. It builds again now.

## Testing

Full build green — **every target, benchmarks included**. Domain suite (3831 cases) and C-API suite (741 cases) pass.